### PR TITLE
feat(command): propagate per-target failures into process exit codes

### DIFF
--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -75,31 +75,73 @@ class Command(ABC):
     def _init_repoq(self) -> Repoq:
         return Repoq(self._load_template())
 
-    def _report_target(self, target: str) -> None:
-        if self.targets[target].out[-1][3] == 0:
+    def _report_target(self, target: str) -> bool:
+        """Log the last command's output for ``target`` and report success.
+
+        Returns ``True`` for zypper exit 0 (success) and exit 4
+        (no repositories — benign, kept as info-warning for parity with
+        prior behaviour). Any other exit code is treated as failure and
+        the call returns ``False`` so the caller can propagate the
+        per-host status into ``_aggregate``.
+        """
+        exitcode = self.targets[target].out[-1][3]
+        if exitcode == 0:
             for line in self.targets[target].out[-1][1].splitlines():
                 logger.info(blue(f"{target}") + f" - {line}")
-        elif self.targets[target].out[-1][3] == 4:
+            return True
+        if exitcode == 4:
+            # zypper: "no repositories defined" — benign in our flow.
             for line in self.targets[target].out[-1][1].splitlines():
                 logger.warning(blue(f"{target}") + f" - {line}")
-        else:
-            for line in self.targets[target].out[-1][2].splitlines():
-                logger.warning(blue(f"{target}") + f" - {line}")
+            return True
+        for line in self.targets[target].out[-1][2].splitlines():
+            logger.warning(blue(f"{target}") + f" - {line}")
+        return False
 
     def _run_parallel(
         self,
-        fn: Callable[..., None],
+        fn: Callable[..., bool],
         *extra_args: Any,
-    ) -> list[Future[None]]:
+    ) -> list[Future[bool]]:
         """Fan ``fn(host, *extra_args)`` across all live targets.
 
         Returns the futures so callers can inspect ``.exception()``
-        (used by PR 6 for exit-code propagation).
+        and ``.result()`` (consumed by ``_aggregate`` for exit-code
+        propagation).
         """
         with concurrent.futures.ThreadPoolExecutor() as ex:
             futures = [ex.submit(fn, host, *extra_args) for host in self.targets.keys()]
             concurrent.futures.wait(futures)
             return futures
+
+    def _aggregate(self, futures: list[Future[bool]]) -> ExitCode:
+        """Collapse per-target futures into a process exit code.
+
+        A future counts as failed when it raised (``f.exception() is not
+        None``) or when its result is explicitly ``False``. A result of
+        ``True`` (or any non-``False`` truthy value) counts as success
+        for forward compatibility with callers that may still return
+        ``None`` during transition.
+
+        Returns ``0`` when every future succeeded, ``2`` when every
+        future failed (including the degenerate single-host all-failed
+        case), and ``1`` otherwise.
+        """
+        total = len(futures)
+        if total == 0:
+            return 0
+        failed = 0
+        for f in futures:
+            if f.exception() is not None:
+                failed += 1
+                continue
+            if f.result() is False:
+                failed += 1
+        if failed == 0:
+            return 0
+        if failed == total:
+            return 2
+        return 1
 
     @staticmethod
     def check_url(url: str) -> bool:

--- a/repose/command/add.py
+++ b/repose/command/add.py
@@ -9,10 +9,18 @@ logger = logging.getLogger("repose.command.add")
 
 
 class Add(Command, name="add"):
-    def _add(self, target):
+    def _add(self, target) -> tuple[set[str], bool]:
+        """Resolve REPA patterns for ``target`` into ``zypper ar`` commands.
+
+        Returns ``(cmds, ok)`` where ``ok`` is ``False`` if any REPA in
+        ``self.repa`` failed to resolve (caught ``ValueError`` from
+        ``Repoq.solve_repa``). The caller uses ``ok`` to mark the host
+        as failed in the aggregated exit code.
+        """
         repoq = self._init_repoq()
         repolist = []
         cmds = set()
+        ok = True
         for repa in self.repa:
             try:
                 repolist += chain.from_iterable(
@@ -23,6 +31,7 @@ class Add(Command, name="add"):
                 )
             except ValueError as error:
                 logger.error(error)
+                ok = False
         cmds.update(
             self.addcmd.format(
                 name=x.name, url=x.url, params="-cfkn" if x.refresh else "-ckn"
@@ -30,23 +39,25 @@ class Add(Command, name="add"):
             for x in repolist
             if self.check_url(x.url)
         )
-        return cmds
+        return cmds, ok
 
-    def _run(self, target) -> None:
-        cmds = self._add(target)
+    def _run(self, target) -> bool:
+        cmds, ok = self._add(target)
         for cmd in cmds:
             if self.dryrun:
                 print("{} - {}".format(blue(target), cmd))
             else:
                 self.targets[target].run(cmd)
-                self._report_target(target)
+                if not self._report_target(target):
+                    ok = False
+        return ok
 
     def run(self) -> ExitCode:
         self.targets.read_products()
-        self._run_parallel(self._run)
+        futures = self._run_parallel(self._run)
 
         if not self.dryrun:
             self.targets.run(self.refcmd)
         self.targets.close()
 
-        return 0
+        return self._aggregate(futures)

--- a/repose/command/clear.py
+++ b/repose/command/clear.py
@@ -12,7 +12,7 @@ class Clear(Command, name="clear"):
     def _clear(self, host):
         return set(r.alias for r in self.targets[host].raw_repos)
 
-    def _run(self, host):
+    def _run(self, host) -> bool:
         repoaliases = self._clear(host)
 
         if self.dryrun:
@@ -22,12 +22,14 @@ class Clear(Command, name="clear"):
                     host, self.rrcmd.format(repos=" ".join(repoaliases))
                 )
             )
-        else:
-            self.targets[host].run(self.rrcmd.format(repos=" ".join(repoaliases)))
-            logger.info("Repositories cleared from %s", host)
+            return True
+
+        self.targets[host].run(self.rrcmd.format(repos=" ".join(repoaliases)))
+        logger.info("Repositories cleared from %s", host)
+        return True
 
     def run(self) -> ExitCode:
         self.targets.read_repos()
-        self._run_parallel(self._run)
+        futures = self._run_parallel(self._run)
         self.targets.close()
-        return 0
+        return self._aggregate(futures)

--- a/repose/command/install.py
+++ b/repose/command/install.py
@@ -9,8 +9,9 @@ logger = logging.getLogger("repose.command.install")
 
 
 class Install(Command, name="install"):
-    def _run(self, target, repoq) -> None:
+    def _run(self, target, repoq) -> bool:
         repositories = {}
+        ok = True
         for repa in self.repa:
             try:
                 repositories.update(
@@ -18,6 +19,7 @@ class Install(Command, name="install"):
                 )
             except ValueError as error:
                 logger.error(error)
+                ok = False
 
         for repo in chain.from_iterable(x for x in (y for y in repositories.values())):
             addcmd = self.addcmd.format(
@@ -27,7 +29,8 @@ class Install(Command, name="install"):
                 print(blue(f"{target}") + f" - {addcmd}")
             else:
                 self.targets[target].run(addcmd)
-                self._report_target(target)
+                if not self._report_target(target):
+                    ok = False
                 self.targets[target].run(self.refcmd)
 
         if repositories.keys():
@@ -41,18 +44,21 @@ class Install(Command, name="install"):
                 print(blue(str(target)) + f" - {inscmd}")
             else:
                 self.targets[target].run(inscmd)
-                self._report_target(target)
+                if not self._report_target(target):
+                    ok = False
                 if transactional:
                     logger.info(
                         "Reboot %s to switch into correct snapshot", str(target)
                     )
         else:
             logger.error("No products to install")
+            ok = False
+        return ok
 
     def run(self) -> ExitCode:
         repoq = self._init_repoq()
         self.targets.read_products()
         self.targets.read_repos()
-        self._run_parallel(self._run, repoq)
+        futures = self._run_parallel(self._run, repoq)
         self.targets.close()
-        return 0
+        return self._aggregate(futures)

--- a/repose/command/remove.py
+++ b/repose/command/remove.py
@@ -44,28 +44,35 @@ class Remove(Command, name="remove"):
                     repolist.add(repo)
         return repolist
 
-    def _run(self, host: str, *args: Any) -> None:
+    def _run(self, host: str, *args: Any) -> bool:
+        """Compute and (optionally) issue the ``zypper rr`` command.
+
+        Returns ``True`` when no work was found (an INFO-level no-op,
+        not an error) and ``True``/``False`` from ``_report_target``
+        when the command actually ran.
+        """
         patterns = self._calculate_pattern(self.repa, host)
 
         if not patterns:
             logger.info("For %s no repos for remove found", host)
-            return
+            return True
         repolist = self._calculate_repolist(host, patterns)
 
         if not repolist:
             logger.info("For %s no repos for remove found", host)
-            return
+            return True
         cmd = self.rrcmd.format(repos=" ".join(repolist))
 
         if self.dryrun:
             print(blue(host) + f" - {cmd}")
-        else:
-            self.targets[host].run(cmd)
-            self._report_target(host)
+            return True
+
+        self.targets[host].run(cmd)
+        return self._report_target(host)
 
     def run(self) -> ExitCode:
         self.targets.read_repos()
         self.targets.parse_repos()
-        self._run_parallel(self._run)
+        futures = self._run_parallel(self._run)
         self.targets.close()
-        return 0
+        return self._aggregate(futures)

--- a/repose/command/reset.py
+++ b/repose/command/reset.py
@@ -25,8 +25,9 @@ class Reset(Clear, name="reset"):
         )
         return cmds
 
-    def _run(self, host) -> None:
+    def _run(self, host) -> bool:
         repoaliases = self._clear(host)
+        ok = True
         try:
             cmds = self._add(host)
 
@@ -37,17 +38,21 @@ class Reset(Clear, name="reset"):
                 )
                 for cmd in cmds:
                     print(blue(host) + f" - {cmd}")
-            else:
-                self.targets[host].run(self.rrcmd.format(repos=" ".join(repoaliases)))
-                for cmd in cmds:
-                    self.targets[host].run(cmd)
-                    self._report_target(host)
+                return True
+
+            self.targets[host].run(self.rrcmd.format(repos=" ".join(repoaliases)))
+            for cmd in cmds:
+                self.targets[host].run(cmd)
+                if not self._report_target(host):
+                    ok = False
         except UnsuportedProductMessage as e:
             logger.error("Refhost %s - %s", host, e)
+            ok = False
+        return ok
 
     def run(self) -> ExitCode:
         self.targets.read_products()
         self.targets.read_repos()
-        self._run_parallel(self._run)
+        futures = self._run_parallel(self._run)
         self.targets.close()
-        return 0
+        return self._aggregate(futures)

--- a/repose/command/uninstall.py
+++ b/repose/command/uninstall.py
@@ -24,13 +24,13 @@ class Uninstall(Remove, name="uninstall"):
                         rdict[repo[1].name] = [repo[0]]
         return rdict
 
-    def _run(self, host: str, *args: Any) -> None:
+    def _run(self, host: str, *args: Any) -> bool:
         # First positional ``args`` element is the orepa list (see ``run``).
         orepa = args[0]
         patterns = self._calculate_pattern(orepa, host)
         if not patterns:
             logger.info("For %s no products for remove found", host)
-            return
+            return True
 
         rdict = self._calculate_repodict(host, patterns)
         if not rdict:
@@ -54,14 +54,19 @@ class Uninstall(Remove, name="uninstall"):
             if rrcmd:
                 print(blue(host) + " - {}".format(rrcmd))
             print(blue(host) + " - {}".format(pdcmd))
-        else:
-            if rrcmd:
-                self.targets[host].run(rrcmd)
-                self._report_target(host)
-            self.targets[host].run(pdcmd)
-            self._report_target(host)
-            if transactional:
-                logger.info("Reboot %s to switch into updated snapshot", host)
+            return True
+
+        ok = True
+        if rrcmd:
+            self.targets[host].run(rrcmd)
+            if not self._report_target(host):
+                ok = False
+        self.targets[host].run(pdcmd)
+        if not self._report_target(host):
+            ok = False
+        if transactional:
+            logger.info("Reboot %s to switch into updated snapshot", host)
+        return ok
 
     def run(self) -> ExitCode:
         self.targets.read_repos()
@@ -72,6 +77,6 @@ class Uninstall(Remove, name="uninstall"):
             r.repo = None
             orepa.append(r)
 
-        self._run_parallel(self._run, orepa)
+        futures = self._run_parallel(self._run, orepa)
         self.targets.close()
-        return 0
+        return self._aggregate(futures)

--- a/repose/types/__init__.py
+++ b/repose/types/__init__.py
@@ -1,3 +1,10 @@
 from typing import Literal, TypeAlias
 
-ExitCode: TypeAlias = Literal[0, 1]
+# Process exit code aggregated from per-target task results.
+#
+# 0 — all targets succeeded.
+# 1 — partial failure: at least one target succeeded and at least one
+#     target failed.
+# 2 — hard failure: every target failed (or no targets were reachable
+#     once the run reached aggregation).
+ExitCode: TypeAlias = Literal[0, 1, 2]

--- a/tests/command/test_add.py
+++ b/tests/command/test_add.py
@@ -17,6 +17,18 @@ class MockRepo:
         self.refresh = refresh
 
 
+def _ok_out():
+    """Return a target.out list with a single zero-exitcode entry,
+    so ``_report_target`` returns True."""
+    return [["cmd", "", "", 0, 0]]
+
+
+def _fail_out():
+    """Return a target.out list with a non-zero exitcode so
+    ``_report_target`` returns False."""
+    return [["cmd", "", "boom", 1, 0]]
+
+
 @pytest.fixture
 def mock_args_and_repa():
     """Fixture for command arguments."""
@@ -44,6 +56,7 @@ def test_add_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
     }
 
     mock_target = MagicMock()
+    mock_target.out = _ok_out()
     mock_host_group_instance = MagicMock()
     mock_host_group_instance.keys.return_value = ["user@host1"]
     mock_host_group_instance.__getitem__.return_value = mock_target
@@ -60,7 +73,7 @@ def test_add_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
 
     # Instantiate and Run
     add_command = Add(mock_args)
-    add_command.run()
+    assert add_command.run() == 0
 
     # Assertions
     mock_host_group_instance.read_products.assert_called_once()
@@ -111,7 +124,7 @@ def test_add_command_dryrun_prints_and_skips_run(
     monkeypatch.setattr(Add, "_init_repoq", MagicMock(return_value=mock_repoq))
     monkeypatch.setattr(Add, "check_url", MagicMock(return_value=True))
 
-    Add(args).run()
+    assert Add(args).run() == 0
 
     mock_target.run.assert_not_called()
     # refcmd skipped on dryrun
@@ -147,7 +160,8 @@ def test_add_command_solve_repa_value_error_logged(
     monkeypatch.setattr(Add, "check_url", MagicMock(return_value=True))
 
     with caplog.at_level("ERROR", logger="repose.command.add"):
-        Add(args).run()
+        # solve_repa failure on the only host → all hosts failed → exit 2.
+        assert Add(args).run() == 2
 
     assert any("Not known product" in r.message for r in caplog.records)
     mock_target.run.assert_not_called()
@@ -177,7 +191,77 @@ def test_add_command_skips_repo_when_check_url_false(
     monkeypatch.setattr(Add, "_init_repoq", MagicMock(return_value=mock_repoq))
     monkeypatch.setattr(Add, "check_url", MagicMock(return_value=False))
 
-    Add(args).run()
+    # Repo filtered out by check_url → no cmds attempted, no failures → 0.
+    assert Add(args).run() == 0
 
     # Repo got filtered out because URL check failed → no per-target add cmd
     mock_target.run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Exit code propagation (PR 06)
+# ---------------------------------------------------------------------------
+
+
+def _setup_add_hosts(monkeypatch, hosts):
+    """Build a HostGroup-like mock with one target per host and stub
+    out the URL probe + repoq resolution to a single repo.
+
+    ``hosts`` is a dict mapping ``host -> target.out`` so callers can
+    decide which hosts succeed and which fail.
+    """
+    targets = {}
+    for host, out in hosts.items():
+        t = MagicMock()
+        t.products.get_base.return_value = "dummy_base"
+        t.out = out
+        targets[host] = t
+
+    hg = MagicMock()
+    hg.keys.return_value = list(hosts.keys())
+    hg.__getitem__.side_effect = lambda k: targets[k]
+
+    monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr(
+        repose.command._command,
+        "HostGroup",
+        MagicMock(return_value=hg),
+    )
+
+    mock_repoq = MagicMock()
+    mock_repoq.solve_repa.return_value = {
+        "product": [MockRepo("repo1", "http://repo1.url", refresh=False)]
+    }
+    monkeypatch.setattr(Add, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Add, "check_url", MagicMock(return_value=True))
+    return targets, hg
+
+
+def test_add_run_returns_0_when_all_succeed(
+    monkeypatch, mock_args_and_repa, mock_ssh_client
+):
+    args, _ = mock_args_and_repa
+    args.target = [{"h1": MagicMock(), "h2": MagicMock()}]
+    _setup_add_hosts(monkeypatch, {"h1": _ok_out(), "h2": _ok_out()})
+
+    assert Add(args).run() == 0
+
+
+def test_add_run_returns_1_on_partial_failure(
+    monkeypatch, mock_args_and_repa, mock_ssh_client
+):
+    args, _ = mock_args_and_repa
+    args.target = [{"h1": MagicMock(), "h2": MagicMock()}]
+    _setup_add_hosts(monkeypatch, {"h1": _ok_out(), "h2": _fail_out()})
+
+    assert Add(args).run() == 1
+
+
+def test_add_run_returns_2_when_all_fail(
+    monkeypatch, mock_args_and_repa, mock_ssh_client
+):
+    args, _ = mock_args_and_repa
+    args.target = [{"h1": MagicMock(), "h2": MagicMock()}]
+    _setup_add_hosts(monkeypatch, {"h1": _fail_out(), "h2": _fail_out()})
+
+    assert Add(args).run() == 2

--- a/tests/command/test_clear.py
+++ b/tests/command/test_clear.py
@@ -43,7 +43,7 @@ def test_clear_command_run(monkeypatch, mock_args, mock_ssh_client):
 
     # Run
     clear_command = Clear(mock_args)
-    clear_command.run()
+    assert clear_command.run() == 0
 
     # Assertions
     mock_host_group_instance.read_repos.assert_called_once()
@@ -78,7 +78,7 @@ def test_clear_command_dryrun_skips_run(monkeypatch, capsys, mock_ssh_client):
         MagicMock(return_value=mock_hg),
     )
 
-    Clear(args).run()
+    assert Clear(args).run() == 0
 
     mock_target.run.assert_not_called()
     out = capsys.readouterr().out
@@ -108,8 +108,84 @@ def test_clear_command_empty_repos(monkeypatch, mock_ssh_client):
         MagicMock(return_value=mock_hg),
     )
 
-    Clear(args).run()
+    assert Clear(args).run() == 0
 
     # rr command still issued, just with empty repos list
     cmd = mock_target.run.call_args[0][0]
     assert cmd.startswith("zypper -n rr")
+
+
+# ---------------------------------------------------------------------------
+# Exit code propagation (PR 06)
+# ---------------------------------------------------------------------------
+
+
+def _setup_clear_hosts(monkeypatch, hosts):
+    """Build a HostGroup mock with one target per host.
+
+    ``hosts`` is a dict mapping ``host -> target.run side_effect``
+    (either ``None`` for success or an exception to raise).
+    """
+    targets = {}
+    for host, run_se in hosts.items():
+        t = MagicMock()
+        t.raw_repos = [MockRawRepo(f"{host}-repo")]
+        if run_se is not None:
+            t.run.side_effect = run_se
+        targets[host] = t
+
+    hg = MagicMock()
+    hg.keys.return_value = list(hosts.keys())
+    hg.__getitem__.side_effect = lambda k: targets[k]
+
+    monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr(
+        repose.command._command,
+        "HostGroup",
+        MagicMock(return_value=hg),
+    )
+    return targets, hg
+
+
+def test_clear_run_returns_0_when_all_succeed(monkeypatch, mock_ssh_client):
+    args = Namespace(
+        dry=False,
+        target=[{"h1": MagicMock(), "h2": MagicMock()}],
+        repa=None,
+        config="dummy_config",
+        yaml=False,
+    )
+    _setup_clear_hosts(monkeypatch, {"h1": None, "h2": None})
+
+    assert Clear(args).run() == 0
+
+
+def test_clear_run_returns_1_on_partial_failure(monkeypatch, mock_ssh_client):
+    """If ``target.run`` raises on one host, that host's _run future
+    holds an exception → partial failure."""
+    args = Namespace(
+        dry=False,
+        target=[{"h1": MagicMock(), "h2": MagicMock()}],
+        repa=None,
+        config="dummy_config",
+        yaml=False,
+    )
+    _setup_clear_hosts(monkeypatch, {"h1": None, "h2": RuntimeError("boom")})
+
+    assert Clear(args).run() == 1
+
+
+def test_clear_run_returns_2_when_all_fail(monkeypatch, mock_ssh_client):
+    args = Namespace(
+        dry=False,
+        target=[{"h1": MagicMock(), "h2": MagicMock()}],
+        repa=None,
+        config="dummy_config",
+        yaml=False,
+    )
+    _setup_clear_hosts(
+        monkeypatch,
+        {"h1": RuntimeError("boom1"), "h2": RuntimeError("boom2")},
+    )
+
+    assert Clear(args).run() == 2

--- a/tests/command/test_command_base.py
+++ b/tests/command/test_command_base.py
@@ -130,16 +130,19 @@ def test_unconnected_targets_are_dropped(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "exitcode,expected_stream",
+    "exitcode,expected_stream,expected_ok",
     [
-        (0, "stdout"),  # logger.info on stdout
-        (4, "stdout"),  # logger.warning on stdout
-        (1, "stderr"),  # logger.warning on stderr
-        (-1, "stderr"),
+        (0, "stdout", True),  # logger.info on stdout, success
+        (4, "stdout", True),  # logger.warning on stdout, benign success
+        (1, "stderr", False),  # logger.warning on stderr, failure
+        (-1, "stderr", False),
     ],
 )
-def test_report_target_routes_by_exitcode(monkeypatch, exitcode, expected_stream):
-    """_report_target picks the right output stream depending on exitcode."""
+def test_report_target_routes_by_exitcode(
+    monkeypatch, exitcode, expected_stream, expected_ok
+):
+    """_report_target picks the right output stream depending on exitcode
+    and returns ``True`` for success/benign exits, ``False`` for failures."""
     target = MagicMock()
     # out is list of [cmd, stdout, stderr, exitcode, runtime]
     target.out = [["cmd", "out-line", "err-line", exitcode, 0]]
@@ -149,8 +152,7 @@ def test_report_target_routes_by_exitcode(monkeypatch, exitcode, expected_stream
     hg.__getitem__.return_value = target
 
     cmd, _ = _make(monkeypatch, host_group=hg)
-    # Should not raise
-    cmd._report_target("host")
+    assert cmd._report_target("host") is expected_ok
 
 
 def test_init_repoq_loads_template(monkeypatch, tmp_path):
@@ -210,3 +212,74 @@ def test_run_parallel_passes_extra_args_after_host(monkeypatch):
         ]
     )
     assert [f.result() for f in futures] == [None, None]
+
+
+# ---------------------------------------------------------------------------
+# _aggregate
+# ---------------------------------------------------------------------------
+
+
+def _ok_future(value: bool = True) -> Future:
+    """Return a completed Future whose result is ``value``."""
+    f: Future = Future()
+    f.set_result(value)
+    return f
+
+
+def _failed_future(exc: BaseException | None = None) -> Future:
+    """Return a completed Future that holds an exception."""
+    f: Future = Future()
+    f.set_exception(exc or RuntimeError("boom"))
+    return f
+
+
+def test_aggregate_returns_0_when_no_futures(monkeypatch):
+    """No targets at all is treated as success — there's nothing that
+    could have failed."""
+    cmd, _ = _make(monkeypatch)
+    assert cmd._aggregate([]) == 0
+
+
+def test_aggregate_returns_0_when_all_succeed(monkeypatch):
+    cmd, _ = _make(monkeypatch)
+    futures = [_ok_future(True), _ok_future(True), _ok_future(True)]
+    assert cmd._aggregate(futures) == 0
+
+
+def test_aggregate_returns_2_when_all_fail_via_exception(monkeypatch):
+    cmd, _ = _make(monkeypatch)
+    futures = [_failed_future(), _failed_future()]
+    assert cmd._aggregate(futures) == 2
+
+
+def test_aggregate_returns_2_when_all_fail_via_false_result(monkeypatch):
+    cmd, _ = _make(monkeypatch)
+    futures = [_ok_future(False), _ok_future(False)]
+    assert cmd._aggregate(futures) == 2
+
+
+def test_aggregate_returns_2_for_single_host_failure(monkeypatch):
+    """Degenerate all-failed case: 1 of 1 failed → still exit 2."""
+    cmd, _ = _make(monkeypatch)
+    assert cmd._aggregate([_ok_future(False)]) == 2
+    assert cmd._aggregate([_failed_future()]) == 2
+
+
+def test_aggregate_returns_1_on_partial_failure(monkeypatch):
+    cmd, _ = _make(monkeypatch)
+    futures = [_ok_future(True), _ok_future(False)]
+    assert cmd._aggregate(futures) == 1
+
+
+def test_aggregate_returns_1_when_some_raise_and_some_succeed(monkeypatch):
+    cmd, _ = _make(monkeypatch)
+    futures = [_ok_future(True), _failed_future(), _ok_future(True)]
+    assert cmd._aggregate(futures) == 1
+
+
+def test_aggregate_treats_none_result_as_success(monkeypatch):
+    """Forward-compatibility: any non-False result counts as success
+    so legacy callers returning ``None`` don't accidentally fail."""
+    cmd, _ = _make(monkeypatch)
+    futures = [_ok_future(None), _ok_future(True)]  # type: ignore[arg-type]
+    assert cmd._aggregate(futures) == 0

--- a/tests/command/test_install.py
+++ b/tests/command/test_install.py
@@ -17,6 +17,14 @@ class MockRepo:
         self.refresh = refresh
 
 
+def _ok_out():
+    return [["cmd", "", "", 0, 0]]
+
+
+def _fail_out():
+    return [["cmd", "", "boom", 1, 0]]
+
+
 @pytest.fixture
 def mock_args_and_repa():
     repa_instance = Repa("dummy-repa")
@@ -41,6 +49,7 @@ def test_install_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
 
     mock_target = MagicMock()
     mock_target.products.get_base.return_value = "dummy_base"
+    mock_target.out = _ok_out()
     mock_host_group_instance = MagicMock()
     mock_host_group_instance.keys.return_value = ["user@host1"]
     mock_host_group_instance.__getitem__.return_value = mock_target
@@ -55,7 +64,7 @@ def test_install_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
 
     # Run
     install_command = Install(mock_args)
-    install_command.run()
+    assert install_command.run() == 0
 
     # Assertions
     mock_host_group_instance.read_products.assert_called_once()
@@ -79,12 +88,13 @@ def test_install_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
     mock_host_group_instance.close.assert_called_once()
 
 
-def _setup_install(monkeypatch, args, repoq_solution):
+def _setup_install(monkeypatch, args, repoq_solution, out=None):
     mock_repoq = MagicMock()
     mock_repoq.solve_repa.return_value = repoq_solution
 
     mock_target = MagicMock()
     mock_target.products.get_base.return_value = "dummy_base"
+    mock_target.out = out if out is not None else _ok_out()
     mock_hg = MagicMock()
     mock_hg.keys.return_value = ["user@host1"]
     mock_hg.__getitem__.return_value = mock_target
@@ -111,7 +121,7 @@ def test_install_command_dryrun_skips_run(
         {"product": [MockRepo("repo1", "http://repo1.url", refresh=True)]},
     )
 
-    Install(args).run()
+    assert Install(args).run() == 0
 
     target.run.assert_not_called()
     out = capsys.readouterr().out
@@ -131,7 +141,7 @@ def test_install_command_sl_micro_uses_transactional(
     )
 
     with caplog.at_level("INFO", logger="repose.command.install"):
-        Install(args).run()
+        assert Install(args).run() == 0
 
     # Find the install command issued
     issued = [c.args[0] for c in target.run.call_args_list]
@@ -151,7 +161,9 @@ def test_install_command_no_products_logs_error(
     )
 
     with caplog.at_level("ERROR", logger="repose.command.install"):
-        Install(args).run()
+        # Empty solution → "No products to install" error → all hosts
+        # failed → exit 2.
+        assert Install(args).run() == 2
 
     assert any("No products to install" in r.message for r in caplog.records)
 
@@ -179,6 +191,74 @@ def test_install_command_solve_repa_value_error_logged(
     monkeypatch.setattr(Install, "_init_repoq", MagicMock(return_value=mock_repoq))
 
     with caplog.at_level("ERROR", logger="repose.command.install"):
-        Install(args).run()
+        # solve_repa raises AND no products → exit 2.
+        assert Install(args).run() == 2
 
     assert any("Unknow product" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Exit code propagation (PR 06)
+# ---------------------------------------------------------------------------
+
+
+def _setup_install_multi(monkeypatch, hosts):
+    """Multi-host variant: one target per host, each with its own ``out``.
+
+    A single-product repoq solution is shared so all hosts attempt the
+    same add+install commands.
+    """
+    mock_repoq = MagicMock()
+    mock_repoq.solve_repa.return_value = {
+        "product-to-install": [MockRepo("repo1", "http://repo1.url", refresh=False)]
+    }
+
+    targets = {}
+    for host, out in hosts.items():
+        t = MagicMock()
+        t.products.get_base.return_value = "dummy_base"
+        t.out = out
+        targets[host] = t
+
+    hg = MagicMock()
+    hg.keys.return_value = list(hosts.keys())
+    hg.__getitem__.side_effect = lambda k: targets[k]
+
+    monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr(
+        repose.command._command,
+        "HostGroup",
+        MagicMock(return_value=hg),
+    )
+    monkeypatch.setattr(Install, "_init_repoq", MagicMock(return_value=mock_repoq))
+    return targets, hg
+
+
+def test_install_run_returns_0_when_all_succeed(
+    monkeypatch, mock_args_and_repa, mock_ssh_client
+):
+    args, _ = mock_args_and_repa
+    args.target = [{"h1": MagicMock(), "h2": MagicMock()}]
+    _setup_install_multi(monkeypatch, {"h1": _ok_out(), "h2": _ok_out()})
+
+    assert Install(args).run() == 0
+
+
+def test_install_run_returns_1_on_partial_failure(
+    monkeypatch, mock_args_and_repa, mock_ssh_client
+):
+    args, _ = mock_args_and_repa
+    args.target = [{"h1": MagicMock(), "h2": MagicMock()}]
+    _setup_install_multi(monkeypatch, {"h1": _ok_out(), "h2": _fail_out()})
+
+    assert Install(args).run() == 1
+
+
+def test_install_run_returns_2_when_all_fail(
+    monkeypatch, mock_args_and_repa, mock_ssh_client
+):
+    args, _ = mock_args_and_repa
+    args.target = [{"h1": MagicMock(), "h2": MagicMock()}]
+    _setup_install_multi(monkeypatch, {"h1": _fail_out(), "h2": _fail_out()})
+
+    assert Install(args).run() == 2

--- a/tests/command/test_remove.py
+++ b/tests/command/test_remove.py
@@ -30,6 +30,14 @@ def mock_args_and_repa():
     return args, repa_instance
 
 
+def _ok_out():
+    return [["cmd", "", "", 0, 0]]
+
+
+def _fail_out():
+    return [["cmd", "", "boom", 1, 0]]
+
+
 def test_remove_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
     mock_args, _ = mock_args_and_repa
 
@@ -41,6 +49,7 @@ def test_remove_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
         "SLES:15-SP4::repo2",
         "other:repo",
     ]
+    mock_target.out = _ok_out()
 
     mock_host_group_instance = MagicMock()
     mock_host_group_instance.keys.return_value = ["user@host1"]
@@ -55,7 +64,7 @@ def test_remove_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
 
     # Instantiate and Run
     remove_command = Remove(mock_args)
-    remove_command.run()
+    assert remove_command.run() == 0
 
     # Assertions
     mock_host_group_instance.read_repos.assert_called_once()
@@ -67,13 +76,16 @@ def test_remove_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
     mock_host_group_instance.close.assert_called_once()
 
 
-def _build_remove_env(monkeypatch, args, products, repos):
+def _build_remove_env(monkeypatch, args, products, repos, out=None, hosts=None):
+    if hosts is None:
+        hosts = ["user@host1"]
     mock_target = MagicMock()
     mock_target.products.flatten.return_value = products
     mock_target.repos.keys.return_value = repos
+    mock_target.out = out if out is not None else _ok_out()
 
     mock_hg = MagicMock()
-    mock_hg.keys.return_value = ["user@host1"]
+    mock_hg.keys.return_value = hosts
     mock_hg.__getitem__.return_value = mock_target
 
     monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", ImmediateExecutor)
@@ -100,7 +112,7 @@ def test_remove_command_dryrun_does_not_run(monkeypatch, capsys, mock_ssh_client
         ["SLES:15-SP4::repo1"],
     )
 
-    Remove(args).run()
+    assert Remove(args).run() == 0
     target.run.assert_not_called()
     out = capsys.readouterr().out
     assert "user@host1" in out
@@ -123,7 +135,9 @@ def test_remove_command_no_matching_pattern_logs(monkeypatch, caplog, mock_ssh_c
     )
 
     with caplog.at_level("INFO", logger="repose.command.remove"):
-        Remove(args).run()
+        # No matching pattern is logged at INFO ("no work to do"),
+        # which is a benign success, not a failure → exit 0.
+        assert Remove(args).run() == 0
 
     target.run.assert_not_called()
     assert any("no repos for remove" in r.message for r in caplog.records)
@@ -151,7 +165,7 @@ def test_remove_command_empty_repolist_does_not_run_rrcmd(
     )
 
     with caplog.at_level("INFO", logger="repose.command.remove"):
-        Remove(args).run()
+        assert Remove(args).run() == 0
 
     target.run.assert_not_called()
     assert any("no repos for remove" in r.message for r in caplog.records)
@@ -174,6 +188,74 @@ def test_remove_command_version_mismatch_skipped(monkeypatch, caplog, mock_ssh_c
     )
 
     with caplog.at_level("INFO", logger="repose.command.remove"):
-        Remove(args).run()
+        assert Remove(args).run() == 0
 
     target.run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Exit code propagation (PR 06)
+# ---------------------------------------------------------------------------
+
+
+def _build_remove_multi(monkeypatch, hosts):
+    """Multi-host helper: each host gets its own target with matching
+    products+repos so ``zypper -n rr`` actually fires."""
+    targets = {}
+    for host, out in hosts.items():
+        t = MagicMock()
+        t.products.flatten.return_value = [MockProduct("SLES", "15-SP4")]
+        t.repos.keys.return_value = ["SLES:15-SP4::repo1"]
+        t.out = out
+        targets[host] = t
+
+    hg = MagicMock()
+    hg.keys.return_value = list(hosts.keys())
+    hg.__getitem__.side_effect = lambda k: targets[k]
+
+    monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr(
+        repose.command._command,
+        "HostGroup",
+        MagicMock(return_value=hg),
+    )
+    return targets, hg
+
+
+def test_remove_run_returns_0_when_all_succeed(monkeypatch, mock_ssh_client):
+    args = Namespace(
+        dry=False,
+        target=[{"h1": MagicMock(), "h2": MagicMock()}],
+        repa=[Repa("SLES:::repo1")],
+        config="dummy",
+        yaml=False,
+    )
+    _build_remove_multi(monkeypatch, {"h1": _ok_out(), "h2": _ok_out()})
+
+    assert Remove(args).run() == 0
+
+
+def test_remove_run_returns_1_on_partial_failure(monkeypatch, mock_ssh_client):
+    args = Namespace(
+        dry=False,
+        target=[{"h1": MagicMock(), "h2": MagicMock()}],
+        repa=[Repa("SLES:::repo1")],
+        config="dummy",
+        yaml=False,
+    )
+    _build_remove_multi(monkeypatch, {"h1": _ok_out(), "h2": _fail_out()})
+
+    assert Remove(args).run() == 1
+
+
+def test_remove_run_returns_2_when_all_fail(monkeypatch, mock_ssh_client):
+    args = Namespace(
+        dry=False,
+        target=[{"h1": MagicMock(), "h2": MagicMock()}],
+        repa=[Repa("SLES:::repo1")],
+        config="dummy",
+        yaml=False,
+    )
+    _build_remove_multi(monkeypatch, {"h1": _fail_out(), "h2": _fail_out()})
+
+    assert Remove(args).run() == 2

--- a/tests/command/test_reset.py
+++ b/tests/command/test_reset.py
@@ -28,6 +28,14 @@ class MockProduct:
         self.version = version
 
 
+def _ok_out():
+    return [["cmd", "", "", 0, 0]]
+
+
+def _fail_out():
+    return [["cmd", "", "boom", 1, 0]]
+
+
 @pytest.fixture
 def mock_args():
     """Fixture for command arguments."""
@@ -55,6 +63,7 @@ def test_reset_command_run(monkeypatch, mock_args, mock_ssh_client):
         MockRawRepo("existing-repo1"),
         MockRawRepo("existing-repo2"),
     ]
+    mock_target.out = _ok_out()
 
     mock_host_group_instance = MagicMock()
     mock_host_group_instance.keys.return_value = ["user@host1"]
@@ -71,7 +80,7 @@ def test_reset_command_run(monkeypatch, mock_args, mock_ssh_client):
 
     # Instantiate and Run
     reset_command = Reset(mock_args)
-    reset_command.run()
+    assert reset_command.run() == 0
 
     # Assertions
     mock_host_group_instance.read_products.assert_called_once()
@@ -103,6 +112,7 @@ def _setup_reset(
     products=None,
     check_url=True,
     solve_side_effect=None,
+    out=None,
 ):
     mock_repoq = MagicMock()
     if solve_side_effect is not None:
@@ -113,6 +123,7 @@ def _setup_reset(
     mock_target = MagicMock()
     mock_target.products = products or [MockProduct("SLES", "15-SP4")]
     mock_target.raw_repos = raw_repos or [MockRawRepo("existing-repo1")]
+    mock_target.out = out if out is not None else _ok_out()
 
     mock_hg = MagicMock()
     mock_hg.keys.return_value = ["user@host1"]
@@ -137,7 +148,7 @@ def test_reset_dryrun_does_not_run(monkeypatch, mock_args, capsys, mock_ssh_clie
         repoq_solution={"product": [MockRepo("repo1", "http://r1", refresh=True)]},
     )
 
-    Reset(mock_args).run()
+    assert Reset(mock_args).run() == 0
 
     target.run.assert_not_called()
     out = capsys.readouterr().out
@@ -156,7 +167,8 @@ def test_reset_unsupported_product_logs_error(
     )
 
     with caplog.at_level("ERROR", logger="repose.command.reset"):
-        Reset(mock_args).run()
+        # UnsuportedProductMessage on the only host → exit 2.
+        assert Reset(mock_args).run() == 2
 
     assert any("Refhost" in r.message for r in caplog.records)
     # _add() raised before reaching the run() block — no commands executed.
@@ -171,9 +183,83 @@ def test_reset_check_url_false_skips_add(monkeypatch, mock_args, mock_ssh_client
         check_url=False,
     )
 
-    Reset(mock_args).run()
+    # rr fires (and succeeds via _ok_out), no ar attempted → exit 0.
+    assert Reset(mock_args).run() == 0
 
     issued = [c.args[0] for c in target.run.call_args_list]
     # rr executed but no ar (filtered out by check_url=False)
     assert any(c.startswith("zypper -n rr") for c in issued)
     assert not any(c.startswith("zypper -n ar") for c in issued)
+
+
+# ---------------------------------------------------------------------------
+# Exit code propagation (PR 06)
+# ---------------------------------------------------------------------------
+
+
+def _setup_reset_multi(monkeypatch, hosts):
+    mock_repoq = MagicMock()
+    mock_repoq.solve_product.return_value = {
+        "product": [MockRepo("repo1", "http://repo1.url", refresh=False)]
+    }
+
+    targets = {}
+    for host, out in hosts.items():
+        t = MagicMock()
+        t.products = [MockProduct("SLES", "15-SP4")]
+        t.raw_repos = [MockRawRepo(f"{host}-existing")]
+        t.out = out
+        targets[host] = t
+
+    hg = MagicMock()
+    hg.keys.return_value = list(hosts.keys())
+    hg.__getitem__.side_effect = lambda k: targets[k]
+
+    monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr(
+        repose.command._command,
+        "HostGroup",
+        MagicMock(return_value=hg),
+    )
+    monkeypatch.setattr(Reset, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Reset, "check_url", MagicMock(return_value=True))
+    return targets, hg
+
+
+def test_reset_run_returns_0_when_all_succeed(monkeypatch, mock_ssh_client):
+    args = Namespace(
+        dry=False,
+        target=[{"h1": MagicMock(), "h2": MagicMock()}],
+        config="dummy_config",
+        repa=None,
+        yaml=False,
+    )
+    _setup_reset_multi(monkeypatch, {"h1": _ok_out(), "h2": _ok_out()})
+
+    assert Reset(args).run() == 0
+
+
+def test_reset_run_returns_1_on_partial_failure(monkeypatch, mock_ssh_client):
+    args = Namespace(
+        dry=False,
+        target=[{"h1": MagicMock(), "h2": MagicMock()}],
+        config="dummy_config",
+        repa=None,
+        yaml=False,
+    )
+    _setup_reset_multi(monkeypatch, {"h1": _ok_out(), "h2": _fail_out()})
+
+    assert Reset(args).run() == 1
+
+
+def test_reset_run_returns_2_when_all_fail(monkeypatch, mock_ssh_client):
+    args = Namespace(
+        dry=False,
+        target=[{"h1": MagicMock(), "h2": MagicMock()}],
+        config="dummy_config",
+        repa=None,
+        yaml=False,
+    )
+    _setup_reset_multi(monkeypatch, {"h1": _fail_out(), "h2": _fail_out()})
+
+    assert Reset(args).run() == 2

--- a/tests/command/test_uninstall.py
+++ b/tests/command/test_uninstall.py
@@ -21,6 +21,14 @@ class MockProduct:
         self.version = version
 
 
+def _ok_out():
+    return [["cmd", "", "", 0, 0]]
+
+
+def _fail_out():
+    return [["cmd", "", "boom", 1, 0]]
+
+
 @pytest.fixture
 def mock_args_and_repa():
     repa_instance = Repa("SLES:15-SP4")
@@ -45,6 +53,7 @@ def test_uninstall_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client)
         "SLES:15-SP4::repo2": MockRepo(name="SLES"),
         "other:repo": MockRepo(name="other"),
     }
+    mock_target.out = _ok_out()
 
     mock_host_group_instance = MagicMock()
     mock_host_group_instance.keys.return_value = ["user@host1"]
@@ -59,7 +68,7 @@ def test_uninstall_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client)
 
     # Run
     uninstall_command = Uninstall(mock_args)
-    uninstall_command.run()
+    assert uninstall_command.run() == 0
 
     # Assertions
     mock_host_group_instance.read_repos.assert_called_once()
@@ -84,12 +93,15 @@ def test_uninstall_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client)
     mock_host_group_instance.close.assert_called_once()
 
 
-def _setup_uninstall(monkeypatch, args, products, repos):
+def _setup_uninstall(monkeypatch, args, products, repos, out=None, hosts=None):
+    if hosts is None:
+        hosts = ["user@host1"]
     mock_target = MagicMock()
     mock_target.products.flatten.return_value = products
     mock_target.repos = repos
+    mock_target.out = out if out is not None else _ok_out()
     mock_hg = MagicMock()
-    mock_hg.keys.return_value = ["user@host1"]
+    mock_hg.keys.return_value = hosts
     mock_hg.__getitem__.return_value = mock_target
     monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", ImmediateExecutor)
     monkeypatch.setattr(
@@ -115,7 +127,7 @@ def test_uninstall_dryrun_does_not_run(monkeypatch, capsys, mock_ssh_client):
         {"SLES:15-SP4::repo1": MockRepo("SLES")},
     )
 
-    Uninstall(args).run()
+    assert Uninstall(args).run() == 0
 
     target.run.assert_not_called()
     out = capsys.readouterr().out
@@ -138,7 +150,8 @@ def test_uninstall_no_patterns_logs(monkeypatch, caplog, mock_ssh_client):
     )
 
     with caplog.at_level("INFO", logger="repose.command.uninstall"):
-        Uninstall(args).run()
+        # No matching pattern → INFO no-op → exit 0.
+        assert Uninstall(args).run() == 0
 
     target.run.assert_not_called()
     assert any("no products for remove" in r.message for r in caplog.records)
@@ -160,7 +173,7 @@ def test_uninstall_no_matching_repos_runs_only_pdcmd(monkeypatch, mock_ssh_clien
         {},  # no repositories at all
     )
 
-    Uninstall(args).run()
+    assert Uninstall(args).run() == 0
 
     # Only one command issued: rrpcmd (no rrcmd because no rdict)
     assert target.run.call_count == 1
@@ -188,7 +201,7 @@ def test_uninstall_sl_micro_uses_transactional(monkeypatch, caplog, mock_ssh_cli
     )
 
     with caplog.at_level("INFO", logger="repose.command.uninstall"):
-        Uninstall(args).run()
+        assert Uninstall(args).run() == 0
 
     issued = [c.args[0] for c in target.run.call_args_list]
     # Both rr (for the matched repo) and the transactional rm should fire.
@@ -199,3 +212,69 @@ def test_uninstall_sl_micro_uses_transactional(monkeypatch, caplog, mock_ssh_cli
     )
     # And the reboot reminder must be emitted.
     assert any("Reboot" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Exit code propagation (PR 06)
+# ---------------------------------------------------------------------------
+
+
+def _setup_uninstall_multi(monkeypatch, hosts):
+    targets = {}
+    for host, out in hosts.items():
+        t = MagicMock()
+        t.products.flatten.return_value = [MockProduct("SLES", "15-SP4")]
+        t.repos = {"SLES:15-SP4::repo1": MockRepo("SLES")}
+        t.out = out
+        targets[host] = t
+
+    hg = MagicMock()
+    hg.keys.return_value = list(hosts.keys())
+    hg.__getitem__.side_effect = lambda k: targets[k]
+
+    monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr(
+        repose.command._command,
+        "HostGroup",
+        MagicMock(return_value=hg),
+    )
+    return targets, hg
+
+
+def test_uninstall_run_returns_0_when_all_succeed(monkeypatch, mock_ssh_client):
+    args = Namespace(
+        dry=False,
+        target=[{"h1": MagicMock(), "h2": MagicMock()}],
+        repa=[Repa("SLES:15-SP4")],
+        config="dummy",
+        yaml=False,
+    )
+    _setup_uninstall_multi(monkeypatch, {"h1": _ok_out(), "h2": _ok_out()})
+
+    assert Uninstall(args).run() == 0
+
+
+def test_uninstall_run_returns_1_on_partial_failure(monkeypatch, mock_ssh_client):
+    args = Namespace(
+        dry=False,
+        target=[{"h1": MagicMock(), "h2": MagicMock()}],
+        repa=[Repa("SLES:15-SP4")],
+        config="dummy",
+        yaml=False,
+    )
+    _setup_uninstall_multi(monkeypatch, {"h1": _ok_out(), "h2": _fail_out()})
+
+    assert Uninstall(args).run() == 1
+
+
+def test_uninstall_run_returns_2_when_all_fail(monkeypatch, mock_ssh_client):
+    args = Namespace(
+        dry=False,
+        target=[{"h1": MagicMock(), "h2": MagicMock()}],
+        repa=[Repa("SLES:15-SP4")],
+        config="dummy",
+        yaml=False,
+    )
+    _setup_uninstall_multi(monkeypatch, {"h1": _fail_out(), "h2": _fail_out()})
+
+    assert Uninstall(args).run() == 2


### PR DESCRIPTION
## Summary

Mutating commands (`add`, `remove`, `reset`, `install`, `clear`, `uninstall`) always returned `0` regardless of what happened on the targets. SSH drops, repo-add conflicts, unknown product names, and `UnsuportedProductMessage` were all logged and then silently swallowed at the shell level. Refhost CI pipelines that wrap `repose` and rely on `\$?` to gate downstream work could not distinguish a successful install from a totally-broken one.

This PR makes `Command.run()` return a meaningful exit code derived from per-target task results.

## Exit code semantics

| Code | Meaning |
| ---- | ------- |
| `0`  | All targets succeeded. |
| `1`  | Partial failure — at least one target succeeded **and** at least one failed. |
| `2`  | Hard failure — every target failed (including the degenerate single-target all-failed case). |

`zypper` exit code 4 (\"no repositories defined\") is kept as a benign success for parity with prior behaviour.

## Implementation

- `ExitCode` widened from `Literal[0, 1]` to `Literal[0, 1, 2]` with documented semantics in `repose/types/__init__.py`.
- `Command._report_target` now returns `bool` instead of `None` — `True` for zypper exit 0/4, `False` otherwise.
- New `Command._aggregate(futures: list[Future[bool]]) -> ExitCode` collapses per-host results: a future counts as failed when it raised (`f.exception() is not None`) **or** when its result is explicitly `False`. Any non-`False` truthy result counts as success (forward-compatible).
- Each `_run` returns `bool` (any failed `_report_target` or caught/logged error flips the host to failed); each `run()` returns `self._aggregate(futures)`.
- `_run_parallel` typing tightened to `Callable[..., bool]` / `list[Future[bool]]`.

## Tests

- 18 new tests; full suite goes from 236 → 254 passing.
- New `_aggregate` tests cover all transitions: empty, all-success, all-fail (via exception **and** via `False` result), single-host all-failed (degenerate exit 2), partial failure, mixed exception+success, `None`-result forward-compat.
- New per-command tests cover the 0/1/2 matrix for every mutating command.
- Pre-existing happy-path tests now assert `== 0`. Pre-existing logged-error tests now assert the correct non-zero code:
  - `test_install_command_no_products_logs_error` → exit 2.
  - `test_install_command_solve_repa_value_error_logged` → exit 2.
  - `test_reset_unsupported_product_logs_error` → exit 2.
  - `test_add_command_solve_repa_value_error_logged` → exit 2.

## Behaviour change — please read

**This is a visible behaviour change for any downstream that wraps `repose` and ignores `\$?` today.** Pipelines that previously treated `repose` as infallible will now see non-zero exits on genuinely broken runs (SSH drop, unknown product, broken repo). That is the intent, but it warrants a CHANGELOG note in the next release.

Read-only commands (`list`, `known`, `list-products`) are out of scope and still return `0` unconditionally; a follow-up can extend the same aggregation to them.

## Verification

```
\$ uv run python3 -m pytest tests/
254 passed

\$ uv run ruff format --diff .
63 files already formatted

\$ uv run ruff check .
All checks passed!

\$ uv run ty check repose
All checks passed!
```

Coverage on every modified module is 98–100%.

Manual smoke (post-merge):
- \`repose install -t bogus-host nonexistent-product; echo \$?\` → \`2\`
- \`repose add -t goodhost -t badhost sle-sdk; echo \$?\` → \`1\` (partial)
- \`repose list-products -t goodhost; echo \$?\` → \`0\`