### PR TITLE
Fixes adding repo if is repository already present on  host

### DIFF
--- a/src/repose.prelude.zsh
+++ b/src/repose.prelude.zsh
@@ -127,7 +127,7 @@ function main-add-install # {{{
       while read rn zcmd; do
         if test-online-repo $zcmd
           then
-            run-in $h $zcmd
+            run-in $h $zcmd || [[ ${?} == 4 ]] && continue
         fi
       done < $tmpf
 


### PR DESCRIPTION
If is repository on host repose add/install returns output of zypper ar
command and stop work, with this change repose simply continue with
adding next repo.

Closes #42 