### PR TITLE
Fix test-online-repo function to test repodata/repomd.xml to avoid

### DIFF
--- a/s/repose.prelude.zsh
+++ b/s/repose.prelude.zsh
@@ -131,7 +131,7 @@ function test-online-repo # {{{
   local f_args=${1}
   local -a url
   url=(${(s: :)f_args})
-  curl -fIs ${url[6]} > /dev/null
+  curl -fIs ${url[6]}/repodata/repomd.xml > /dev/null
  } #}}}
 
 


### PR DESCRIPTION
problems with forbidden directory listings.

it partially fixes -> https://github.com/openSUSE/repose/issues/34