### PR TITLE
repoq: sle-module-* pattern requires lowercase input

### DIFF
--- a/cfg/repoq.rules
+++ b/cfg/repoq.rules
@@ -50,7 +50,7 @@ sle-haegeo:11
 infra
   gm $H/ibs/QA:/Maintenance:/Infrastructure/SLE_${V/-/_}/
 
-sle-(live-patching|manager-tools|module(-[[:IDENT:]]##)##):12
+sle-(live-patching|manager-tools|module(-[[:lower:]]##)##):12
   gm $H/ibs/SUSE/Products/${${(C)P}/#Sle-/SLE-}/12/$A/product/
   up $H/ibs/SUSE/Updates/${${(C)P}/#Sle-/SLE-}/12/$A/update/
   dg $H/ibs/SUSE/Products/${${(C)P}/#Sle-/SLE-}/12/$A/product_debug/

--- a/tests/effects/repoq,naming-snafus.t
+++ b/tests/effects/repoq,naming-snafus.t
@@ -6,7 +6,17 @@ setup::
   $ . $TESTROOT/setup
 
 
-test::
+test case-mismatch::
+
+  $ repoq sle-module-Web-Scripting:12:x86_64:gm
+  repoq: no rule matches 'sle-module-Web-Scripting:12:x86_64:gm'
+  [1]
+
+  $ repoq sle-module-web-scripting:12:x86_64:gm
+  sle-module-web-scripting:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-Module-Web-Scripting/12/x86_64/product/
+
+
+test special-snowflake products::
 
   $ repoq -a x86_64 suse-openstack-cloud:6
   suse-openstack-cloud:6::gm http://dl.example.org/ibs/SUSE/Products/OpenStack-Cloud/6/x86_64/product/

--- a/tests/effects/repose-install.t
+++ b/tests/effects/repose-install.t
@@ -99,6 +99,12 @@ test::
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sle-sdk-release
 
 
+test case-mismatch::
+
+  $ repose install -n fubar.example.org -- sle-module-Web-Scripting
+  repoq: no rule matches 'sle-module-Web-Scripting:12'
+  [1]
+
 FIXME: installs already present products::
 
   $ repose install -n {snafu,fubar}.example.org -- sle-we


### PR DESCRIPTION
[[:IDENT:]] permits uppercase, this led to main-add-install
emitting repo names which do not correspond to any product.
you could do `repose install ... -- sle-module-Web-Scripting`
only to have it replaced by a subsequent `repose reset`.

fixes openSUSE/repose#13