### PR TITLE
refactor(cli): dispatch subcommands via Command.registry

### DIFF
--- a/repose/argparsing.py
+++ b/repose/argparsing.py
@@ -2,66 +2,14 @@ import argparse
 import logging
 from pathlib import Path
 
+import repose.command  # noqa: F401 — populate Command.registry
 from repose import __version__
+from repose.command import Command
 
 from .host import ParseHosts
 from .types.repa import Repa
 
 logger = logging.getLogger("repose.arg")
-
-
-def do_install(args):
-    from repose.command.install import Install
-
-    Install(args).run()
-
-
-def do_list_products(args):
-    from repose.command.list import ListProducts
-
-    ListProducts(args).run()
-
-
-def do_list_repos(args):
-    from repose.command.list import ListRepos
-
-    ListRepos(args).run()
-
-
-def do_remove(args):
-    from repose.command.remove import Remove
-
-    Remove(args).run()
-
-
-def do_clear(args):
-    from repose.command.clear import Clear
-
-    Clear(args).run()
-
-
-def do_uninstall(args):
-    from repose.command.uninstall import Uninstall
-
-    Uninstall(args).run()
-
-
-def do_add(args):
-    from repose.command.add import Add
-
-    Add(args).run()
-
-
-def do_reset(args):
-    from repose.command.reset import Reset
-
-    Reset(args).run()
-
-
-def do_known_products(args):
-    from repose.command.known import KnownProducts
-
-    KnownProducts(args).run()
 
 
 def get_parser():
@@ -105,8 +53,12 @@ def get_parser():
 
     commands = parser.add_subparsers()
 
-    def add_subparser(name, help_text, func, arguments=None):
-        """Helper to create a subparser and add common arguments."""
+    def add_subparser(name, help_text, arguments=None):
+        """Create a subparser dispatched via ``Command.registry``.
+
+        The CLI ``name`` must match the ``name=`` kwarg used when the
+        corresponding ``Command`` subclass is declared.
+        """
         if arguments is None:
             arguments = []
         subparser = commands.add_parser(name, help=help_text)
@@ -128,24 +80,24 @@ def get_parser():
                 type=Repa,
                 help="REPA pattern specification for needed repository",
             )
-        subparser.set_defaults(func=func)
+        # Late-bind via default arg to dodge the closure late-binding
+        # trap, and resolve through the registry at call time so tests
+        # can monkeypatch ``Command.registry`` entries.
+        subparser.set_defaults(
+            func=lambda args, _n=name: Command.registry[_n](args).run()
+        )
         return subparser
 
     # command ADD
-    add_subparser(
-        "add", "add specified repository to target", do_add, ["target", "repa"]
-    )
+    add_subparser("add", "add specified repository to target", ["target", "repa"])
 
     # command REMOVE
-    add_subparser(
-        "remove", "remove repository from target", do_remove, ["target", "repa"]
-    )
+    add_subparser("remove", "remove repository from target", ["target", "repa"])
 
     # command RESET
     add_subparser(
         "reset",
         "reset target repositories to only installed products repositories",
-        do_reset,
         ["target"],
     )
 
@@ -153,25 +105,21 @@ def get_parser():
     add_subparser(
         "install",
         "add specified repository to target and install product",
-        do_install,
         ["target", "repa"],
     )
 
     # command CLEAR
-    add_subparser("clear", "clear all repositories from target", do_clear, ["target"])
+    add_subparser("clear", "clear all repositories from target", ["target"])
 
     # command Uninstall
     add_subparser(
         "uninstall",
         "remove specified repository from target and uninstall product",
-        do_uninstall,
         ["target", "repa"],
     )
 
     # command LIST-Products
-    cmdlistp = add_subparser(
-        "list-products", "list products on target", do_list_products, ["target"]
-    )
+    cmdlistp = add_subparser("list-products", "list products on target", ["target"])
     glistp = cmdlistp.add_mutually_exclusive_group()
     glistp.add_argument(
         "--yaml",
@@ -180,13 +128,9 @@ def get_parser():
     )
 
     # command LIST-Repos
-    add_subparser(
-        "list-repos", "list repositories on target", do_list_repos, ["target"]
-    )
+    add_subparser("list-repos", "list repositories on target", ["target"])
 
     # command KnownProducts
-    add_subparser(
-        "known-products", "list known products by 'repose'", do_known_products
-    )
+    add_subparser("known-products", "list known products by 'repose'")
 
     return parser

--- a/tests/test_argparsing.py
+++ b/tests/test_argparsing.py
@@ -1,21 +1,12 @@
 import sys
+from unittest.mock import MagicMock
 
 import pytest
 
 import repose.argparsing
 from repose import __version__
-from repose.argparsing import (
-    do_add,
-    do_clear,
-    do_install,
-    do_known_products,
-    do_list_products,
-    do_list_repos,
-    do_remove,
-    do_reset,
-    do_uninstall,
-    get_parser,
-)
+from repose.argparsing import get_parser
+from repose.command import Command
 
 
 @pytest.fixture
@@ -44,23 +35,56 @@ def test_debug_action():
 
 
 @pytest.mark.parametrize(
-    "command, expected_func, cli_args",
+    "command, registry_key, cli_args",
     [
-        ("add", do_add, ["add", "-t", "dummy", "dummy"]),
-        ("remove", do_remove, ["remove", "-t", "dummy", "dummy"]),
-        ("reset", do_reset, ["reset", "-t", "dummy"]),
-        ("install", do_install, ["install", "-t", "dummy", "dummy"]),
-        ("clear", do_clear, ["clear", "-t", "dummy"]),
-        ("uninstall", do_uninstall, ["uninstall", "-t", "dummy", "dummy"]),
-        ("list-products", do_list_products, ["list-products", "-t", "dummy"]),
-        ("list-repos", do_list_repos, ["list-repos", "-t", "dummy"]),
-        ("known-products", do_known_products, ["known-products"]),
+        ("add", "add", ["add", "-t", "dummy", "dummy"]),
+        ("remove", "remove", ["remove", "-t", "dummy", "dummy"]),
+        ("reset", "reset", ["reset", "-t", "dummy"]),
+        ("install", "install", ["install", "-t", "dummy", "dummy"]),
+        ("clear", "clear", ["clear", "-t", "dummy"]),
+        ("uninstall", "uninstall", ["uninstall", "-t", "dummy", "dummy"]),
+        ("list-products", "list-products", ["list-products", "-t", "dummy"]),
+        ("list-repos", "list-repos", ["list-repos", "-t", "dummy"]),
+        ("known-products", "known-products", ["known-products"]),
     ],
 )
-def test_command_functions(mock_types, command, expected_func, cli_args):
+def test_command_dispatches_to_registry(
+    monkeypatch, mock_types, command, registry_key, cli_args
+):
+    """args.func resolves the matching Command class via the registry."""
+    instance = MagicMock()
+    fake_cls = MagicMock(return_value=instance)
+    monkeypatch.setitem(Command.registry, registry_key, fake_cls)
+
+    args = get_parser().parse_args(cli_args)
+    args.func(args)
+
+    fake_cls.assert_called_once_with(args)
+    instance.run.assert_called_once()
+
+
+def test_dispatch_uses_late_binding_per_subcommand(monkeypatch, mock_types):
+    """Each subparser dispatches to its OWN command, not the last one
+    registered (regression test for the closure late-binding trap)."""
+    add_instance = MagicMock()
+    add_cls = MagicMock(return_value=add_instance)
+    clear_instance = MagicMock()
+    clear_cls = MagicMock(return_value=clear_instance)
+    monkeypatch.setitem(Command.registry, "add", add_cls)
+    monkeypatch.setitem(Command.registry, "clear", clear_cls)
+
     parser = get_parser()
-    args = parser.parse_args(cli_args)
-    assert args.func == expected_func
+
+    add_args = parser.parse_args(["add", "-t", "h", "x"])
+    add_args.func(add_args)
+    add_cls.assert_called_once_with(add_args)
+    add_instance.run.assert_called_once()
+    clear_cls.assert_not_called()
+
+    clear_args = parser.parse_args(["clear", "-t", "h"])
+    clear_args.func(clear_args)
+    clear_cls.assert_called_once_with(clear_args)
+    clear_instance.run.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -132,40 +156,3 @@ def test_list_products_yaml_flag():
 def test_list_products_yaml_default_false():
     args = get_parser().parse_args(["list-products", "-t", "h"])
     assert args.yaml is False
-
-
-# Smoke tests for do_* dispatchers — make sure they import the right
-# command class and call .run().
-
-
-@pytest.mark.parametrize(
-    "do_func,submodule,class_name",
-    [
-        (do_add, "add", "Add"),
-        (do_remove, "remove", "Remove"),
-        (do_install, "install", "Install"),
-        (do_uninstall, "uninstall", "Uninstall"),
-        (do_clear, "clear", "Clear"),
-        (do_reset, "reset", "Reset"),
-        (do_list_products, "list", "ListProducts"),
-        (do_list_repos, "list", "ListRepos"),
-        (do_known_products, "known", "KnownProducts"),
-    ],
-)
-def test_do_funcs_invoke_command_run(monkeypatch, do_func, submodule, class_name):
-    """Each ``do_*`` instantiates the named command class and calls run()."""
-    from unittest.mock import MagicMock
-    import importlib
-
-    mod = importlib.import_module(f"repose.command.{submodule}")
-
-    instance = MagicMock()
-    klass = MagicMock(return_value=instance)
-    # do_* funcs do `from repose.command.<sub> import <Class>` — patch
-    # the name on the submodule where the do_* import looks it up.
-    monkeypatch.setattr(mod, class_name, klass)
-
-    do_func("the-args")
-
-    klass.assert_called_once_with("the-args")
-    instance.run.assert_called_once()


### PR DESCRIPTION
## Summary

Removes the nine `do_X(args): X(args).run()` shims from
`repose/argparsing.py` and dispatches subcommands directly through
`Command.registry` (populated by `__init_subclass__`).

## Motivation

The shims were boilerplate left over from old directory-scan command
discovery. With self-registering `Command` subclasses, they only hide
the subparser-to-class binding behind an extra hop. Collapsing them
makes the CLI surface ↔ Command class binding explicit at a single
site and trims ~50 LOC of dispatch boilerplate.

## Changes

- Delete `do_add`, `do_remove`, `do_reset`, `do_install`, `do_clear`,
  `do_uninstall`, `do_list_products`, `do_list_repos`,
  `do_known_products`.
- `add_subparser` drops its `func` parameter and sets
  ``func=lambda args, _n=name: Command.registry[_n](args).run()``
  — default-arg ``_n=name`` sidesteps the closure late-binding trap.
- Import ``repose.command`` for its side effect of populating
  ``Command.registry``.

## Tests

- Existing per-subcommand parametrized test rewritten to monkeypatch
  `Command.registry` entries and assert the matching class is
  instantiated + `.run()` called.
- New `test_dispatch_uses_late_binding_per_subcommand` regression
  test verifies two subparsers each dispatch to their own command,
  not the last one registered.

## Verification

- `ruff format --diff .` — clean
- `ruff check .` — clean
- `pytest -q` — **228 passed**
- `argparsing.py` coverage: **100%**
- `argparsing.py` LOC: 192 → 138 (−56)
- `rg '^def do_' repose` → no matches
- `repose add --help`, `repose list-products --help`,
  `repose known-products --help` — all render
- CLI surface unchanged (back-compat preserved)