### PR TITLE
rename default repo for SECURITY module to 'se', fixes collision with…

### DIFF
--- a/c/repoq.rules
+++ b/c/repoq.rules
@@ -116,7 +116,7 @@ sles:12
 sles:11.[1-3]
   gm $H/update/zypp-patches.suse.de/$A/update/SLE-SERVER/$V-POOL/
   up $H/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/$V/$A/update/
-  up $H/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/${V/-*}-SECURITY/$A/update/
+  se $H/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/${V/-*}-SECURITY/$A/update/
   up $H/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/$V-LTSS/$A/update/
   dg $H/update/zypp-patches.suse.de/$A/update/SLE-DEBUGINFO/$V-POOL/
   du $H/update/build-ncc.suse.de/SUSE/Updates/SLE-DEBUGINFO/$V/
@@ -124,7 +124,7 @@ sles:11.[1-3]
 sles:11.4
   gm $H/update/zypp-patches.suse.de/$A/update/SLE-SERVER/$V-POOL/
   up $H/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/$V/$A/update/
-  up $H/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/${V/-*}-SECURITY/$A/update/
+  se $H/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/${V/-*}-SECURITY/$A/update/
   dg $H/update/zypp-patches.suse.de/$A/update/SLE-DEBUGINFO/$V-POOL/
   du $H/update/build-ncc.suse.de/SUSE/Updates/SLE-DEBUGINFO/$V/
 

--- a/t/effects/repoq,full-spec.t
+++ b/t/effects/repoq,full-spec.t
@@ -24,7 +24,7 @@ happy path::
   $ repoq sles:11.3:s390x sle-sdk:11.3:s390x
   sles:11.3::gm http://dl.example.org/update/zypp-patches.suse.de/s390x/update/SLE-SERVER/11-SP3-POOL/
   sles:11.3::up http://dl.example.org/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/11-SP3/s390x/update/
-  sles:11.3::up http://dl.example.org/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/11-SECURITY/s390x/update/
+  sles:11.3::se http://dl.example.org/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/11-SECURITY/s390x/update/
   sles:11.3::up http://dl.example.org/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/11-SP3-LTSS/s390x/update/
   sles:11.3::dg http://dl.example.org/update/zypp-patches.suse.de/s390x/update/SLE-DEBUGINFO/11-SP3-POOL/
   sles:11.3::du http://dl.example.org/update/build-ncc.suse.de/SUSE/Updates/SLE-DEBUGINFO/11-SP3/
@@ -54,7 +54,7 @@ happy path::
   $ repoq sles:11.4:s390x sle-sdk:12:ppc64le
   sles:11.4::gm http://dl.example.org/update/zypp-patches.suse.de/s390x/update/SLE-SERVER/11-SP4-POOL/
   sles:11.4::up http://dl.example.org/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/11-SP4/s390x/update/
-  sles:11.4::up http://dl.example.org/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/11-SECURITY/s390x/update/
+  sles:11.4::se http://dl.example.org/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/11-SECURITY/s390x/update/
   sles:11.4::dg http://dl.example.org/update/zypp-patches.suse.de/s390x/update/SLE-DEBUGINFO/11-SP4-POOL/
   sles:11.4::du http://dl.example.org/update/build-ncc.suse.de/SUSE/Updates/SLE-DEBUGINFO/11-SP4/
   sle-sdk:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12/ppc64le/product/


### PR DESCRIPTION
… 'up' - update

fixes https://bugzilla.suse.com/show_bug.cgi?id=997392