### PR TITLE
refactor(command): register commands via __init_subclass__

### DIFF
--- a/repose/argparsing.py
+++ b/repose/argparsing.py
@@ -11,55 +11,55 @@ logger = logging.getLogger("repose.arg")
 
 
 def do_install(args):
-    from repose.command import Install  # ty: ignore[unresolved-import]  # FOLLOWUP-ty-residuals (PR 04)
+    from repose.command.install import Install
 
     Install(args).run()
 
 
 def do_list_products(args):
-    from repose.command import ListProducts  # ty: ignore[unresolved-import]  # FOLLOWUP-ty-residuals (PR 04)
+    from repose.command.list import ListProducts
 
     ListProducts(args).run()
 
 
 def do_list_repos(args):
-    from repose.command import ListRepos  # ty: ignore[unresolved-import]  # FOLLOWUP-ty-residuals (PR 04)
+    from repose.command.list import ListRepos
 
     ListRepos(args).run()
 
 
 def do_remove(args):
-    from repose.command import Remove  # ty: ignore[unresolved-import]  # FOLLOWUP-ty-residuals (PR 04)
+    from repose.command.remove import Remove
 
     Remove(args).run()
 
 
 def do_clear(args):
-    from repose.command import Clear  # ty: ignore[unresolved-import]  # FOLLOWUP-ty-residuals (PR 04)
+    from repose.command.clear import Clear
 
     Clear(args).run()
 
 
 def do_uninstall(args):
-    from repose.command import Uninstall  # ty: ignore[unresolved-import]  # FOLLOWUP-ty-residuals (PR 04)
+    from repose.command.uninstall import Uninstall
 
     Uninstall(args).run()
 
 
 def do_add(args):
-    from repose.command import Add  # ty: ignore[unresolved-import]  # FOLLOWUP-ty-residuals (PR 04)
+    from repose.command.add import Add
 
     Add(args).run()
 
 
 def do_reset(args):
-    from repose.command import Reset  # ty: ignore[unresolved-import]  # FOLLOWUP-ty-residuals (PR 04)
+    from repose.command.reset import Reset
 
     Reset(args).run()
 
 
 def do_known_products(args):
-    from repose.command import KnownProducts  # ty: ignore[unresolved-import]  # FOLLOWUP-ty-residuals (PR 04)
+    from repose.command.known import KnownProducts
 
     KnownProducts(args).run()
 

--- a/repose/command/__init__.py
+++ b/repose/command/__init__.py
@@ -1,25 +1,17 @@
-import importlib
-from pathlib import Path
 from ._command import Command as Command
 
-_rootdir = Path(__file__).resolve().parent
-cmd_list = []
-
-for pth in _rootdir.iterdir():
-    # list all ".py"
-    if pth.is_file() and pth.suffix == ".py":
-        modname = pth.stem
-    else:
-        continue
-    # skip things like __init__, __pycache__, __main__ , _commad ...
-    if modname.startswith("_"):
-        continue
-    try:
-        module = importlib.import_module("." + modname, "repose.command")
-    except Exception:
-        continue
-    # register classes
-    __klzs = [x for x in dir(module) if hasattr(getattr(module, x), "command")]
-    cmd_list += __klzs
-    for x in __klzs:
-        globals()[x] = getattr(module, x)
+# Importing for the side effect of populating ``Command.registry`` via
+# ``__init_subclass__``. Order matters: ``remove`` must import before
+# ``uninstall`` (Uninstall subclasses Remove), and ``clear`` before
+# ``reset`` (Reset subclasses Clear). The alphabetical order below
+# satisfies both constraints.
+from . import (  # noqa: F401
+    add,
+    clear,
+    install,
+    known,
+    list,
+    remove,
+    reset,
+    uninstall,
+)

--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -5,7 +5,7 @@ from concurrent.futures import Future
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, ClassVar
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
@@ -21,6 +21,20 @@ logger = logging.getLogger("repose.command")
 
 
 class Command(ABC):
+    registry: ClassVar[dict[str, type["Command"]]] = {}
+
+    def __init_subclass__(cls, *, name: str | None = None, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # ``name`` is optional so abstract intermediates (e.g. a future
+        # base shared by several concrete commands) can inherit from
+        # ``Command`` without polluting the CLI registry. Concrete
+        # commands MUST pass ``name=``.
+        if name is None:
+            return
+        if name in Command.registry:
+            raise RuntimeError(f"Duplicate command name: {name!r}")
+        Command.registry[name] = cls
+
     addcmd: str = "zypper -n ar {params} {name} {url} {name}"
     rrcmd: str = "zypper -n rr {repos}"
     refcmd: str = "zypper -n --gpg-auto-import-keys ref -f"

--- a/repose/command/add.py
+++ b/repose/command/add.py
@@ -8,9 +8,7 @@ from ..utils import blue
 logger = logging.getLogger("repose.command.add")
 
 
-class Add(Command):
-    command = True
-
+class Add(Command, name="add"):
     def _add(self, target):
         repoq = self._init_repoq()
         repolist = []

--- a/repose/command/clear.py
+++ b/repose/command/clear.py
@@ -8,9 +8,7 @@ from ..utils import blue
 logger = logging.getLogger("repose.command.clear")
 
 
-class Clear(Command):
-    command = True
-
+class Clear(Command, name="clear"):
     def _clear(self, host):
         return set(r.alias for r in self.targets[host].raw_repos)
 

--- a/repose/command/install.py
+++ b/repose/command/install.py
@@ -8,9 +8,7 @@ from ..utils import blue
 logger = logging.getLogger("repose.command.install")
 
 
-class Install(Command):
-    command = True
-
+class Install(Command, name="install"):
     def _run(self, target, repoq) -> None:
         repositories = {}
         for repa in self.repa:

--- a/repose/command/known.py
+++ b/repose/command/known.py
@@ -2,9 +2,7 @@ from . import Command
 from ..types import ExitCode
 
 
-class KnownProducts(Command):
-    command = True
-
+class KnownProducts(Command, name="known-products"):
     def run(self) -> ExitCode:
         template = self._load_template()
         self.display.list_known_products(sorted(template.keys()))

--- a/repose/command/list.py
+++ b/repose/command/list.py
@@ -6,9 +6,7 @@ from ..types import ExitCode
 logger = logging.getLogger("repose.command.list")
 
 
-class ListRepos(Command):
-    command = True
-
+class ListRepos(Command, name="list-repos"):
     def run(self) -> ExitCode:
         self.targets.read_repos()
         self.targets.report_repos(self.display.list_update_repos)
@@ -16,9 +14,7 @@ class ListRepos(Command):
         return 0
 
 
-class ListProducts(Command):
-    command = True
-
+class ListProducts(Command, name="list-products"):
     def run(self) -> ExitCode:
         self.targets.read_products()
         if self.yaml:

--- a/repose/command/remove.py
+++ b/repose/command/remove.py
@@ -9,9 +9,7 @@ from ..utils import blue
 logger = logging.getLogger("repose.command.remove")
 
 
-class Remove(Command):
-    command = True
-
+class Remove(Command, name="remove"):
     def _calculate_pattern(self, orepa: Iterable[Repa], host: str) -> set[str]:
         pattern = "{product}:{version}::{repo}"
         products = self.targets[host].products.flatten()

--- a/repose/command/reset.py
+++ b/repose/command/reset.py
@@ -9,9 +9,7 @@ from .clear import Clear
 logger = logging.getLogger("repose.command.reset")
 
 
-class Reset(Clear):
-    command = True
-
+class Reset(Clear, name="reset"):
     def _add(self, target):
         repoq = self._init_repoq()
         cmds = set()

--- a/repose/command/uninstall.py
+++ b/repose/command/uninstall.py
@@ -10,9 +10,7 @@ from ..types import ExitCode
 logger = logging.getLogger("repose.command.uninstall")
 
 
-class Uninstall(Remove):
-    command = True
-
+class Uninstall(Remove, name="uninstall"):
     def _calculate_repodict(
         self, host: str, patterns: set[str]
     ) -> dict[str, list[str]]:

--- a/tests/command/test_discovery.py
+++ b/tests/command/test_discovery.py
@@ -1,32 +1,64 @@
-"""Tests for ``repose.command`` dynamic command discovery."""
+"""Tests for ``repose.command`` registry-based command discovery."""
 
-import repose.command as cmd_pkg
+import pytest
+
+import repose.command  # noqa: F401  # populate Command.registry
+from repose.command import Command
+from repose.types import ExitCode
 
 
 EXPECTED_COMMANDS = {
-    "Add",
-    "Remove",
-    "Install",
-    "Uninstall",
-    "Clear",
-    "Reset",
-    "ListRepos",
-    "ListProducts",
-    "KnownProducts",
+    "add",
+    "remove",
+    "reset",
+    "install",
+    "clear",
+    "uninstall",
+    "list-products",
+    "list-repos",
+    "known-products",
 }
 
 
-def test_cmd_list_contains_expected_commands():
-    assert EXPECTED_COMMANDS.issubset(set(cmd_pkg.cmd_list))
+def test_registry_contains_expected_commands():
+    """Registry holds exactly the 9 CLI names — no more, no less."""
+    assert set(Command.registry) == EXPECTED_COMMANDS
 
 
-def test_each_command_class_exposed_at_module_level():
-    for name in EXPECTED_COMMANDS:
-        assert hasattr(cmd_pkg, name)
-        assert getattr(cmd_pkg, name).command is True
+def test_registered_classes_inherit_command_base():
+    for name, klass in Command.registry.items():
+        assert issubclass(klass, Command), (
+            f"{name!r} -> {klass!r} is not a Command subclass"
+        )
 
 
-def test_command_classes_inherit_command_base():
-    for name in EXPECTED_COMMANDS:
-        klass = getattr(cmd_pkg, name)
-        assert issubclass(klass, cmd_pkg.Command)
+def test_subclass_without_name_kwarg_is_not_registered():
+    """Subclasses that omit ``name=`` must not pollute the registry."""
+
+    class _Anon(Command):
+        def run(self) -> ExitCode:
+            return 0
+
+    assert _Anon not in Command.registry.values()
+
+
+def test_duplicate_name_raises():
+    """Registering two classes under the same name must fail loudly."""
+    sentinel = "__pr04_duplicate_test_name"
+    assert sentinel not in Command.registry
+
+    try:
+
+        class _First(Command, name=sentinel):
+            def run(self) -> ExitCode:
+                return 0
+
+        assert Command.registry[sentinel] is _First
+
+        with pytest.raises(RuntimeError, match="Duplicate command name"):
+
+            class _Second(Command, name=sentinel):
+                def run(self) -> ExitCode:
+                    return 0
+    finally:
+        Command.registry.pop(sentinel, None)

--- a/tests/test_argparsing.py
+++ b/tests/test_argparsing.py
@@ -139,29 +139,31 @@ def test_list_products_yaml_default_false():
 
 
 @pytest.mark.parametrize(
-    "do_func,class_name",
+    "do_func,submodule,class_name",
     [
-        (do_add, "Add"),
-        (do_remove, "Remove"),
-        (do_install, "Install"),
-        (do_uninstall, "Uninstall"),
-        (do_clear, "Clear"),
-        (do_reset, "Reset"),
-        (do_list_products, "ListProducts"),
-        (do_list_repos, "ListRepos"),
-        (do_known_products, "KnownProducts"),
+        (do_add, "add", "Add"),
+        (do_remove, "remove", "Remove"),
+        (do_install, "install", "Install"),
+        (do_uninstall, "uninstall", "Uninstall"),
+        (do_clear, "clear", "Clear"),
+        (do_reset, "reset", "Reset"),
+        (do_list_products, "list", "ListProducts"),
+        (do_list_repos, "list", "ListRepos"),
+        (do_known_products, "known", "KnownProducts"),
     ],
 )
-def test_do_funcs_invoke_command_run(monkeypatch, do_func, class_name):
+def test_do_funcs_invoke_command_run(monkeypatch, do_func, submodule, class_name):
     """Each ``do_*`` instantiates the named command class and calls run()."""
     from unittest.mock import MagicMock
-    import repose.command as cmd_pkg
+    import importlib
+
+    mod = importlib.import_module(f"repose.command.{submodule}")
 
     instance = MagicMock()
     klass = MagicMock(return_value=instance)
-    # do_* funcs do `from repose.command import <Class>` — patch the
-    # name on the package namespace.
-    monkeypatch.setattr(cmd_pkg, class_name, klass)
+    # do_* funcs do `from repose.command.<sub> import <Class>` — patch
+    # the name on the submodule where the do_* import looks it up.
+    monkeypatch.setattr(mod, class_name, klass)
 
     do_func("the-args")
 


### PR DESCRIPTION
## Summary

Replace the directory-walking, exception-swallowing dynamic discovery in `repose/command/__init__.py` with an explicit `Command.registry` populated by `__init_subclass__`. CLI names become first-class and live next to their classes.

## Why

The previous discovery loop had three sharp edges:

1. **Silent failure** — `except Exception: continue` meant any command module with an import error simply vanished from the CLI instead of raising loudly.
2. **Duck-typed marker** — registration depended on a `command = True` class attribute, which is easy to forget on new commands and easy for unrelated classes to accidentally match.
3. **Implicit CLI ↔ class link** — the string `"list-products"` lived in `argparsing.py` while `ListProducts` lived in `command/list.py` with no cross-reference.

## Changes

- **`repose/command/_command.py`** — add `Command.registry: ClassVar[dict[str, type[Command]]]` and `__init_subclass__(cls, *, name=None)`. The kwarg is optional so abstract intermediates don't pollute the registry; duplicate names raise `RuntimeError` immediately.
- **9 command classes** converted to `class X(Command, name="…"):`; the `command = True` marker is removed everywhere. `Uninstall(Remove, name="uninstall")` and `Reset(Clear, name="reset")` declare their own names (the kwarg does not propagate through inheritance).
- **`repose/command/__init__.py`** — replaced with a deterministic submodule-import list. No directory scan, no exception swallowing, no `globals()` injection. The alphabetical ordering satisfies the only real ordering constraints (Remove before Uninstall, Clear before Reset).
- **`repose/argparsing.py`** — `do_*` shims now import from canonical submodule paths (`from repose.command.add import Add`). The matching `ty: ignore[unresolved-import]` comments are dropped now that ty can resolve them statically.
- **`tests/command/test_discovery.py`** — rewritten to assert against `Command.registry` (the 9 CLI names, not class names). New negative tests cover `subclass-without-name kwarg stays out of the registry` and `duplicate-name registration raises`.
- **`tests/test_argparsing.py`** — monkeypatch targets updated from `repose.command.<ClassName>` to the submodule attribute, matching the new import path in the `do_*` shims.

## Verification

- `uv run pytest -v --cov=repose` — 236 passed, 92% coverage.
- `uv run ruff format --diff .` — no diff.
- `uv run ruff check .` — clean.
- `repose --help` lists the same 9 subcommands as before (no CLI regression).
- `python -c "from repose.command import Command; print(sorted(Command.registry))"` outputs the 9 expected CLI names.
- Loud-failure smoke check: injecting a bogus `from nonexistent_module import x` into any command module now raises `ModuleNotFoundError` at `from repose.command import Command` instead of silently dropping the subcommand.

## Risk

Low. The contract change is exactly the intended one: a broken command module now blocks import everywhere instead of vanishing from the CLI silently. No CLI-surface backward-incompatibility — `repose --help` is unchanged. Internal API only: any external consumer that did `from repose.command import <ClassName>` must now import from the submodule (`from repose.command.add import Add`); the project's own `argparsing.py` is the only such caller and is updated in this PR.