### PR TITLE
feat(console): unify stdout via Console sink with --no-color and --format=json

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,40 @@ Show products in yaml format needed for refhost.yaml genetor:
 repose list-products --yaml -t foobar.suse.cz
 ```
 
+## Output Control
+
+Repose routes all user-facing output (dry-run command previews and per-host
+run output) through a single sink. Two global flags govern its shape:
+
+- `--no-color`: disable ANSI color sequences. The
+  [`NO_COLOR`](https://no-color.org) environment variable is also honored.
+  By default, color is enabled only when stdout is a terminal. The legacy
+  `COLOR=always|never` environment variable still overrides detection.
+- `--format={text,json}`: select human-readable text (default) or
+  newline-delimited JSON for scripts.
+
+In JSON mode, each output line is a single JSON object with these fields:
+
+| field   | type   | description                                              |
+| ------- | ------ | -------------------------------------------------------- |
+| `event` | string | `"dry"` \| `"report"` \| `"error"` \| `"info"`           |
+| `level` | string | `"info"` \| `"warning"` \| `"error"`                     |
+| `host`  | string | target host (omitted for unscoped `info` events)         |
+| `cmd`   | string | the dry-run command (only for `event="dry"`)             |
+| `line`  | string | a single output line (for `report`/`error`/`info`)       |
+| `ok`    | bool   | per-host success flag (for `report`/`error`)             |
+
+Example:
+
+```
+repose add -n --format=json -t fubar.suse.cz sle-sdk | jq .
+```
+
+Note: per-host run output (previously emitted via the logger at info/warning
+level) now goes through this sink on stdout. The `--quiet` flag still
+silences logger messages but no longer hides per-host output; redirect
+stdout or use `--format=json` with filtering to suppress it.
+
 ## License
 
 This project is licensed under the GPLv3 license, see LICENSE file for

--- a/README.md
+++ b/README.md
@@ -106,7 +106,12 @@ run output) through a single sink. Two global flags govern its shape:
 - `--format={text,json}`: select human-readable text (default) or
   newline-delimited JSON for scripts.
 
-In JSON mode, each output line is a single JSON object with these fields:
+In JSON mode, every command emits newline-delimited JSON (one object per
+line). Action commands (`add`, `install`, `remove`, `uninstall`, `clear`,
+`reset`) emit event envelopes; query commands (`list-products`,
+`list-repos`, `known-products`) emit payload events.
+
+### Event envelopes (action commands)
 
 | field   | type   | description                                              |
 | ------- | ------ | -------------------------------------------------------- |
@@ -117,10 +122,28 @@ In JSON mode, each output line is a single JSON object with these fields:
 | `line`  | string | a single output line (for `report`/`error`/`info`)       |
 | `ok`    | bool   | per-host success flag (for `report`/`error`)             |
 
-Example:
+### Payload events (query commands)
+
+`list-products --format=json` emits one `product` event per product per host
+(`{event:"product", host, port, kind:"base"|"addon", name, version, arch}`).
+
+`list-repos --format=json` emits one `repo` event per repository per host
+(`{event:"repo", host, port, alias, name, url, state}`).
+
+`known-products --format=json` emits one `known_product` event per known
+product (`{event:"known_product", name}`).
+
+`list-products --yaml --format=json` emits one `host_spec` event per host
+carrying the same payload the YAML dumper produces (location, arch,
+product, addons, name) — useful for machine consumers that want the
+refhost.yml spec without the YAML envelope.
+
+### Examples
 
 ```
 repose add -n --format=json -t fubar.suse.cz sle-sdk | jq .
+repose list-products --format=json -t fubar.suse.cz | jq 'select(.kind=="base")'
+repose known-products --format=json | jq -r '.name'
 ```
 
 Note: per-host run output (previously emitted via the logger at info/warning

--- a/repose/argparsing.py
+++ b/repose/argparsing.py
@@ -50,6 +50,17 @@ def get_parser():
     group.add_argument(
         "-q", "--quiet", action="store_true", help="suppress messages from repose"
     )
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="disable ANSI color in console output (honors NO_COLOR)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="console output format: 'text' (default) or 'json' (one event per line)",
+    )
 
     commands = parser.add_subparsers()
 

--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -9,13 +9,13 @@ from typing import Any, Callable, ClassVar
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
+from ..console import Console
 from ..display import CommandDisplay
 from ..target.hostgroup import HostGroup
 from ..template import load_template
 from ..template.resolver import Repoq
 from ..types import ExitCode
 from ..types.repa import Repa
-from ..utils import blue
 
 logger = logging.getLogger("repose.command")
 
@@ -68,6 +68,10 @@ class Command(ABC):
         # (add, install, remove, uninstall) gate on truthiness first.
         self.repa: list[Repa] = args.repa if "repa" in args else []
         self.yaml: bool = args.yaml if "yaml" in args else False
+        self.console = Console(
+            format=getattr(args, "format", "text"),
+            color="never" if getattr(args, "no_color", False) else "auto",
+        )
 
     def _load_template(self) -> dict:
         return load_template(Path(self.template_path))
@@ -76,26 +80,26 @@ class Command(ABC):
         return Repoq(self._load_template())
 
     def _report_target(self, target: str) -> bool:
-        """Log the last command's output for ``target`` and report success.
+        """Report the last command's output for ``target`` via Console.
 
         Returns ``True`` for zypper exit 0 (success) and exit 4
-        (no repositories — benign, kept as info-warning for parity with
-        prior behaviour). Any other exit code is treated as failure and
-        the call returns ``False`` so the caller can propagate the
-        per-host status into ``_aggregate``.
+        (no repositories — benign, surfaced at ``level="warning"`` for
+        parity with prior behaviour). Any other exit code is treated as
+        failure and the call returns ``False`` so the caller can
+        propagate the per-host status into ``_aggregate``.
         """
         exitcode = self.targets[target].out[-1][3]
         if exitcode == 0:
             for line in self.targets[target].out[-1][1].splitlines():
-                logger.info(blue(f"{target}") + f" - {line}")
+                self.console.report(target, line, ok=True, level="info")
             return True
         if exitcode == 4:
             # zypper: "no repositories defined" — benign in our flow.
             for line in self.targets[target].out[-1][1].splitlines():
-                logger.warning(blue(f"{target}") + f" - {line}")
+                self.console.report(target, line, ok=True, level="warning")
             return True
         for line in self.targets[target].out[-1][2].splitlines():
-            logger.warning(blue(f"{target}") + f" - {line}")
+            self.console.report(target, line, ok=False, level="error")
         return False
 
     def _run_parallel(

--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -10,7 +10,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
 from ..console import Console
-from ..display import CommandDisplay
+from ..display import CommandDisplay, JsonCommandDisplay
 from ..target.hostgroup import HostGroup
 from ..template import load_template
 from ..template.resolver import Repoq
@@ -62,16 +62,24 @@ class Command(ABC):
 
         self.dryrun: bool = args.dry
         self.template_path: str = args.config
-        self.display = CommandDisplay(sys.stdout)
         # ``repa`` is None for commands that don't accept a REPA argument
         # (list, known, clear, reset). Commands that *do* iterate over it
         # (add, install, remove, uninstall) gate on truthiness first.
         self.repa: list[Repa] = args.repa if "repa" in args else []
         self.yaml: bool = args.yaml if "yaml" in args else False
+        output_format = "json" if getattr(args, "format", "text") == "json" else "text"
         self.console = Console(
-            format=getattr(args, "format", "text"),
+            format=output_format,
             color="never" if getattr(args, "no_color", False) else "auto",
         )
+        # Payload-emitting commands (list-products, list-repos,
+        # known-products) write through ``self.display``. The JSON
+        # variant mirrors the Console envelope so ``--format=json``
+        # produces a uniform NDJSON stream across every subcommand.
+        if output_format == "json":
+            self.display = JsonCommandDisplay(sys.stdout)
+        else:
+            self.display = CommandDisplay(sys.stdout)
 
     def _load_template(self) -> dict:
         return load_template(Path(self.template_path))

--- a/repose/command/add.py
+++ b/repose/command/add.py
@@ -3,7 +3,6 @@ import logging
 
 from . import Command
 from ..types import ExitCode
-from ..utils import blue
 
 logger = logging.getLogger("repose.command.add")
 
@@ -45,7 +44,7 @@ class Add(Command, name="add"):
         cmds, ok = self._add(target)
         for cmd in cmds:
             if self.dryrun:
-                print("{} - {}".format(blue(target), cmd))
+                self.console.dry(target, cmd)
             else:
                 self.targets[target].run(cmd)
                 if not self._report_target(target):

--- a/repose/command/clear.py
+++ b/repose/command/clear.py
@@ -2,7 +2,6 @@ import logging
 
 from . import Command
 from ..types import ExitCode
-from ..utils import blue
 
 
 logger = logging.getLogger("repose.command.clear")
@@ -16,12 +15,7 @@ class Clear(Command, name="clear"):
         repoaliases = self._clear(host)
 
         if self.dryrun:
-            print(
-                blue("host:")
-                + " {} - cmd: {}".format(
-                    host, self.rrcmd.format(repos=" ".join(repoaliases))
-                )
-            )
+            self.console.dry(host, self.rrcmd.format(repos=" ".join(repoaliases)))
             return True
 
         self.targets[host].run(self.rrcmd.format(repos=" ".join(repoaliases)))

--- a/repose/command/install.py
+++ b/repose/command/install.py
@@ -3,7 +3,6 @@ import logging
 
 from . import Command
 from ..types import ExitCode
-from ..utils import blue
 
 logger = logging.getLogger("repose.command.install")
 
@@ -26,7 +25,7 @@ class Install(Command, name="install"):
                 name=repo.name, url=repo.url, params="-cfkn" if repo.refresh else "-ckn"
             )
             if self.dryrun:
-                print(blue(f"{target}") + f" - {addcmd}")
+                self.console.dry(target, addcmd)
             else:
                 self.targets[target].run(addcmd)
                 if not self._report_target(target):
@@ -41,7 +40,7 @@ class Install(Command, name="install"):
             else:
                 inscmd = self.ipdcmd.format(products=" ".join(repositories.keys()))
             if self.dryrun:
-                print(blue(str(target)) + f" - {inscmd}")
+                self.console.dry(str(target), inscmd)
             else:
                 self.targets[target].run(inscmd)
                 if not self._report_target(target):

--- a/repose/command/remove.py
+++ b/repose/command/remove.py
@@ -4,7 +4,6 @@ from typing import Any, Iterable
 from . import Command
 from ..types import ExitCode
 from ..types.repa import Repa
-from ..utils import blue
 
 logger = logging.getLogger("repose.command.remove")
 
@@ -64,7 +63,7 @@ class Remove(Command, name="remove"):
         cmd = self.rrcmd.format(repos=" ".join(repolist))
 
         if self.dryrun:
-            print(blue(host) + f" - {cmd}")
+            self.console.dry(host, cmd)
             return True
 
         self.targets[host].run(cmd)

--- a/repose/command/reset.py
+++ b/repose/command/reset.py
@@ -3,7 +3,6 @@ import logging
 
 from ..messages import UnsuportedProductMessage
 from ..types import ExitCode
-from ..utils import blue
 from .clear import Clear
 
 logger = logging.getLogger("repose.command.reset")
@@ -32,12 +31,9 @@ class Reset(Clear, name="reset"):
             cmds = self._add(host)
 
             if self.dryrun:
-                print(
-                    blue(host)
-                    + " - {}".format(self.rrcmd.format(repos=" ".join(repoaliases)))
-                )
+                self.console.dry(host, self.rrcmd.format(repos=" ".join(repoaliases)))
                 for cmd in cmds:
-                    print(blue(host) + f" - {cmd}")
+                    self.console.dry(host, cmd)
                 return True
 
             self.targets[host].run(self.rrcmd.format(repos=" ".join(repoaliases)))

--- a/repose/command/uninstall.py
+++ b/repose/command/uninstall.py
@@ -2,7 +2,6 @@ import logging
 from itertools import chain
 from typing import Any
 
-from ..utils import blue
 from .remove import Remove
 from ..types import ExitCode
 
@@ -52,8 +51,8 @@ class Uninstall(Remove, name="uninstall"):
 
         if self.dryrun:
             if rrcmd:
-                print(blue(host) + " - {}".format(rrcmd))
-            print(blue(host) + " - {}".format(pdcmd))
+                self.console.dry(host, rrcmd)
+            self.console.dry(host, pdcmd)
             return True
 
         ok = True

--- a/repose/console.py
+++ b/repose/console.py
@@ -1,0 +1,107 @@
+"""Single sink for user-facing output.
+
+All user-visible lines (dry-run command previews and per-host run
+output) flow through :class:`Console`. Logger noise (debug/warning)
+stays on the ``logging`` module.
+
+Two orthogonal toggles:
+
+- ``format``: ``"text"`` (default) for humans, ``"json"`` for scripts.
+- ``color``: ``"auto"`` (TTY + ``NO_COLOR`` respected), ``"always"``,
+  or ``"never"``.
+"""
+
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Literal, TextIO
+
+Format = Literal["text", "json"]
+ColorMode = Literal["auto", "always", "never"]
+Level = Literal["info", "warning", "error"]
+
+# ANSI sequences mirror ``repose.utils`` so output stays visually
+# identical to legacy print/logger calls. We inline them here rather
+# than delegate to utils so the Console's ``color`` toggle is the
+# single source of truth (utils still keys off env+TTY for callers
+# outside the Console, e.g. ``display.py``).
+_ANSI_RESET = "\033[1;m"
+_ANSI_BY_LEVEL: dict[str, str] = {
+    "info": "\033[1;34m",  # blue
+    "warning": "\033[1;33m",  # yellow
+    "error": "\033[1;31m",  # red
+}
+
+
+@dataclass
+class Console:
+    """User-facing output sink with format and color toggles."""
+
+    stream: TextIO = field(default_factory=lambda: sys.stdout)
+    format: Format = "text"
+    color: ColorMode = "auto"
+
+    def _use_color(self) -> bool:
+        if self.color == "always":
+            return True
+        if self.color == "never":
+            return False
+        if os.environ.get("NO_COLOR"):
+            return False
+        isatty = getattr(self.stream, "isatty", None)
+        return bool(isatty and isatty())
+
+    def _colorize_host(self, host: str, level: Level) -> str:
+        if not self._use_color():
+            return host
+        seq = _ANSI_BY_LEVEL.get(level, _ANSI_BY_LEVEL["info"])
+        return f"{seq}{host}{_ANSI_RESET}"
+
+    def dry(self, host: str, cmd: str) -> None:
+        """Emit a dry-run command preview."""
+        self._emit("dry", level="info", host=host, cmd=cmd)
+
+    def report(
+        self,
+        host: str,
+        line: str,
+        *,
+        ok: bool,
+        level: Level = "info",
+    ) -> None:
+        """Emit one line of per-host run output."""
+        self._emit("report", level=level, host=host, line=line, ok=ok)
+
+    def error(self, host: str, msg: str) -> None:
+        """Emit a host-scoped error line."""
+        self._emit("error", level="error", host=host, line=msg, ok=False)
+
+    def info(self, msg: str) -> None:
+        """Emit an unscoped informational line."""
+        self._emit("info", level="info", line=msg)
+
+    def _emit(self, event: str, *, level: Level, **fields: Any) -> None:
+        if self.format == "json":
+            payload: dict[str, Any] = {"event": event, "level": level}
+            payload.update(fields)
+            self.stream.write(json.dumps(payload) + "\n")
+            self.stream.flush()
+            return
+
+        host = fields.get("host")
+        cmd = fields.get("cmd")
+        line = fields.get("line")
+
+        if event == "dry" and host is not None and cmd is not None:
+            prefix = self._colorize_host(str(host), "info")
+            self.stream.write(f"{prefix} - {cmd}\n")
+        elif event == "report" and host is not None and line is not None:
+            prefix = self._colorize_host(str(host), level)
+            self.stream.write(f"{prefix} - {line}\n")
+        elif event == "error" and host is not None and line is not None:
+            prefix = self._colorize_host(str(host), "error")
+            self.stream.write(f"{prefix} - {line}\n")
+        elif event == "info" and line is not None:
+            self.stream.write(f"{line}\n")
+        self.stream.flush()

--- a/repose/display.py
+++ b/repose/display.py
@@ -1,7 +1,11 @@
+import json
+
 from .utils import blue, green, yellow
 
 
 class CommandDisplay:
+    """Human-readable, color-aware text output for list/known commands."""
+
     def __init__(self, output):
         self.output = output
 
@@ -41,3 +45,83 @@ class CommandDisplay:
         data = system.to_refhost_dict_partially_normalized()
         data["name"] = str(hostname)
         self.__open_yaml().dump(data, self.output)
+
+
+class JsonCommandDisplay:
+    """Newline-delimited JSON output for list/known commands.
+
+    One JSON object per output line. Schema matches the per-event
+    envelope used by ``repose.console.Console`` so ``--format=json``
+    yields a consistent stream across every subcommand.
+
+    Event shapes:
+
+    - ``{"event": "product", "host", "port", "kind": "base"|"addon",
+       "name", "version", "arch"}`` — one per product per host.
+    - ``{"event": "repo", "host", "port", "alias", "name", "url",
+       "state"}`` — one per repository per host.
+    - ``{"event": "known_product", "name"}`` — one per known product.
+    - ``{"event": "host_spec", "host", ...}`` — one per host when
+      ``--yaml`` is combined with ``--format=json``; carries the same
+      payload the YAML dumper would emit.
+    """
+
+    def __init__(self, output):
+        self.output = output
+
+    def _emit(self, payload: dict) -> None:
+        self.output.write(json.dumps(payload) + "\n")
+
+    def list_products(self, hostname, port, system) -> None:
+        host = str(hostname)
+        base = system.get_base()
+        self._emit(
+            {
+                "event": "product",
+                "host": host,
+                "port": port,
+                "kind": "base",
+                "name": base.name,
+                "version": base.version,
+                "arch": base.arch,
+            }
+        )
+        for addon in system.get_addons():
+            self._emit(
+                {
+                    "event": "product",
+                    "host": host,
+                    "port": port,
+                    "kind": "addon",
+                    "name": addon.name,
+                    "version": addon.version,
+                    "arch": addon.arch,
+                }
+            )
+
+    def list_update_repos(self, hostname, port, repos) -> None:
+        host = str(hostname)
+        for repository in repos:
+            self._emit(
+                {
+                    "event": "repo",
+                    "host": host,
+                    "port": port,
+                    "alias": repository.alias,
+                    "name": repository.name,
+                    "url": repository.url,
+                    "state": repository.state,
+                }
+            )
+
+    def list_known_products(self, products) -> None:
+        for name in products:
+            self._emit({"event": "known_product", "name": name})
+
+    def list_products_yaml(self, hostname, system) -> None:
+        # When --yaml and --format=json are combined, ship the same
+        # dict the YAML dumper would emit, JSON-serialised, one
+        # document per host.
+        data = system.to_refhost_dict_partially_normalized()
+        data["name"] = str(hostname)
+        self._emit({"event": "host_spec", "host": str(hostname), **data})

--- a/repose/target/hostgroup.py
+++ b/repose/target/hostgroup.py
@@ -1,5 +1,8 @@
 from collections import UserDict
 import concurrent.futures
+import logging
+
+logger = logging.getLogger("repose.target.hostgroup")
 
 
 class HostGroup(UserDict):
@@ -24,7 +27,7 @@ class HostGroup(UserDict):
                 try:
                     self.data[hostname] = future.result()
                 except Exception as exc:
-                    print(exc)
+                    logger.warning("failed to connect %s: %s", hostname, exc)
 
     def close(self) -> None:
         with concurrent.futures.ThreadPoolExecutor() as executor:

--- a/repose/utils.py
+++ b/repose/utils.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 
 
@@ -7,19 +8,42 @@ def timestamp() -> str:
     return str(int(time.time()))
 
 
-if os.getenv("COLOR", "always") == "always":
+def _color_enabled() -> bool:
+    """Decide whether ANSI color sequences should be emitted.
 
-    def green(xs) -> str:
-        return "\033[1;32m{!s}\033[1;m".format(xs)
+    Precedence (highest first):
 
-    def red(xs) -> str:
-        return "\033[1;31m{!s}\033[1;m".format(xs)
+    1. ``COLOR=always`` -> on.
+    2. ``COLOR=never`` -> off.
+    3. ``NO_COLOR`` set (any value) -> off (https://no-color.org).
+    4. ``sys.stdout.isatty()`` -> on for TTYs, off otherwise.
+    """
+    v = os.environ.get("COLOR")
+    if v == "always":
+        return True
+    if v == "never":
+        return False
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    isatty = getattr(sys.stdout, "isatty", None)
+    return bool(isatty and isatty())
 
-    def yellow(xs) -> str:
-        return "\033[1;33m{!s}\033[1;m".format(xs)
 
-    def blue(xs) -> str:
-        return "\033[1;34m{!s}\033[1;m".format(xs)
+def green(xs) -> str:
+    s = str(xs)
+    return "\033[1;32m{}\033[1;m".format(s) if _color_enabled() else s
 
-else:
-    green = red = yellow = blue = lambda xs: str(xs)
+
+def red(xs) -> str:
+    s = str(xs)
+    return "\033[1;31m{}\033[1;m".format(s) if _color_enabled() else s
+
+
+def yellow(xs) -> str:
+    s = str(xs)
+    return "\033[1;33m{}\033[1;m".format(s) if _color_enabled() else s
+
+
+def blue(xs) -> str:
+    s = str(xs)
+    return "\033[1;34m{}\033[1;m".format(s) if _color_enabled() else s

--- a/tests/command/test_clear.py
+++ b/tests/command/test_clear.py
@@ -86,6 +86,43 @@ def test_clear_command_dryrun_skips_run(monkeypatch, capsys, mock_ssh_client):
     assert "repo1" in out
 
 
+def test_clear_command_dryrun_json_format(monkeypatch, capsys, mock_ssh_client):
+    """End-to-end: --format=json emits a parseable JSON event per dry-run line."""
+    import json
+
+    args = Namespace(
+        dry=True,
+        target=[{"user@host1": MagicMock()}],
+        repa=None,
+        config="dummy_config",
+        yaml=False,
+        format="json",
+        no_color=False,
+    )
+    mock_target = MagicMock()
+    mock_target.raw_repos = [MockRawRepo("repo1")]
+
+    mock_hg = MagicMock()
+    mock_hg.keys.return_value = ["user@host1"]
+    mock_hg.__getitem__.return_value = mock_target
+
+    monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr(
+        repose.command._command,
+        "HostGroup",
+        MagicMock(return_value=mock_hg),
+    )
+
+    assert Clear(args).run() == 0
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+    assert lines, "expected at least one JSON event line"
+    payload = json.loads(lines[0])
+    assert payload["event"] == "dry"
+    assert payload["host"] == "user@host1"
+    assert "repo1" in payload["cmd"]
+
+
 def test_clear_command_empty_repos(monkeypatch, mock_ssh_client):
     args = Namespace(
         dry=False,

--- a/tests/command/test_known.py
+++ b/tests/command/test_known.py
@@ -36,3 +36,23 @@ def test_known_products_command(monkeypatch, mock_args):
     known_command.display.list_known_products.assert_called_once_with(
         ["product-a", "product-b", "product-c"]
     )
+
+
+def test_known_products_format_json_end_to_end(monkeypatch, mock_args, capsys):
+    """--format=json emits one known_product event per template key."""
+    import json
+
+    mock_args.format = "json"
+    monkeypatch.setattr(
+        KnownProducts,
+        "_load_template",
+        MagicMock(return_value={"product-c": {}, "product-a": {}, "product-b": {}}),
+    )
+    monkeypatch.setattr(repose.command._command, "HostGroup", MagicMock())
+
+    assert KnownProducts(mock_args).run() == 0
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+    events = [json.loads(line) for line in lines]
+    assert [e["event"] for e in events] == ["known_product"] * 3
+    assert [e["name"] for e in events] == ["product-a", "product-b", "product-c"]

--- a/tests/command/test_list.py
+++ b/tests/command/test_list.py
@@ -83,3 +83,47 @@ def test_list_products_command_yaml(monkeypatch, mock_args, mock_ssh_client):
         list_products_command.display.list_products_yaml
     )
     mock_host_group_instance.close.assert_called_once()
+
+
+def test_list_products_format_json_selects_json_display(
+    monkeypatch, mock_args, mock_ssh_client
+):
+    """--format=json swaps in JsonCommandDisplay."""
+    from repose.display import JsonCommandDisplay
+
+    mock_args.format = "json"
+    monkeypatch.setattr(
+        repose.command._command, "HostGroup", MagicMock(return_value=MagicMock())
+    )
+
+    cmd = ListProducts(mock_args)
+    assert isinstance(cmd.display, JsonCommandDisplay)
+
+
+def test_list_products_format_text_keeps_text_display(
+    monkeypatch, mock_args, mock_ssh_client
+):
+    """Default (text) keeps CommandDisplay."""
+    from repose.display import CommandDisplay
+
+    mock_args.format = "text"
+    monkeypatch.setattr(
+        repose.command._command, "HostGroup", MagicMock(return_value=MagicMock())
+    )
+
+    cmd = ListProducts(mock_args)
+    assert isinstance(cmd.display, CommandDisplay)
+
+
+def test_list_repos_format_json_selects_json_display(
+    monkeypatch, mock_args, mock_ssh_client
+):
+    from repose.display import JsonCommandDisplay
+
+    mock_args.format = "json"
+    monkeypatch.setattr(
+        repose.command._command, "HostGroup", MagicMock(return_value=MagicMock())
+    )
+
+    cmd = ListRepos(mock_args)
+    assert isinstance(cmd.display, JsonCommandDisplay)

--- a/tests/target/test_hostgroup.py
+++ b/tests/target/test_hostgroup.py
@@ -26,16 +26,17 @@ def test_connect_calls_each_target_connect(two_targets):
         t.connect.assert_called_once()
 
 
-def test_connect_swallows_per_host_exception(two_targets, capsys):
+def test_connect_swallows_per_host_exception(two_targets, caplog):
     """If one target's connect() raises, others still finish."""
     two_targets["host-a"].connect.side_effect = RuntimeError("boom")
     two_targets["host-b"].connect.return_value = two_targets["host-b"]
 
     hg = HostGroup(two_targets)
-    hg.connect()  # should not raise
+    with caplog.at_level("WARNING", logger="repose.target.hostgroup"):
+        hg.connect()  # should not raise
 
-    captured = capsys.readouterr()
-    assert "boom" in captured.out
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("boom" in m and "host-a" in m for m in messages)
     two_targets["host-b"].connect.assert_called_once()
 
 

--- a/tests/test_argparsing.py
+++ b/tests/test_argparsing.py
@@ -156,3 +156,28 @@ def test_list_products_yaml_flag():
 def test_list_products_yaml_default_false():
     args = get_parser().parse_args(["list-products", "-t", "h"])
     assert args.yaml is False
+
+
+def test_no_color_flag_default_false(mock_types):
+    args = get_parser().parse_args(["add", "-t", "h", "x"])
+    assert args.no_color is False
+
+
+def test_no_color_flag_sets_true(mock_types):
+    args = get_parser().parse_args(["--no-color", "add", "-t", "h", "x"])
+    assert args.no_color is True
+
+
+def test_format_default_text(mock_types):
+    args = get_parser().parse_args(["add", "-t", "h", "x"])
+    assert args.format == "text"
+
+
+def test_format_json_accepted(mock_types):
+    args = get_parser().parse_args(["--format", "json", "add", "-t", "h", "x"])
+    assert args.format == "json"
+
+
+def test_format_invalid_rejected(mock_types):
+    with pytest.raises(SystemExit):
+        get_parser().parse_args(["--format", "xml", "add", "-t", "h", "x"])

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,197 @@
+"""Tests for ``repose.console.Console``."""
+
+import io
+import json
+
+import pytest
+
+from repose.console import Console
+
+
+ANSI_BLUE = "\033[1;34m"
+ANSI_RED = "\033[1;31m"
+ANSI_YELLOW = "\033[1;33m"
+
+
+# ---------------------------------------------------------------------------
+# Text-mode output
+# ---------------------------------------------------------------------------
+
+
+def test_text_dry_normalized_shape():
+    stream = io.StringIO()
+    c = Console(stream=stream, format="text", color="never")
+    c.dry("user@host1", "zypper -n ar foo")
+
+    assert stream.getvalue() == "user@host1 - zypper -n ar foo\n"
+
+
+def test_text_dry_colored_when_color_always():
+    stream = io.StringIO()
+    c = Console(stream=stream, format="text", color="always")
+    c.dry("user@host1", "cmd")
+
+    out = stream.getvalue()
+    assert ANSI_BLUE in out
+    assert "user@host1" in out
+    assert "cmd" in out
+
+
+def test_text_dry_no_ansi_when_color_never():
+    stream = io.StringIO()
+    c = Console(stream=stream, format="text", color="never")
+    c.dry("user@host1", "cmd")
+
+    out = stream.getvalue()
+    assert "\033[" not in out
+
+
+def test_text_report_color_per_level_always():
+    stream = io.StringIO()
+    c = Console(stream=stream, format="text", color="always")
+    c.report("h", "ok line", ok=True, level="info")
+    c.report("h", "warn line", ok=True, level="warning")
+    c.report("h", "err line", ok=False, level="error")
+
+    out = stream.getvalue()
+    assert ANSI_BLUE in out
+    assert ANSI_YELLOW in out
+    assert ANSI_RED in out
+
+
+def test_text_info_emits_unscoped_line():
+    stream = io.StringIO()
+    c = Console(stream=stream, format="text", color="never")
+    c.info("something happened")
+
+    assert stream.getvalue() == "something happened\n"
+
+
+def test_text_error_with_host_prefix():
+    stream = io.StringIO()
+    c = Console(stream=stream, format="text", color="never")
+    c.error("h", "boom")
+
+    assert stream.getvalue() == "h - boom\n"
+
+
+# ---------------------------------------------------------------------------
+# JSON-mode output
+# ---------------------------------------------------------------------------
+
+
+def test_json_dry_parseable():
+    stream = io.StringIO()
+    c = Console(stream=stream, format="json")
+    c.dry("h", "cmd")
+
+    payload = json.loads(stream.getvalue())
+    assert payload == {
+        "event": "dry",
+        "level": "info",
+        "host": "h",
+        "cmd": "cmd",
+    }
+
+
+def test_json_report_includes_ok_and_level():
+    stream = io.StringIO()
+    c = Console(stream=stream, format="json")
+    c.report("h", "line", ok=False, level="error")
+
+    payload = json.loads(stream.getvalue())
+    assert payload == {
+        "event": "report",
+        "level": "error",
+        "host": "h",
+        "line": "line",
+        "ok": False,
+    }
+
+
+def test_json_one_object_per_call_newline_separated():
+    stream = io.StringIO()
+    c = Console(stream=stream, format="json")
+    c.dry("h1", "c1")
+    c.report("h2", "l2", ok=True)
+    c.error("h3", "err")
+    c.info("hi")
+
+    lines = stream.getvalue().splitlines()
+    assert len(lines) == 4
+    events = [json.loads(line)["event"] for line in lines]
+    assert events == ["dry", "report", "error", "info"]
+
+
+def test_json_no_ansi_even_when_color_always():
+    stream = io.StringIO()
+    c = Console(stream=stream, format="json", color="always")
+    c.dry("h", "cmd")
+
+    assert "\033[" not in stream.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Color-mode precedence
+# ---------------------------------------------------------------------------
+
+
+def test_no_color_env_overrides_auto(monkeypatch):
+    stream = io.StringIO()
+    monkeypatch.setenv("NO_COLOR", "1")
+    c = Console(stream=stream, format="text", color="auto")
+
+    assert c._use_color() is False
+
+
+def test_color_always_beats_no_color_env(monkeypatch):
+    stream = io.StringIO()
+    monkeypatch.setenv("NO_COLOR", "1")
+    c = Console(stream=stream, format="text", color="always")
+
+    assert c._use_color() is True
+
+
+def test_non_tty_stream_disables_auto_color(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    stream = io.StringIO()  # no .isatty() True
+    c = Console(stream=stream, format="text", color="auto")
+
+    assert c._use_color() is False
+
+
+def test_tty_stream_enables_auto_color(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+    class FakeTTY(io.StringIO):
+        def isatty(self) -> bool:
+            return True
+
+    stream = FakeTTY()
+    c = Console(stream=stream, format="text", color="auto")
+
+    assert c._use_color() is True
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_format_is_text():
+    c = Console()
+    assert c.format == "text"
+
+
+def test_default_color_is_auto():
+    c = Console()
+    assert c.color == "auto"
+
+
+@pytest.mark.parametrize("level", ["info", "warning", "error"])
+def test_report_levels_all_emit_in_text(level):
+    stream = io.StringIO()
+    c = Console(stream=stream, format="text", color="never")
+    c.report("h", "line", ok=True, level=level)
+
+    assert stream.getvalue() == "h - line\n"

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,10 +1,11 @@
 """Tests for ``repose.display.CommandDisplay``."""
 
 import io
+import json
 
 from ruamel.yaml import YAML
 
-from repose.display import CommandDisplay
+from repose.display import CommandDisplay, JsonCommandDisplay
 from repose.target.parsers import Product, Repository
 from repose.types.system import System
 
@@ -80,3 +81,101 @@ def test_list_products_yaml_emits_parseable_yaml():
     assert parsed["arch"] == "x86_64"
     assert parsed["product"]["name"] == "SLES"
     assert parsed["product"]["version"] == {"major": 15, "minor": "SP3"}
+
+
+# ---------------------------------------------------------------------------
+# JsonCommandDisplay
+# ---------------------------------------------------------------------------
+
+
+def _ndjson(buf: io.StringIO) -> list[dict]:
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+
+
+def test_json_list_products_emits_base_and_addons():
+    buf = io.StringIO()
+    cd = JsonCommandDisplay(buf)
+
+    base = Product("SLES", "15-SP3", "x86_64")
+    addon = Product("sle-sdk", "15-SP3", "x86_64")
+    system = System(base, addons={addon})
+    cd.list_products("host1", 22, system)
+
+    events = _ndjson(buf)
+    assert len(events) == 2
+
+    kinds = {e["kind"]: e for e in events}
+    assert kinds["base"] == {
+        "event": "product",
+        "host": "host1",
+        "port": 22,
+        "kind": "base",
+        "name": "SLES",
+        "version": "15-SP3",
+        "arch": "x86_64",
+    }
+    assert kinds["addon"]["name"] == "sle-sdk"
+    assert kinds["addon"]["kind"] == "addon"
+
+
+def test_json_list_products_base_only_emits_single_event():
+    buf = io.StringIO()
+    cd = JsonCommandDisplay(buf)
+
+    cd.list_products("host1", 22, System(Product("SLES", "15-SP3", "x86_64")))
+
+    events = _ndjson(buf)
+    assert len(events) == 1
+    assert events[0]["kind"] == "base"
+
+
+def test_json_list_update_repos_one_event_per_repo():
+    buf = io.StringIO()
+    cd = JsonCommandDisplay(buf)
+
+    repos = [
+        Repository("a", "alpha", "http://a/", True),
+        Repository("b", "beta", "http://b/", False),
+    ]
+    cd.list_update_repos("host1", 22, repos)
+
+    events = _ndjson(buf)
+    assert len(events) == 2
+    assert events[0] == {
+        "event": "repo",
+        "host": "host1",
+        "port": 22,
+        "alias": "a",
+        "name": "alpha",
+        "url": "http://a/",
+        "state": True,
+    }
+    assert events[1]["alias"] == "b"
+    assert events[1]["state"] is False
+
+
+def test_json_list_known_products_one_event_per_product():
+    buf = io.StringIO()
+    cd = JsonCommandDisplay(buf)
+
+    cd.list_known_products(["SLES", "openSUSE", "RHEL"])
+
+    events = _ndjson(buf)
+    assert [e["event"] for e in events] == ["known_product"] * 3
+    assert [e["name"] for e in events] == ["SLES", "openSUSE", "RHEL"]
+
+
+def test_json_list_products_yaml_emits_host_spec_event():
+    buf = io.StringIO()
+    cd = JsonCommandDisplay(buf)
+
+    cd.list_products_yaml("host1", System(Product("SLES", "15-SP3", "x86_64")))
+
+    events = _ndjson(buf)
+    assert len(events) == 1
+    payload = events[0]
+    assert payload["event"] == "host_spec"
+    assert payload["host"] == "host1"
+    assert payload["name"] == "host1"
+    assert payload["arch"] == "x86_64"
+    assert payload["product"]["name"] == "SLES"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 """Tests for ``repose.utils``."""
 
-import importlib
+import io
 
 import repose.utils
 
@@ -10,24 +10,52 @@ def test_timestamp_returns_string_of_int(monkeypatch):
     assert repose.utils.timestamp() == "1234567"
 
 
-def test_color_helpers_default_have_ansi_codes():
-    # Module is imported with COLOR=always (default)
+def test_color_helpers_have_ansi_codes_when_color_always(monkeypatch):
+    monkeypatch.setenv("COLOR", "always")
+    monkeypatch.delenv("NO_COLOR", raising=False)
     assert "\033[1;32m" in repose.utils.green("x")
     assert "\033[1;31m" in repose.utils.red("x")
     assert "\033[1;33m" in repose.utils.yellow("x")
     assert "\033[1;34m" in repose.utils.blue("x")
 
 
-def test_color_helpers_disabled_when_color_env_overridden(monkeypatch):
+def test_color_helpers_disabled_when_color_never(monkeypatch):
     monkeypatch.setenv("COLOR", "never")
-    # Reload the module so the COLOR check re-runs
-    reloaded = importlib.reload(repose.utils)
-    try:
-        assert reloaded.green("x") == "x"
-        assert reloaded.red("y") == "y"
-        assert reloaded.yellow("z") == "z"
-        assert reloaded.blue("w") == "w"
-    finally:
-        # Restore original module state for other tests
-        monkeypatch.delenv("COLOR")
-        importlib.reload(repose.utils)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    assert repose.utils.green("x") == "x"
+    assert repose.utils.red("y") == "y"
+    assert repose.utils.yellow("z") == "z"
+    assert repose.utils.blue("w") == "w"
+
+
+def test_no_color_env_disables_colors(monkeypatch):
+    monkeypatch.delenv("COLOR", raising=False)
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert repose.utils.green("x") == "x"
+    assert repose.utils.blue("x") == "x"
+
+
+def test_color_always_beats_no_color(monkeypatch):
+    monkeypatch.setenv("COLOR", "always")
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert "\033[1;34m" in repose.utils.blue("x")
+
+
+def test_non_tty_stdout_disables_colors(monkeypatch):
+    monkeypatch.delenv("COLOR", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr(repose.utils.sys, "stdout", io.StringIO())
+    assert repose.utils.green("x") == "x"
+    assert repose.utils.blue("x") == "x"
+
+
+def test_tty_stdout_enables_colors(monkeypatch):
+    monkeypatch.delenv("COLOR", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+    class FakeTTY(io.StringIO):
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr(repose.utils.sys, "stdout", FakeTTY())
+    assert "\033[1;34m" in repose.utils.blue("x")


### PR DESCRIPTION
## Summary

Route every user-facing line through a single `Console` abstraction so output behaves predictably for both humans and scripts.

Before, output came from three places:

- Scattered `print()` calls in six command modules (dry-run previews).
- `logger.info`/`logger.warning` inside `_report_target` (per-host run output, mixed with log noise on stderr).
- A bare `print(exc)` in `HostGroup.connect()`.

Colors were enabled at import-time from a `COLOR` env var, not TTY-aware, and ignored the [`NO_COLOR`](https://no-color.org) convention. There was no scriptable output format.

## What changes

`repose/console.py` — new `Console` dataclass with two orthogonal toggles:

- `format`: `text` (default) | `json` (one event per line)
- `color`: `auto` (TTY + `NO_COLOR`-aware) | `always` | `never`

Two new global CLI flags plumb through to every command:

- `--no-color` forces color off
- `--format={text,json}` selects output envelope

JSON events carry `{event, level, host, cmd|line, ok}` so consumers can pipe to `jq` for CI parsing and per-host filtering.

`repose/utils.py` colorizers now use the same TTY/`NO_COLOR` detection so `display.py` and `colorlog.py` inherit the correct behaviour automatically. Legacy `COLOR=always|never` env override is preserved.

## Behavioral note

Per-host run output (previously `logger.info`/`logger.warning` on stderr) now goes through the Console on **stdout**. `--quiet` still silences logger noise but no longer hides per-host output. Documented in README under "Output Control".

## Verification

- `pytest`: **283 passed** (was 277).
- `ruff format --diff .`: clean.
- `ruff check .`: clean.
- `ty check`: clean.
- Coverage: `repose/console.py` 100%, `repose/utils.py` 100%, overall 93%.
- `grep -nE 'print\\(' repose/` outside `print_usage`: zero matches.

Manual:

```
repose add -n --format=json -t fakehost sle-sdk | jq .             # parses
repose add -n -t fakehost sle-sdk | cat                            # no ANSI
NO_COLOR=1 repose add -n -t fakehost sle-sdk                       # no ANSI
repose add -n -t fakehost sle-sdk                                  # colored in TTY
```