### PR TITLE
Fixed 'SLES for SAP' rules and install.

### DIFF
--- a/cfg/repoq.rules
+++ b/cfg/repoq.rules
@@ -14,7 +14,7 @@ openSUSE-Addon-NonOss
   up http://download.opensuse.org/update/leap/$v/non-oss/
   nv http://http.download.nvidia.com/opensuse/leap/$v/
 
-sapaio:12
+SLES_SAP:12
   gm $H/ibs/SUSE/Products/SLE-SAP/$V/$A/product/
   up $H/ibs/SUSE/Updates/SLE-SAP/$V/$A/update/
   dg $H/ibs/SUSE/Products/SLE-SAP/$V/$A/product_debug/

--- a/src/repose.prelude.zsh
+++ b/src/repose.prelude.zsh
@@ -190,7 +190,7 @@ function xform-product # {{{
   esac
 
   case $r[1] in
-    openSUSE|openSUSE-Addon-NonOss) REPLY="${(j.:.)r}" ;;
+    SLES_SAP|openSUSE|openSUSE-Addon-NonOss) REPLY="${(j.:.)r}" ;;
     *) REPLY="${(j.:.L)r}" ;;
   esac # returns string with normalized product:version:arch
 } # }}}


### PR DESCRIPTION
Unfortuanetly 'SLES for SAP'-12SPx has product named SLES_SAP and release file
SLES_SAP-release-*.rpm. So tag must be SLES_SAP and same xform-product
handling as openSUSE