### PR TITLE
fix issue #6: repose reset with no defined repo

### DIFF
--- a/s/repose-reset.zsh
+++ b/s/repose-reset.zsh
@@ -79,7 +79,10 @@ function $cmdname-main # {{{
     done
     o rh-list-repos $h
     local ca=$'\001'
-    local -A rhrepos; rhrepos=("${(@pj:$ca:s:$ca:)reply}")
+    local -A rhrepos;
+    if [[ -n "$reply" ]]; then
+        rhrepos=("${(@pj:$ca:s:$ca:)reply}")
+    fi
     local -a rnames; rnames=("${(@ko)rhrepos}")
     for rn in $rnames; do
       [[ $rn == ${~${(j:|:)products}} ]] && continue


### PR DESCRIPTION
Fix #6 

repose cannot reset a host when there is no defined repository. The
error is produced when 'local -A' tries to cast an empty variable.
>repose-reset-main:47: bad set of key/value pairs for associative array

This can be fixed by checking if the input variable is empty before
assigning.