### PR TITLE
perf(template): cache load_template and build Repoq once per command

### DIFF
--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from argparse import Namespace
 import concurrent.futures
 from concurrent.futures import Future
+import functools
 import logging
 import sys
 from pathlib import Path
@@ -61,7 +62,9 @@ class Command(ABC):
         self.targets = targets
 
         self.dryrun: bool = args.dry
-        self.template_path: str = args.config
+        # ``args.config`` is already a ``Path`` (argparse ``type=Path``);
+        # the prior ``str`` annotation was a lie.
+        self.template_path: Path = args.config
         # ``repa`` is None for commands that don't accept a REPA argument
         # (list, known, clear, reset). Commands that *do* iterate over it
         # (add, install, remove, uninstall) gate on truthiness first.
@@ -81,11 +84,22 @@ class Command(ABC):
         else:
             self.display = CommandDisplay(sys.stdout)
 
-    def _load_template(self) -> dict:
-        return load_template(Path(self.template_path))
+    @functools.cached_property
+    def repoq(self) -> Repoq:
+        """Shared ``Repoq`` resolver built once per ``Command`` instance.
 
-    def _init_repoq(self) -> Repoq:
-        return Repoq(self._load_template())
+        Thread-safety: ``cached_property`` is safe for read-after-write,
+        but the *first* read materialises the value. Callers MUST ensure
+        the first access happens on the main thread before any worker
+        thread (e.g. ``_run_parallel``) is spawned, otherwise two
+        workers may race and each construct a ``Repoq``. ``_run_parallel``
+        consumers in this codebase satisfy the invariant by touching
+        ``self.repoq`` only from within per-host worker functions that
+        all observe the same instance once one of them populates the
+        cache (a wasted re-construct, not a correctness bug, in the
+        unlikely tied case).
+        """
+        return Repoq(load_template(self.template_path))
 
     def _report_target(self, target: str) -> bool:
         """Report the last command's output for ``target`` via Console.

--- a/repose/command/add.py
+++ b/repose/command/add.py
@@ -16,7 +16,6 @@ class Add(Command, name="add"):
         ``Repoq.solve_repa``). The caller uses ``ok`` to mark the host
         as failed in the aggregated exit code.
         """
-        repoq = self._init_repoq()
         repolist = []
         cmds = set()
         ok = True
@@ -24,7 +23,7 @@ class Add(Command, name="add"):
             try:
                 repolist += chain.from_iterable(
                     x
-                    for x in repoq.solve_repa(
+                    for x in self.repoq.solve_repa(
                         repa, self.targets[target].products.get_base()
                     ).values()
                 )
@@ -52,6 +51,9 @@ class Add(Command, name="add"):
         return ok
 
     def run(self) -> ExitCode:
+        # Materialise the shared ``Repoq`` on the main thread before
+        # ``_run_parallel`` spawns workers (see ``Command.repoq``).
+        _ = self.repoq
         self.targets.read_products()
         futures = self._run_parallel(self._run)
 

--- a/repose/command/install.py
+++ b/repose/command/install.py
@@ -8,13 +8,15 @@ logger = logging.getLogger("repose.command.install")
 
 
 class Install(Command, name="install"):
-    def _run(self, target, repoq) -> bool:
+    def _run(self, target) -> bool:
         repositories = {}
         ok = True
         for repa in self.repa:
             try:
                 repositories.update(
-                    repoq.solve_repa(repa, self.targets[target].products.get_base())
+                    self.repoq.solve_repa(
+                        repa, self.targets[target].products.get_base()
+                    )
                 )
             except ValueError as error:
                 logger.error(error)
@@ -55,9 +57,11 @@ class Install(Command, name="install"):
         return ok
 
     def run(self) -> ExitCode:
-        repoq = self._init_repoq()
+        # Materialise the shared ``Repoq`` on the main thread before
+        # ``_run_parallel`` spawns workers (see ``Command.repoq``).
+        _ = self.repoq
         self.targets.read_products()
         self.targets.read_repos()
-        futures = self._run_parallel(self._run, repoq)
+        futures = self._run_parallel(self._run)
         self.targets.close()
         return self._aggregate(futures)

--- a/repose/command/known.py
+++ b/repose/command/known.py
@@ -1,9 +1,10 @@
 from . import Command
+from ..template import load_template
 from ..types import ExitCode
 
 
 class KnownProducts(Command, name="known-products"):
     def run(self) -> ExitCode:
-        template = self._load_template()
+        template = load_template(self.template_path)
         self.display.list_known_products(sorted(template.keys()))
         return 0

--- a/repose/command/reset.py
+++ b/repose/command/reset.py
@@ -10,10 +10,9 @@ logger = logging.getLogger("repose.command.reset")
 
 class Reset(Clear, name="reset"):
     def _add(self, target):
-        repoq = self._init_repoq()
         cmds = set()
         repolist = chain.from_iterable(
-            x for x in repoq.solve_product(self.targets[target].products).values()
+            x for x in self.repoq.solve_product(self.targets[target].products).values()
         )
         cmds.update(
             self.addcmd.format(
@@ -47,6 +46,9 @@ class Reset(Clear, name="reset"):
         return ok
 
     def run(self) -> ExitCode:
+        # Materialise the shared ``Repoq`` on the main thread before
+        # ``_run_parallel`` spawns workers (see ``Command.repoq``).
+        _ = self.repoq
         self.targets.read_products()
         self.targets.read_repos()
         futures = self._run_parallel(self._run)

--- a/repose/template/__init__.py
+++ b/repose/template/__init__.py
@@ -1,11 +1,20 @@
+import functools
 from pathlib import Path
 from typing import Any
 
 from ruamel.yaml import YAML
 
 
+@functools.cache
 def load_template(path: Path) -> dict[str, Any]:
     """Load and return the products YAML template file.
+
+    The result is cached for the lifetime of the process keyed by
+    ``path``. This is safe for the CLI (one invocation = one process)
+    but tests that mutate the same path between cases MUST call
+    ``load_template.cache_clear()`` to avoid stale data. The
+    ``_clear_template_cache`` autouse fixture in ``tests/conftest.py``
+    handles this globally.
 
     Args:
         path: Path to the products YAML configuration file.

--- a/tests/command/test_add.py
+++ b/tests/command/test_add.py
@@ -68,7 +68,7 @@ def test_add_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
         "HostGroup",
         MagicMock(return_value=mock_host_group_instance),
     )
-    monkeypatch.setattr(Add, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Add, "repoq", mock_repoq)
     monkeypatch.setattr(Add, "check_url", MagicMock(return_value=True))
 
     # Instantiate and Run
@@ -121,7 +121,7 @@ def test_add_command_dryrun_prints_and_skips_run(
         "HostGroup",
         MagicMock(return_value=mock_hg),
     )
-    monkeypatch.setattr(Add, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Add, "repoq", mock_repoq)
     monkeypatch.setattr(Add, "check_url", MagicMock(return_value=True))
 
     assert Add(args).run() == 0
@@ -156,7 +156,7 @@ def test_add_command_solve_repa_value_error_logged(
         "HostGroup",
         MagicMock(return_value=mock_hg),
     )
-    monkeypatch.setattr(Add, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Add, "repoq", mock_repoq)
     monkeypatch.setattr(Add, "check_url", MagicMock(return_value=True))
 
     with caplog.at_level("ERROR", logger="repose.command.add"):
@@ -188,7 +188,7 @@ def test_add_command_skips_repo_when_check_url_false(
         "HostGroup",
         MagicMock(return_value=mock_hg),
     )
-    monkeypatch.setattr(Add, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Add, "repoq", mock_repoq)
     monkeypatch.setattr(Add, "check_url", MagicMock(return_value=False))
 
     # Repo filtered out by check_url → no cmds attempted, no failures → 0.
@@ -232,7 +232,7 @@ def _setup_add_hosts(monkeypatch, hosts):
     mock_repoq.solve_repa.return_value = {
         "product": [MockRepo("repo1", "http://repo1.url", refresh=False)]
     }
-    monkeypatch.setattr(Add, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Add, "repoq", mock_repoq)
     monkeypatch.setattr(Add, "check_url", MagicMock(return_value=True))
     return targets, hg
 

--- a/tests/command/test_command_base.py
+++ b/tests/command/test_command_base.py
@@ -155,7 +155,7 @@ def test_report_target_routes_by_exitcode(
     assert cmd._report_target("host") is expected_ok
 
 
-def test_init_repoq_loads_template(monkeypatch, tmp_path):
+def test_repoq_loads_template(monkeypatch, tmp_path):
     yml = tmp_path / "products.yml"
     yml.write_text("SLES:\n  '15':\n    default_repos:\n      - update\n")
 
@@ -163,8 +163,7 @@ def test_init_repoq_loads_template(monkeypatch, tmp_path):
         monkeypatch,
         args_overrides={"config": yml},
     )
-    repoq = cmd._init_repoq()
-    assert "SLES" in repoq.template
+    assert "SLES" in cmd.repoq.template
 
 
 # ---------------------------------------------------------------------------

--- a/tests/command/test_install.py
+++ b/tests/command/test_install.py
@@ -60,7 +60,7 @@ def test_install_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
         "HostGroup",
         MagicMock(return_value=mock_host_group_instance),
     )
-    monkeypatch.setattr(Install, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Install, "repoq", mock_repoq)
 
     # Run
     install_command = Install(mock_args)
@@ -105,7 +105,7 @@ def _setup_install(monkeypatch, args, repoq_solution, out=None):
         "HostGroup",
         MagicMock(return_value=mock_hg),
     )
-    monkeypatch.setattr(Install, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Install, "repoq", mock_repoq)
     return mock_target, mock_hg, mock_repoq
 
 
@@ -188,7 +188,7 @@ def test_install_command_solve_repa_value_error_logged(
         "HostGroup",
         MagicMock(return_value=mock_hg),
     )
-    monkeypatch.setattr(Install, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Install, "repoq", mock_repoq)
 
     with caplog.at_level("ERROR", logger="repose.command.install"):
         # solve_repa raises AND no products → exit 2.
@@ -230,7 +230,7 @@ def _setup_install_multi(monkeypatch, hosts):
         "HostGroup",
         MagicMock(return_value=hg),
     )
-    monkeypatch.setattr(Install, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Install, "repoq", mock_repoq)
     return targets, hg
 
 

--- a/tests/command/test_known.py
+++ b/tests/command/test_known.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import repose.command._command
+import repose.command.known
 from repose.command.known import KnownProducts
 
 
@@ -23,7 +24,7 @@ def test_known_products_command(monkeypatch, mock_args):
     mock_load_template = MagicMock(
         return_value={"product-c": {}, "product-a": {}, "product-b": {}}
     )
-    monkeypatch.setattr(KnownProducts, "_load_template", mock_load_template)
+    monkeypatch.setattr(repose.command.known, "load_template", mock_load_template)
     monkeypatch.setattr(repose.command._command, "HostGroup", MagicMock())
 
     # Run
@@ -44,8 +45,8 @@ def test_known_products_format_json_end_to_end(monkeypatch, mock_args, capsys):
 
     mock_args.format = "json"
     monkeypatch.setattr(
-        KnownProducts,
-        "_load_template",
+        repose.command.known,
+        "load_template",
         MagicMock(return_value={"product-c": {}, "product-a": {}, "product-b": {}}),
     )
     monkeypatch.setattr(repose.command._command, "HostGroup", MagicMock())

--- a/tests/command/test_reset.py
+++ b/tests/command/test_reset.py
@@ -75,7 +75,7 @@ def test_reset_command_run(monkeypatch, mock_args, mock_ssh_client):
         "HostGroup",
         MagicMock(return_value=mock_host_group_instance),
     )
-    monkeypatch.setattr(Reset, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Reset, "repoq", mock_repoq)
     monkeypatch.setattr(Reset, "check_url", MagicMock(return_value=True))
 
     # Instantiate and Run
@@ -135,7 +135,7 @@ def _setup_reset(
         "HostGroup",
         MagicMock(return_value=mock_hg),
     )
-    monkeypatch.setattr(Reset, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Reset, "repoq", mock_repoq)
     monkeypatch.setattr(Reset, "check_url", MagicMock(return_value=check_url))
     return mock_target, mock_hg, mock_repoq
 
@@ -221,7 +221,7 @@ def _setup_reset_multi(monkeypatch, hosts):
         "HostGroup",
         MagicMock(return_value=hg),
     )
-    monkeypatch.setattr(Reset, "_init_repoq", MagicMock(return_value=mock_repoq))
+    monkeypatch.setattr(Reset, "repoq", mock_repoq)
     monkeypatch.setattr(Reset, "check_url", MagicMock(return_value=True))
     return targets, hg
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,23 @@ import paramiko
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _clear_template_cache():
+    """Reset the ``load_template`` cache around every test.
+
+    ``load_template`` is decorated with ``@functools.cache`` for the
+    process lifetime. Without this fixture, tests that write different
+    contents to the same path between cases (e.g. ``tmp_path /
+    "products.yml"`` reused via a session-scoped fixture, or sequential
+    cases that mutate the file) would observe stale parsed YAML.
+    """
+    from repose.template import load_template
+
+    load_template.cache_clear()
+    yield
+    load_template.cache_clear()
+
+
 @pytest.fixture
 def mock_ssh_client(monkeypatch):
     mock_ssh_class = MagicMock()

--- a/tests/template/test_loader.py
+++ b/tests/template/test_loader.py
@@ -1,6 +1,7 @@
 """Tests for ``repose.template.load_template``."""
 
 import pytest
+from ruamel.yaml import YAML
 
 from repose.template import load_template
 
@@ -30,3 +31,30 @@ def test_load_template_returns_dict(tmp_path):
 def test_load_template_missing_file_raises(tmp_path):
     with pytest.raises(FileNotFoundError):
         load_template(tmp_path / "missing.yml")
+
+
+def test_load_template_caches(tmp_path, monkeypatch):
+    """``load_template`` parses each path only once per process.
+
+    Counts ``YAML.load`` invocations across three calls with the same
+    path. With ``@functools.cache`` in place, the parser runs exactly
+    once.
+    """
+    path = tmp_path / "products.yml"
+    path.write_text("sle-sdk:\n  '12-SP2':\n    default_repos: []\n")
+
+    calls = 0
+    real_load = YAML.load
+
+    def counting(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real_load(self, *args, **kwargs)
+
+    monkeypatch.setattr(YAML, "load", counting)
+
+    load_template(path)
+    load_template(path)
+    load_template(path)
+
+    assert calls == 1


### PR DESCRIPTION
## Summary

Re-reading and re-parsing `/etc/repose/products.yml` on every call was pure waste: `Add._add`, `Install._run`, and `Reset._add` each constructed a fresh `Repoq` per host, so a 10-host invocation parsed the same YAML 10 times. This PR caches the load and shares one resolver per command instance.

## Changes

- **`load_template`** decorated with `@functools.cache` — parser runs once per path for the process lifetime.
- **`Command.repoq`** added as a `functools.cached_property` — every subcommand reuses one `Repoq` instance.
- **`Add.run`, `Install.run`, `Reset.run`** pre-warm `self.repoq` on the main thread before `_run_parallel` spawns workers (keeps the cached_property safe against worker races; the invariant is documented on the property).
- **Dropped** `Command._load_template` and `Command._init_repoq` helpers; `known.py` calls `load_template` directly.
- **Fixed** the long-standing lie that `Command.template_path` was `str` — argparse hands us a `Path`.

## Tests

- Migrated patches in `test_add`, `test_install`, `test_reset`, `test_known`, `test_command_base` from the removed helpers to the new `repoq` attribute / module-level `load_template`. `cached_property` is a non-data descriptor, so `monkeypatch.setattr(Cls, "repoq", mock)` cleanly shadows it.
- New `test_load_template_caches` in `tests/template/test_loader.py` counts `YAML.load` invocations to lock in the caching contract.
- New autouse `_clear_template_cache` fixture in `tests/conftest.py` resets the cache around every test for hermeticity.

## Verification

- `ruff format --diff .` — no changes
- `ruff check .` — all clean
- `pytest -q` — **293 passed** (baseline + 1 new cache test)
- `rg "_init_repoq|_load_template" repose/` — zero matches
- Cache test verified to fail when `@functools.cache` is removed (parser runs 3× instead of 1×)

## Risk

Low. Single sharp edge is thread-safety of `cached_property` under `_run_parallel`; mitigated by pre-warming on the main thread in every command that fans out, and documented in a comment on the property.

This is PR 09 from the local improvement plan.