### PR TITLE
Fix for repose reset, for HOST without repositories

### DIFF
--- a/src/repose.prelude.zsh
+++ b/src/repose.prelude.zsh
@@ -259,7 +259,9 @@ function rh-list-repos # {{{
 
 function rh-fetch-repos # {{{
 {
+  unsetopt err_return
   print= run-in $1 zypper -x lr
+  unsetopt err_return
 } # }}}
 
 function xml-get-repos # {{{
@@ -377,9 +379,9 @@ function redir # {{{
 
   while getopts 0:1:2: optname; do
     case $optname in
-    0) exec {o0}<$OPTARG ;;
-    1) exec {o1}>$OPTARG ;;
-    2) exec {o2}>$OPTARG ;;
+      0) exec {o0}<$OPTARG ;;
+      1) exec {o1}>$OPTARG ;;
+      2) exec {o2}>$OPTARG ;;
     esac
   done; shift $((OPTIND - 1))
 


### PR DESCRIPTION
zypper -x lr returns in this case EXITCODE 6 and triggers err_return
so I locally disable this option in redir function.

Fixes https://github.com/openSUSE/repose/issues/6