### PR TITLE
Rename oppensuse rules to openSUSE*

### DIFF
--- a/c/repoq.rules
+++ b/c/repoq.rules
@@ -3,13 +3,13 @@
 
 define H http://dl.example.org
 
-opensuse-leap
+openSUSE
   gm http://download.opensuse.org/distribution/leap/$v/repo/oss/
   up http://download.opensuse.org/update/leap/$v/oss/
   dg http://download.opensuse.org/debug/distribution/leap/$v/repo/oss/
   du http://download.opensuse.org/debug/update/leap/$v/oss/
 
-opensuse-leap-nonoss
+openSUSE-addon-nonoss
   gm http://download.opensuse.org/distribution/leap/$v/repo/non-oss/
   up http://download.opensuse.org/update/leap/$v/non-oss/
 


### PR DESCRIPTION
repose install uses first part of REPA as source for *-release install