### PR TITLE
renamed sle-infra to infra 

### DIFF
--- a/c/repoq.rules
+++ b/c/repoq.rules
@@ -37,7 +37,7 @@ sle-haegeo:11
   gm $H/update/zypp-patches.suse.de/$A/update/SLE-HAE/$V-GEO-POOL/
   up $H/update/build-ncc.suse.de/SUSE/Updates/SLE-HAE/$V-GEO/$A/update/
 
-sle-infra
+infra
   gm $H/ibs/QA:/Maintenance:/Infrastructure/SLE_${V/-/_}/
 
 sle-(live-patching|manager-tools|module(-[[:IDENT:]]##)##):12


### PR DESCRIPTION
fix for issue https://github.com/openSUSE/repose/issues/22

infra is not an official extension of SLE

AFTER PATCH
~~~~~~~~~~

/home/devin/commits/repose devin@cert% repoq -a x86_64 sle-infra:12.1
repoq: no rule matches 'sle-infra:12.1'

/home/devin/commits/repose devin@cert% repoq -a x86_64 infra:12.1 
infra:12.1::gm http://dl.example.org/ibs/QA:/Maintenance:/Infrastructure/SLE_12_SP1/