### PR TITLE
SLE12 LTS + test-online repo

### DIFF
--- a/c/repoq.rules
+++ b/c/repoq.rules
@@ -112,6 +112,8 @@ sles:12
   up $H/ibs/SUSE/Updates/SLE-SERVER/$V/$A/update/
   dg $H/ibs/SUSE/Products/SLE-SERVER/$V/$A/product_debug/
   du $H/ibs/SUSE/Updates/SLE-SERVER/$V/$A/update_debug/
+  lt $H/ibs/SUSE/Updates/SLE-SERVER/$V-LTSS/$A/update/
+  dl $H/ibs/SUSE/Updates/SLE-SERVER/$V-LTSS/$A/update_debug/
 
 sles:11.[1-3]
   gm $H/update/zypp-patches.suse.de/$A/update/SLE-SERVER/$V-POOL/
@@ -120,7 +122,7 @@ sles:11.[1-3]
   lt $H/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/$V-LTSS/$A/update/
   dg $H/update/zypp-patches.suse.de/$A/update/SLE-DEBUGINFO/$V-POOL/
   du $H/update/build-ncc.suse.de/SUSE/Updates/SLE-DEBUGINFO/$V/
-
+  
 sles:11.4
   gm $H/update/zypp-patches.suse.de/$A/update/SLE-SERVER/$V-POOL/
   up $H/update/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/$V/$A/update/

--- a/s/repose-reset.zsh
+++ b/s/repose-reset.zsh
@@ -91,7 +91,10 @@ function $cmdname-main # {{{
     o repoq -A -a $arch -t gm -t up -t se -t lt ${products/%:\*} \
     | while read rn zcmd; do
         [[ $rn == "${(~@kj:|:)~rhrepos}" ]] && continue
-        run-in $h $zcmd
+        if test-online-repo $zcmd
+        then
+          run-in $h $zcmd
+        fi
       done
   done
 } # }}}

--- a/s/repose.prelude.zsh
+++ b/s/repose.prelude.zsh
@@ -107,7 +107,10 @@ function main-add-install # {{{
       && parts[2]=$basev
       o repoq -A -a $arch -t gm -t up -t se -t lt "${${(@j.:.)parts}%%:##}" \
       | while read rn zcmd; do
-          o $print ssh -n -o BatchMode=yes $h $zcmd
+          if test-online-repo $zcmd
+          then
+            o $print ssh -n -o BatchMode=yes $h $zcmd
+          fi
         done
       if (( DO_INSTALL )); then
         o $print ssh -n -o BatchMode=yes $h "zypper -n --gpg-auto-import-keys in -l ${parts[1]}-release"
@@ -115,6 +118,15 @@ function main-add-install # {{{
     done
   done
 } # }}}
+
+
+function test-online-repo # {{{
+{
+  local f_args=${1}
+  local -a url
+  url=(${(s: :)f_args})
+  curl -fIs ${url[6]} > /dev/null
+ } #}}}
 
 
 function rh-list-products # {{{

--- a/t/effects/repoq,full-spec.t
+++ b/t/effects/repoq,full-spec.t
@@ -36,6 +36,8 @@ happy path::
   sles:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/s390x/update/
   sles:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-SERVER/12/s390x/product_debug/
   sles:12::du http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/s390x/update_debug/
+  sles:12::lt http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/s390x/update/
+  sles:12::dl http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/s390x/update_debug/
   sle-sdk:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12/x86_64/product/
   sle-sdk:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SDK/12/x86_64/update/
   sle-sdk:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12/x86_64/product_debug/
@@ -46,6 +48,8 @@ happy path::
   sles:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/s390x/update/
   sles:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-SERVER/12/s390x/product_debug/
   sles:12::du http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/s390x/update_debug/
+  sles:12::lt http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/s390x/update/
+  sles:12::dl http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/s390x/update_debug/
   sle-sdk:12.1::gm http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12-SP1/x86_64/product/
   sle-sdk:12.1::up http://dl.example.org/ibs/SUSE/Updates/SLE-SDK/12-SP1/x86_64/update/
   sle-sdk:12.1::dg http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12-SP1/x86_64/product_debug/
@@ -69,6 +73,8 @@ mixed results (*currently*, repoq does a single pass over its operands)::
   sles:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update/
   sles:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-SERVER/12/x86_64/product_debug/
   sles:12::du http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update_debug/
+  sles:12::lt http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update/
+  sles:12::dl http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update_debug/
   repoq: no rule matches 'notthere:69:omg'
   [1]
 
@@ -81,5 +87,7 @@ mixed results (*currently*, repoq does a single pass over its operands)::
   sles:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update/
   sles:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-SERVER/12/x86_64/product_debug/
   sles:12::du http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update_debug/
+  sles:12::lt http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update/
+  sles:12::dl http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update_debug/
   repoq: no rule matches 'notthere:69:omg'
   [1]

--- a/t/effects/repoq,opt-arch.t
+++ b/t/effects/repoq,opt-arch.t
@@ -47,3 +47,5 @@ test::
   sles:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/s390x/update/
   sles:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-SERVER/12/s390x/product_debug/
   sles:12::du http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/s390x/update_debug/
+  sles:12::lt http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/s390x/update/
+  sles:12::dl http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/s390x/update_debug/

--- a/t/effects/repoq,opt-noname.t
+++ b/t/effects/repoq,opt-noname.t
@@ -40,6 +40,8 @@ happy path::
   http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/s390x/update/
   http://dl.example.org/ibs/SUSE/Products/SLE-SERVER/12/s390x/product_debug/
   http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/s390x/update_debug/
+  http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/s390x/update/
+  http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/s390x/update_debug/
   http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12/x86_64/product/
   http://dl.example.org/ibs/SUSE/Updates/SLE-SDK/12/x86_64/update/
   http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12/x86_64/product_debug/
@@ -50,6 +52,8 @@ happy path::
   http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/s390x/update/
   http://dl.example.org/ibs/SUSE/Products/SLE-SERVER/12/s390x/product_debug/
   http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/s390x/update_debug/
+  http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/s390x/update/
+  http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/s390x/update_debug/
   http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12-SP1/x86_64/product/
   http://dl.example.org/ibs/SUSE/Updates/SLE-SDK/12-SP1/x86_64/update/
   http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12-SP1/x86_64/product_debug/
@@ -73,6 +77,8 @@ mixed results (*currently*, repoq does a single pass over its operands)::
   http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update/
   http://dl.example.org/ibs/SUSE/Products/SLE-SERVER/12/x86_64/product_debug/
   http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update_debug/
+  http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update/
+  http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update_debug/
   repoq: no rule matches 'notthere:69:omg'
   [1]
 
@@ -81,5 +87,7 @@ mixed results (*currently*, repoq does a single pass over its operands)::
   http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update/
   http://dl.example.org/ibs/SUSE/Products/SLE-SERVER/12/x86_64/product_debug/
   http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update_debug/
+  http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update/
+  http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update_debug/
   repoq: no rule matches 'notthere:69:omg'
   [1]

--- a/t/effects/repoq,with-tags.t
+++ b/t/effects/repoq,with-tags.t
@@ -41,6 +41,8 @@ complementary sets (negation)::
   sles:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update/
   sles:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-SERVER/12/x86_64/product_debug/
   sles:12::du http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update_debug/
+  sles:12::lt http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update/
+  sles:12::dl http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update_debug/
   sled:12.1::gm http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12-SP1/x86_64/product/
   sled:12.1::up http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12-SP1/x86_64/update/
   sled:12.1::dg http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12-SP1/x86_64/product_debug/
@@ -50,6 +52,8 @@ complementary sets (negation)::
   sles:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update/
   sles:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-SERVER/12/x86_64/product_debug/
   sles:12::du http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update_debug/
+  sles:12::lt http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update/
+  sles:12::dl http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update_debug/
   sled:12.1::gm http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12-SP1/x86_64/product/
   sled:12.1::up http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12-SP1/x86_64/update/
   sled:12.1::dg http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12-SP1/x86_64/product_debug/

--- a/t/effects/repose-add.t
+++ b/t/effects/repose-add.t
@@ -24,6 +24,7 @@ no attempt to skip already-present repos::
   $ noglob repose add -n fubar.example.org snafu.example.org -- sles:12 sled:12::^nv,at sle-sdk
   ssh -n -o BatchMode=yes fubar.example.org zypper -n ar -cgkn sles:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-SERVER/12/x86_64/product/ sles:12::gm
   ssh -n -o BatchMode=yes fubar.example.org zypper -n ar -cgkfn sles:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update/ sles:12::up
+  ssh -n -o BatchMode=yes fubar.example.org zypper -n ar -cgkfn sles:12::lt http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update/ sles:12::lt
   ssh -n -o BatchMode=yes fubar.example.org zypper -n ar -cgkn sled:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12/x86_64/product/ sled:12::gm
   ssh -n -o BatchMode=yes fubar.example.org zypper -n ar -cgkfn sled:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12/x86_64/update/ sled:12::up
   ssh -n -o BatchMode=yes fubar.example.org zypper -n ar -cgkfn sled:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12/x86_64/product_debug/ sled:12::dg
@@ -32,6 +33,7 @@ no attempt to skip already-present repos::
   ssh -n -o BatchMode=yes fubar.example.org zypper -n ar -cgkfn sle-sdk:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SDK/12/x86_64/update/ sle-sdk:12::up
   ssh -n -o BatchMode=yes snafu.example.org zypper -n ar -cgkn sles:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-SERVER/12/x86_64/product/ sles:12::gm
   ssh -n -o BatchMode=yes snafu.example.org zypper -n ar -cgkfn sles:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12/x86_64/update/ sles:12::up
+  ssh -n -o BatchMode=yes snafu.example.org zypper -n ar -cgkfn sles:12::lt http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update/ sles:12::lt
   ssh -n -o BatchMode=yes snafu.example.org zypper -n ar -cgkn sled:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12/x86_64/product/ sled:12::gm
   ssh -n -o BatchMode=yes snafu.example.org zypper -n ar -cgkfn sled:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12/x86_64/update/ sled:12::up
   ssh -n -o BatchMode=yes snafu.example.org zypper -n ar -cgkfn sled:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12/x86_64/product_debug/ sled:12::dg

--- a/t/effects/repose-reset.t
+++ b/t/effects/repose-reset.t
@@ -26,6 +26,7 @@ test::
   ssh -n -o BatchMode=yes omg.example.org zypper -n rr http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12/x86_64/product/
   ssh -n -o BatchMode=yes omg.example.org zypper -n rr http://dl.example.org/ibs/SUSE/Products/SLE-WE/12/x86_64/product/
   ssh -n -o BatchMode=yes omg.example.org zypper -n rr http://dl.example.org/ibs/SUSE/Updates/SLE-WE/12/x86_64/update/
+  ssh -n -o BatchMode=yes omg.example.org zypper -n ar -cgkfn sles:12::lt http://dl.example.org/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update/ sles:12::lt
 
   $ repose reset -n wtf.example.org
   ssh -n -o BatchMode=yes wtf.example.org zypper -n rr http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12/x86_64/product/

--- a/t/setup
+++ b/t/setup
@@ -195,3 +195,7 @@ fake scp <<\EOF
   (( $#s )) || return 0
   cp $s ${(P)#}
 EOF
+
+fake curl <<\EOF
+  return 0
+EOF


### PR DESCRIPTION
This fixes https://github.com/openSUSE/repose/issues/5 and enhances repose with https://github.com/openSUSE/repose/issues/1 . As side effect It adds only valid online repositories with ```repose add``` , ```repose install``` and ```repose reset``` command