### PR TITLE
fix(command): correct check_url fallback, SL-Micro detection, remove no-op rr

### DIFF
--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -65,18 +65,24 @@ class Command(ABC):
 
     @staticmethod
     def check_url(url) -> bool:
-        state = True
+        """Check whether a repository URL exposes a valid repomd.xml.
+
+        Tries ``<url>repodata/repomd.xml`` first and falls back to
+        ``<url>suse/repodata/repomd.xml`` (used by SUSE-style layouts).
+
+        Returns ``True`` if either probe succeeds, ``False`` otherwise.
+        """
         try:
             urlopen(url + "repodata/repomd.xml")
+            return True
         except (HTTPError, URLError):
-            state = False
+            pass
 
-        if not state:
-            try:
-                urlopen(url + "suse/repodata/repomd.xml")
-            except (HTTPError, URLError):
-                state = False
-        return state
+        try:
+            urlopen(url + "suse/repodata/repomd.xml")
+            return True
+        except (HTTPError, URLError):
+            return False
 
     @abstractmethod
     def run(self) -> ExitCode:

--- a/repose/command/remove.py
+++ b/repose/command/remove.py
@@ -55,6 +55,7 @@ class Remove(Command):
 
         if not repolist:
             logger.info("For %s no repos for remove found", host)
+            return
         cmd = self.rrcmd.format(repos=" ".join(repolist))
 
         if self.dryrun:

--- a/repose/command/uninstall.py
+++ b/repose/command/uninstall.py
@@ -38,16 +38,14 @@ class Uninstall(Remove):
                 repos=" ".join(chain.from_iterable(rdict.values()))
             )
 
-        transactional = False
-        if "SL-Micro" in patterns:
-            transactional = True
-            pdcmd = self.rrpdtcmd.format(
-                prodcuts=" ".join(x.split(":")[0] for x in patterns)
-            )
+        # Patterns are formatted as "<product>:<version>::<repo>" — detect
+        # SL-Micro by matching the product component, not the whole pattern.
+        transactional = any(p.split(":", 1)[0] == "SL-Micro" for p in patterns)
+        products_arg = " ".join(x.split(":")[0] for x in patterns)
+        if transactional:
+            pdcmd = self.rrpdtcmd.format(products=products_arg)
         else:
-            pdcmd = self.rrpcmd.format(
-                products=" ".join(x.split(":")[0] for x in patterns)
-            )
+            pdcmd = self.rrpcmd.format(products=products_arg)
 
         if self.dryrun:
             if rrcmd:

--- a/tests/command/test_command_base.py
+++ b/tests/command/test_command_base.py
@@ -63,6 +63,39 @@ def test_check_url_handles_http_error(monkeypatch):
     assert Command.check_url("http://example.com/") is False
 
 
+def test_check_url_returns_true_when_suse_fallback_succeeds(monkeypatch):
+    """If the canonical repomd.xml is missing but the ``suse/`` variant
+    answers, the URL is still considered valid."""
+    called: list[str] = []
+
+    def _selective(url):
+        called.append(url)
+        if "suse/repodata/repomd.xml" in url:
+            return MagicMock()
+        raise URLError("not at root")
+
+    monkeypatch.setattr(cmdmod, "urlopen", _selective)
+    assert Command.check_url("http://example.com/") is True
+    # Both probes should have been attempted, in order.
+    assert called == [
+        "http://example.com/repodata/repomd.xml",
+        "http://example.com/suse/repodata/repomd.xml",
+    ]
+
+
+def test_check_url_short_circuits_on_first_success(monkeypatch):
+    """If the canonical repomd.xml answers we do not probe the fallback."""
+    called: list[str] = []
+
+    def _ok(url):
+        called.append(url)
+        return MagicMock()
+
+    monkeypatch.setattr(cmdmod, "urlopen", _ok)
+    assert Command.check_url("http://example.com/") is True
+    assert called == ["http://example.com/repodata/repomd.xml"]
+
+
 # ---------------------------------------------------------------------------
 # Filtering of unconnected targets
 # ---------------------------------------------------------------------------

--- a/tests/command/test_remove.py
+++ b/tests/command/test_remove.py
@@ -129,6 +129,34 @@ def test_remove_command_no_matching_pattern_logs(monkeypatch, caplog, mock_ssh_c
     assert any("no repos for remove" in r.message for r in caplog.records)
 
 
+def test_remove_command_empty_repolist_does_not_run_rrcmd(
+    monkeypatch, caplog, mock_ssh_client
+):
+    """Patterns are computed but no repo on the host contains them →
+    we must log and return without issuing ``zypper -n rr`` with an empty
+    argument list."""
+    args = Namespace(
+        dry=False,
+        target=[{"user@host1": MagicMock()}],
+        repa=[Repa("SLES:15-SP4::repo-missing")],
+        config="dummy",
+        yaml=False,
+    )
+    target, _ = _build_remove_env(
+        monkeypatch,
+        args,
+        [MockProduct("SLES", "15-SP4")],
+        # Host has a repo, but none containing the requested "repo-missing".
+        ["SLES:15-SP4::repo-other"],
+    )
+
+    with caplog.at_level("INFO", logger="repose.command.remove"):
+        Remove(args).run()
+
+    target.run.assert_not_called()
+    assert any("no repos for remove" in r.message for r in caplog.records)
+
+
 def test_remove_command_version_mismatch_skipped(monkeypatch, caplog, mock_ssh_client):
     """If version is specified but doesn't match, the product is skipped."""
     args = Namespace(

--- a/tests/command/test_uninstall.py
+++ b/tests/command/test_uninstall.py
@@ -165,3 +165,37 @@ def test_uninstall_no_matching_repos_runs_only_pdcmd(monkeypatch, mock_ssh_clien
     # Only one command issued: rrpcmd (no rrcmd because no rdict)
     assert target.run.call_count == 1
     assert "rm -t product" in target.run.call_args[0][0]
+
+
+def test_uninstall_sl_micro_uses_transactional(monkeypatch, caplog, mock_ssh_client):
+    """SL-Micro uninstalls must dispatch via ``transactional-update``.
+
+    Patterns are formatted ``<product>:<version>::<repo>`` so SL-Micro
+    detection has to match on the product component, not the whole pattern.
+    """
+    args = Namespace(
+        dry=False,
+        target=[{"user@host1": MagicMock()}],
+        repa=[Repa("SL-Micro:6.0")],
+        config="dummy",
+        yaml=False,
+    )
+    target, _ = _setup_uninstall(
+        monkeypatch,
+        args,
+        [MockProduct("SL-Micro", "6.0")],
+        {"SL-Micro:6.0::repo1": MockRepo("SL-Micro")},
+    )
+
+    with caplog.at_level("INFO", logger="repose.command.uninstall"):
+        Uninstall(args).run()
+
+    issued = [c.args[0] for c in target.run.call_args_list]
+    # Both rr (for the matched repo) and the transactional rm should fire.
+    assert any(cmd.startswith("zypper -n rr") for cmd in issued)
+    assert any(
+        "transactional-update pkg rm -t product" in cmd and "SL-Micro" in cmd
+        for cmd in issued
+    )
+    # And the reboot reminder must be emitted.
+    assert any("Reboot" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Four bugs in `repose/command/` surfaced by code review. All are small, surgical fixes with focused tests.

## Bugs Fixed

### 1. `_command.check_url` silently dropped SUSE-style repos
The canonical probe failure set `state = False` and the `suse/` fallback never reset it on success, so even a valid `suse/repodata/repomd.xml` returned `False`. Result: every SUSE-style repository was silently dropped by ``Add`` and ``Reset``. Rewrote with explicit ``return True`` on either probe and a single ``return False`` when both fail.

### 2. `uninstall` SL-Micro detection was dead code
Patterns are formatted as ``<product>:<version>::<repo>``, so ``"SL-Micro" in patterns`` could never match. Switched to comparing the product component (``p.split(":", 1)[0]``), mirroring how ``Install`` does the check.

### 3. `uninstall` ``rrpdtcmd`` kwarg typo
``prodcuts=`` vs the template's ``{products}`` would have raised ``KeyError`` the first time the SL-Micro branch was reachable. Fixed and hoisted the join expression so both branches share it. (Compounded by #2 — the typo was unreachable, so SL-Micro uninstall had never worked end-to-end.)

### 4. `remove` issued ``zypper -n rr`` with no arguments
When patterns were computed but no host repo matched, the method logged "no repos for remove found" and then fell through to run ``zypper -n rr `` (empty repo list). Added the missing ``return``.

## Tests Added

- ``test_check_url_returns_true_when_suse_fallback_succeeds`` — locks in #1.
- ``test_check_url_short_circuits_on_first_success`` — confirms we don't probe the fallback unnecessarily.
- ``test_uninstall_sl_micro_uses_transactional`` — exercises the previously-dead SL-Micro branch end-to-end (#2 + #3).
- ``test_remove_command_empty_repolist_does_not_run_rrcmd`` — guards #4.

## Verification

- ``python3 -m pytest`` — **232 passed** (228 pre-existing + 4 new), 88% coverage
- ``ruff check .`` — All checks passed
- ``ruff format --diff .`` — 64 files already formatted