### PR TITLE
Add [-f|--force] option to repose install command

### DIFF
--- a/src/repose-install.zsh
+++ b/src/repose-install.zsh
@@ -26,6 +26,7 @@ Install a product, add its repositories
     --help                Display full help
     -n,--print            Display, do not perform destructive commands
     -t,--tag              Set tags for installation (default are gm lt se up)
+    -f,--force            Set force installation of [product]-release file
 
   Operands:
     HOST                  Machine to operate on

--- a/src/repose.prelude.zsh
+++ b/src/repose.prelude.zsh
@@ -36,9 +36,9 @@ function main-hosts-repas # {{{
 
   while haveopt oi on oa $=options -- "$@"; do
     case $on in
-    h | help      ) display-help $on ;;
-    n | print     ) print=print ;;
-    *             ) reject-misuse -$oa ;;
+      h | help      ) display-help $on ;;
+      n | print     ) print=print ;;
+      *             ) reject-misuse -$oa ;;
     esac
   done; shift $oi
 
@@ -77,6 +77,7 @@ function main-add-install # {{{
     h   help
     n   print
     t=  tag=
+    f   force
   )
 
   local print
@@ -84,15 +85,17 @@ function main-add-install # {{{
   local -i first_tag=1
   local on oa
   local -i oi=0
+  local force='--force '
 
   while haveopt oi on oa $=options -- "$@"; do
     case $on in
-    h | help      ) display-help $on ;;
-    n | print     ) print=print ;;
-    t | tag       ) (( first_tag )) && { first_tag=0; tags=() }
-                    tags+=($oa)
+      h | help      ) display-help $on ;;
+      n | print     ) print=print ;;
+      t | tag       ) (( first_tag )) && { first_tag=0; tags=() }
+                      tags+=($oa)
                     ;;
-    *             ) reject-misuse -$oa ;;
+      f | force     ) force='' ;;
+      *             ) reject-misuse -$oa ;;
     esac
   done; shift $oi
 
@@ -128,8 +131,11 @@ function main-add-install # {{{
         fi
       done < $tmpf
 
+      local zcmd="zypper -n --gpg-auto-import-keys in --force -l ${parts[1]}-release"
+      zcmd=${zcmd/${force}/}
+
       if (( DO_INSTALL )); then
-        run-in $h "zypper -n --gpg-auto-import-keys in --force -l ${parts[1]}-release"
+        run-in $h $zcmd
       fi
 
     done

--- a/tests/effects/repose-install.t
+++ b/tests/effects/repose-install.t
@@ -15,29 +15,29 @@ test default behavior (adds default repos)::
   $ repose install -n fubar.example.org snafu.example.org -- sle-module-legacy:12 sle-sdk:12
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cgkn sle-module-legacy:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-Module-Legacy/12/x86_64/product/ sle-module-legacy:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sle-module-legacy:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update/ sle-module-legacy:12::up
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sle-module-legacy-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in -l sle-module-legacy-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cgkn sle-sdk:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12/x86_64/product/ sle-sdk:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sle-sdk:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SDK/12/x86_64/update/ sle-sdk:12::up
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sle-sdk-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in -l sle-sdk-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cgkn sle-module-legacy:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-Module-Legacy/12/x86_64/product/ sle-module-legacy:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cfgkn sle-module-legacy:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update/ sle-module-legacy:12::up
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in --force -l sle-module-legacy-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in -l sle-module-legacy-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cgkn sle-sdk:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12/x86_64/product/ sle-sdk:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cfgkn sle-sdk:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SDK/12/x86_64/update/ sle-sdk:12::up
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in --force -l sle-sdk-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in -l sle-sdk-release
 
 
 test adds only requested repos::
 
   $ repose install -n fubar.example.org snafu.example.org -- sled:12::{up,du}
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sled:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12/x86_64/update/ sled:12::up
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sled-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in -l sled-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sled:12::du http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12/x86_64/update_debug/ sled:12::du
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sled-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in -l sled-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cfgkn sled:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12/x86_64/update/ sled:12::up
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in --force -l sled-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in -l sled-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cfgkn sled:12::du http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12/x86_64/update_debug/ sled:12::du
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in --force -l sled-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in -l sled-release
 
 
 test that `-t/--tag` provides defaults to tagless patterns::
@@ -45,18 +45,18 @@ test that `-t/--tag` provides defaults to tagless patterns::
   $ repose install -n -t gm -t dg fubar.example.org snafu.example.org -- sle-we:12 sled:12::gm,up,at
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cgkn sle-we:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-WE/12/x86_64/product/ sle-we:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cgkn sle-we:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-WE/12/x86_64/product_debug/ sle-we:12::dg
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sle-we-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in -l sle-we-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cgkn sled:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12/x86_64/product/ sled:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sled:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12/x86_64/update/ sled:12::up
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sled:12::at http://www2.ati.com/suse/sle12/ sled:12::at
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sled-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in -l sled-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cgkn sle-we:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-WE/12/x86_64/product/ sle-we:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cgkn sle-we:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-WE/12/x86_64/product_debug/ sle-we:12::dg
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in --force -l sle-we-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in -l sle-we-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cgkn sled:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12/x86_64/product/ sled:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cfgkn sled:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12/x86_64/update/ sled:12::up
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cfgkn sled:12::at http://www2.ati.com/suse/sle12/ sled:12::at
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in --force -l sled-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in -l sled-release
 
 
 test that tag negation means "all tags but these"::
@@ -66,12 +66,12 @@ test that tag negation means "all tags but these"::
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cfgkn sled:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12/x86_64/update/ sled:12::up
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cgkn sled:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12/x86_64/product_debug/ sled:12::dg
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cfgkn sled:12::du http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12/x86_64/update_debug/ sled:12::du
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in --force -l sled-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in -l sled-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cgkn sled:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12/x86_64/product/ sled:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sled:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12/x86_64/update/ sled:12::up
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cgkn sled:12::dg http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12/x86_64/product_debug/ sled:12::dg
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sled:12::du http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12/x86_64/update_debug/ sled:12::du
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sled-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in -l sled-release
 
   $ repose install -n fubar.example.org -- sled:12::~.
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cgkn sled:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-DESKTOP/12/x86_64/product/ sled:12::gm
@@ -80,23 +80,23 @@ test that tag negation means "all tags but these"::
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sled:12::du http://dl.example.org/ibs/SUSE/Updates/SLE-DESKTOP/12/x86_64/update_debug/ sled:12::du
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sled:12::nv http://download.nvidia.com/novell/sle12/ sled:12::nv
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sled:12::at http://www2.ati.com/suse/sle12/ sled:12::at
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sled-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in -l sled-release
 
 test::
 
   $ repose install -n {snafu,fubar}.example.org -- sle-module-legacy:12 sle-sdk:12
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cgkn sle-module-legacy:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-Module-Legacy/12/x86_64/product/ sle-module-legacy:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cfgkn sle-module-legacy:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update/ sle-module-legacy:12::up
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in --force -l sle-module-legacy-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in -l sle-module-legacy-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cgkn sle-sdk:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12/x86_64/product/ sle-sdk:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cfgkn sle-sdk:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SDK/12/x86_64/update/ sle-sdk:12::up
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in --force -l sle-sdk-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in -l sle-sdk-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cgkn sle-module-legacy:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-Module-Legacy/12/x86_64/product/ sle-module-legacy:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sle-module-legacy:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update/ sle-module-legacy:12::up
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sle-module-legacy-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in -l sle-module-legacy-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cgkn sle-sdk:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12/x86_64/product/ sle-sdk:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sle-sdk:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SDK/12/x86_64/update/ sle-sdk:12::up
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sle-sdk-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in -l sle-sdk-release
 
 
 test case-mismatch::
@@ -110,12 +110,29 @@ FIXME: installs already present products::
   $ repose install -n {snafu,fubar}.example.org -- sle-we
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cgkn sle-we:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-WE/12/x86_64/product/ sle-we:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cfgkn sle-we:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-WE/12/x86_64/update/ sle-we:12::up
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in --force -l sle-we-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in -l sle-we-release
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cgkn sle-we:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-WE/12/x86_64/product/ sle-we:12::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sle-we:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-WE/12/x86_64/update/ sle-we:12::up
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sle-we-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in -l sle-we-release
 
   $ repose install -n osuse.example.org -- openSUSE-Addon-NonOss:42.2
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no osuse.example.org zypper -n ar -cgkn openSUSE-Addon-NonOss:42.2::gm http://download.opensuse.org/distribution/leap/42.2/repo/non-oss/ openSUSE-Addon-NonOss:42.2::gm
   ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no osuse.example.org zypper -n ar -cfgkn openSUSE-Addon-NonOss:42.2::up http://download.opensuse.org/update/leap/42.2/non-oss/ openSUSE-Addon-NonOss:42.2::up
-  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no osuse.example.org zypper -n --gpg-auto-import-keys in --force -l openSUSE-Addon-NonOss-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no osuse.example.org zypper -n --gpg-auto-import-keys in -l openSUSE-Addon-NonOss-release
+
+
+test force option::
+
+  $ repose install -n -f fubar.example.org snafu.example.org -- sle-module-legacy:12 sle-sdk:12
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cgkn sle-module-legacy:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-Module-Legacy/12/x86_64/product/ sle-module-legacy:12::gm
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sle-module-legacy:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update/ sle-module-legacy:12::up
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sle-module-legacy-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cgkn sle-sdk:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12/x86_64/product/ sle-sdk:12::gm
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n ar -cfgkn sle-sdk:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SDK/12/x86_64/update/ sle-sdk:12::up
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no fubar.example.org zypper -n --gpg-auto-import-keys in --force -l sle-sdk-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cgkn sle-module-legacy:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-Module-Legacy/12/x86_64/product/ sle-module-legacy:12::gm
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cfgkn sle-module-legacy:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update/ sle-module-legacy:12::up
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in --force -l sle-module-legacy-release
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cgkn sle-sdk:12::gm http://dl.example.org/ibs/SUSE/Products/SLE-SDK/12/x86_64/product/ sle-sdk:12::gm
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n ar -cfgkn sle-sdk:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SDK/12/x86_64/update/ sle-sdk:12::up
+  ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no snafu.example.org zypper -n --gpg-auto-import-keys in --force -l sle-sdk-release

--- a/tests/traces/repose-install.t
+++ b/tests/traces/repose-install.t
@@ -21,7 +21,7 @@ setup::
   >   --
 test::
 
-  $ repose install root@{omg,wtf}.example.org -- sle-{module-toolchain,sdk}:12
+  $ repose install -f root@{omg,wtf}.example.org -- sle-{module-toolchain,sdk}:12
   o scp -Bq root@omg.example.org:/etc/products.d/baseproduct * (glob)
   o repoq -A -a x86_64 -t gm -t lt -t se -t up sle-module-toolchain:12
   o ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@omg.example.org 'zypper -n ar -cgkn sle-module-toolchain:12::gm http://*/SLE-Module-Toolchain/12/x86_64/product/ sle-module-toolchain:12::gm' (glob)
@@ -41,9 +41,18 @@ test::
   o ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@wtf.example.org 'zypper -n ar -cfgkn sle-sdk:12::up http://dl.example.org/ibs/SUSE/Updates/SLE-SDK/12/x86_64/update/ sle-sdk:12::up'
   o ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@wtf.example.org 'zypper -n --gpg-auto-import-keys in --force -l sle-sdk-release'
 
-  $ repose install root@osuse.example.org  -- openSUSE-Addon-NonOss:42.2
+  $ repose install -f root@osuse.example.org  -- openSUSE-Addon-NonOss:42.2
   o scp -Bq root@osuse.example.org:/etc/products.d/baseproduct * (glob)
   o repoq -A -a x86_64 -t gm -t lt -t se -t up openSUSE-Addon-NonOss:42.2
   o ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@osuse.example.org 'zypper -n ar -cgkn openSUSE-Addon-NonOss:42.2::gm http://download.opensuse.org/distribution/leap/42.2/repo/non-oss/ openSUSE-Addon-NonOss:42.2::gm'
   o ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@osuse.example.org 'zypper -n ar -cfgkn openSUSE-Addon-NonOss:42.2::up http://download.opensuse.org/update/leap/42.2/non-oss/ openSUSE-Addon-NonOss:42.2::up'
   o ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@osuse.example.org 'zypper -n --gpg-auto-import-keys in --force -l openSUSE-Addon-NonOss-release'
+
+test without force flag::
+  $ repose install root@osuse.example.org  -- openSUSE-Addon-NonOss:42.2
+  o scp -Bq root@osuse.example.org:/etc/products.d/baseproduct * (glob)
+  o repoq -A -a x86_64 -t gm -t lt -t se -t up openSUSE-Addon-NonOss:42.2
+  o ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@osuse.example.org 'zypper -n ar -cgkn openSUSE-Addon-NonOss:42.2::gm http://download.opensuse.org/distribution/leap/42.2/repo/non-oss/ openSUSE-Addon-NonOss:42.2::gm'
+  o ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@osuse.example.org 'zypper -n ar -cfgkn openSUSE-Addon-NonOss:42.2::up http://download.opensuse.org/update/leap/42.2/non-oss/ openSUSE-Addon-NonOss:42.2::up'
+  o ssh -n -q -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@osuse.example.org 'zypper -n --gpg-auto-import-keys in -l openSUSE-Addon-NonOss-release'
+

--- a/tests/usage/repose-install,basics.t
+++ b/tests/usage/repose-install,basics.t
@@ -16,6 +16,7 @@ help::
       --help                Display full help
       -n,--print            Display, do not perform destructive commands
       -t,--tag              Set tags for installation (default are gm lt se up)
+      -f,--force            Set force installation of [product]-release file
   
     Operands:
       HOST                  Machine to operate on


### PR DESCRIPTION
Unfortuanetly `zypper in --force` doesn't accept provides. So we need
use by default installation without forcing installation. With
possibility override this behaviour

Fixes https://github.com/openSUSE/repose/issues/55