### PR TITLE
perf(probe): parallelize repository URL probes and add timeout/skip flags

### DIFF
--- a/repose/argparsing.py
+++ b/repose/argparsing.py
@@ -91,6 +91,19 @@ def get_parser():
                 type=Repa,
                 help="REPA pattern specification for needed repository",
             )
+        if "probe" in arguments:
+            subparser.add_argument(
+                "--probe-timeout",
+                type=float,
+                default=5.0,
+                metavar="SECONDS",
+                help="seconds to wait per repository URL probe (default: 5)",
+            )
+            subparser.add_argument(
+                "--no-probe",
+                action="store_true",
+                help="skip repository URL liveness probes",
+            )
         # Late-bind via default arg to dodge the closure late-binding
         # trap, and resolve through the registry at call time so tests
         # can monkeypatch ``Command.registry`` entries.
@@ -100,7 +113,11 @@ def get_parser():
         return subparser
 
     # command ADD
-    add_subparser("add", "add specified repository to target", ["target", "repa"])
+    add_subparser(
+        "add",
+        "add specified repository to target",
+        ["target", "repa", "probe"],
+    )
 
     # command REMOVE
     add_subparser("remove", "remove repository from target", ["target", "repa"])
@@ -109,14 +126,14 @@ def get_parser():
     add_subparser(
         "reset",
         "reset target repositories to only installed products repositories",
-        ["target"],
+        ["target", "probe"],
     )
 
     # command INSTALL
     add_subparser(
         "install",
         "add specified repository to target and install product",
-        ["target", "repa"],
+        ["target", "repa", "probe"],
     )
 
     # command CLEAR

--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -6,9 +6,7 @@ import functools
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Callable, ClassVar
-from urllib.error import HTTPError, URLError
-from urllib.request import urlopen
+from typing import Any, Callable, ClassVar, Iterable
 
 from ..console import Console
 from ..display import CommandDisplay, JsonCommandDisplay
@@ -17,6 +15,7 @@ from ..template import load_template
 from ..template.resolver import Repoq
 from ..types import ExitCode
 from ..types.repa import Repa
+from ..utils import check_repo_url
 
 logger = logging.getLogger("repose.command")
 
@@ -83,6 +82,12 @@ class Command(ABC):
             self.display = JsonCommandDisplay(sys.stdout)
         else:
             self.display = CommandDisplay(sys.stdout)
+        # Probe knobs. ``getattr`` is defensive: commands without the
+        # ``probe`` argparse group (list-products, clear, known-products,
+        # ...) construct cleanly with the same defaults that apply when
+        # the flag is absent for probing commands.
+        self.probe_timeout: float = getattr(args, "probe_timeout", 5.0)
+        self.no_probe: bool = getattr(args, "no_probe", False)
 
     @functools.cached_property
     def repoq(self) -> Repoq:
@@ -169,26 +174,31 @@ class Command(ABC):
             return 2
         return 1
 
-    @staticmethod
-    def check_url(url: str) -> bool:
-        """Check whether a repository URL exposes a valid repomd.xml.
+    def _filter_live_urls(self, repos: Iterable[Any]) -> list[Any]:
+        """Return only the repos whose URL passes ``check_repo_url``.
 
-        Tries ``<url>repodata/repomd.xml`` first and falls back to
-        ``<url>suse/repodata/repomd.xml`` (used by SUSE-style layouts).
+        Probes run in parallel via ``ThreadPoolExecutor`` so wall time
+        scales with ``max(latency)`` rather than ``sum(latency)``.
+        Pool size is capped at 16 to keep concurrent connections to a
+        single mirror reasonable; smaller batches use a correspondingly
+        smaller pool.
 
-        Returns ``True`` if either probe succeeds, ``False`` otherwise.
+        Honors ``self.no_probe`` (short-circuits, returning every repo
+        unchanged) and ``self.probe_timeout`` (per-probe socket
+        timeout). Order of the returned list mirrors the input order.
         """
-        try:
-            urlopen(url + "repodata/repomd.xml")
-            return True
-        except (HTTPError, URLError):
-            pass
-
-        try:
-            urlopen(url + "suse/repodata/repomd.xml")
-            return True
-        except (HTTPError, URLError):
-            return False
+        repos = list(repos)
+        if self.no_probe or not repos:
+            return repos
+        max_workers = min(16, len(repos))
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
+            alive = list(
+                ex.map(
+                    lambda r: check_repo_url(r.url, timeout=self.probe_timeout),
+                    repos,
+                )
+            )
+        return [r for r, ok in zip(repos, alive) if ok]
 
     @abstractmethod
     def run(self) -> ExitCode:

--- a/repose/command/add.py
+++ b/repose/command/add.py
@@ -30,12 +30,14 @@ class Add(Command, name="add"):
             except ValueError as error:
                 logger.error(error)
                 ok = False
+        # Probe all candidate URLs in parallel before issuing any
+        # ``zypper ar`` so a slow mirror doesn't serialise the cohort.
+        live = self._filter_live_urls(repolist)
         cmds.update(
             self.addcmd.format(
                 name=x.name, url=x.url, params="-cfkn" if x.refresh else "-ckn"
             )
-            for x in repolist
-            if self.check_url(x.url)
+            for x in live
         )
         return cmds, ok
 

--- a/repose/command/install.py
+++ b/repose/command/install.py
@@ -22,7 +22,14 @@ class Install(Command, name="install"):
                 logger.error(error)
                 ok = False
 
-        for repo in chain.from_iterable(x for x in (y for y in repositories.values())):
+        # New in PR 08: probe candidate URLs in parallel and skip
+        # adding repos whose mirror is dead. The product install below
+        # is unchanged - it still iterates ``repositories.keys()`` so a
+        # product whose repos all fail the probe is still requested
+        # from whatever sources zypper already knows about.
+        all_repos = list(chain.from_iterable(repositories.values()))
+        live_repos = self._filter_live_urls(all_repos)
+        for repo in live_repos:
             addcmd = self.addcmd.format(
                 name=repo.name, url=repo.url, params="-cfkn" if repo.refresh else "-ckn"
             )

--- a/repose/command/reset.py
+++ b/repose/command/reset.py
@@ -14,12 +14,15 @@ class Reset(Clear, name="reset"):
         repolist = chain.from_iterable(
             x for x in self.repoq.solve_product(self.targets[target].products).values()
         )
+        # Probe all candidate URLs in parallel before issuing any
+        # ``zypper ar``; otherwise each per-host worker would serialise
+        # 1-2 probes per repository.
+        live = self._filter_live_urls(repolist)
         cmds.update(
             self.addcmd.format(
                 name=x.name, url=x.url, params="-cfkn" if x.refresh else "-ckn"
             )
-            for x in repolist
-            if self.check_url(x.url)
+            for x in live
         )
         return cmds
 

--- a/repose/utils.py
+++ b/repose/utils.py
@@ -1,11 +1,35 @@
 import os
 import sys
 import time
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
 
 
 def timestamp() -> str:
     # remove fractional part
     return str(int(time.time()))
+
+
+def check_repo_url(url: str, *, timeout: float = 5.0) -> bool:
+    """Check whether a repository URL exposes a valid ``repomd.xml``.
+
+    Tries ``<url>repodata/repomd.xml`` first and falls back to
+    ``<url>suse/repodata/repomd.xml`` (used by SUSE-style layouts).
+
+    The ``timeout`` keyword bounds each individual ``urlopen`` call in
+    seconds; without it ``urlopen`` would honour
+    ``socket.getdefaulttimeout()``, which is typically unset and hangs
+    forever on a black-holed IP.
+
+    Returns ``True`` if either probe succeeds, ``False`` otherwise.
+    """
+    for suffix in ("repodata/repomd.xml", "suse/repodata/repomd.xml"):
+        try:
+            urlopen(url + suffix, timeout=timeout)
+            return True
+        except (HTTPError, URLError, TimeoutError, OSError):
+            continue
+    return False
 
 
 def _color_enabled() -> bool:

--- a/tests/command/test_add.py
+++ b/tests/command/test_add.py
@@ -69,7 +69,9 @@ def test_add_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
         MagicMock(return_value=mock_host_group_instance),
     )
     monkeypatch.setattr(Add, "repoq", mock_repoq)
-    monkeypatch.setattr(Add, "check_url", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        repose.command._command, "check_repo_url", lambda url, *, timeout: True
+    )
 
     # Instantiate and Run
     add_command = Add(mock_args)
@@ -122,7 +124,9 @@ def test_add_command_dryrun_prints_and_skips_run(
         MagicMock(return_value=mock_hg),
     )
     monkeypatch.setattr(Add, "repoq", mock_repoq)
-    monkeypatch.setattr(Add, "check_url", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        repose.command._command, "check_repo_url", lambda url, *, timeout: True
+    )
 
     assert Add(args).run() == 0
 
@@ -157,7 +161,9 @@ def test_add_command_solve_repa_value_error_logged(
         MagicMock(return_value=mock_hg),
     )
     monkeypatch.setattr(Add, "repoq", mock_repoq)
-    monkeypatch.setattr(Add, "check_url", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        repose.command._command, "check_repo_url", lambda url, *, timeout: True
+    )
 
     with caplog.at_level("ERROR", logger="repose.command.add"):
         # solve_repa failure on the only host → all hosts failed → exit 2.
@@ -167,7 +173,7 @@ def test_add_command_solve_repa_value_error_logged(
     mock_target.run.assert_not_called()
 
 
-def test_add_command_skips_repo_when_check_url_false(
+def test_add_command_skips_repo_when_probe_fails(
     monkeypatch, mock_args_and_repa, mock_ssh_client
 ):
     args, _ = mock_args_and_repa
@@ -189,12 +195,14 @@ def test_add_command_skips_repo_when_check_url_false(
         MagicMock(return_value=mock_hg),
     )
     monkeypatch.setattr(Add, "repoq", mock_repoq)
-    monkeypatch.setattr(Add, "check_url", MagicMock(return_value=False))
+    monkeypatch.setattr(
+        repose.command._command, "check_repo_url", lambda url, *, timeout: False
+    )
 
-    # Repo filtered out by check_url → no cmds attempted, no failures → 0.
+    # Repo filtered out by probe → no cmds attempted, no failures → 0.
     assert Add(args).run() == 0
 
-    # Repo got filtered out because URL check failed → no per-target add cmd
+    # Repo got filtered out because URL probe failed → no per-target add cmd
     mock_target.run.assert_not_called()
 
 
@@ -233,7 +241,9 @@ def _setup_add_hosts(monkeypatch, hosts):
         "product": [MockRepo("repo1", "http://repo1.url", refresh=False)]
     }
     monkeypatch.setattr(Add, "repoq", mock_repoq)
-    monkeypatch.setattr(Add, "check_url", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        repose.command._command, "check_repo_url", lambda url, *, timeout: True
+    )
     return targets, hg
 
 

--- a/tests/command/test_command_base.py
+++ b/tests/command/test_command_base.py
@@ -2,7 +2,6 @@
 
 from concurrent.futures import Future
 from unittest.mock import MagicMock, call
-from urllib.error import HTTPError, URLError
 
 import pytest
 
@@ -39,62 +38,105 @@ def _make(monkeypatch, args_overrides=None, host_group=None):
 
 
 # ---------------------------------------------------------------------------
-# check_url
+# _filter_live_urls
 # ---------------------------------------------------------------------------
 
 
-def test_check_url_returns_true_when_url_opens(monkeypatch):
-    monkeypatch.setattr(cmdmod, "urlopen", lambda url: MagicMock())
-    assert Command.check_url("http://example.com/") is True
+class _StubRepo:
+    """Minimal stand-in matching the ``.url`` attribute consumed by the
+    helper. Real ``Repository`` instances carry more state, but the
+    filter doesn't touch any of it."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
 
 
-def test_check_url_returns_false_when_both_urls_fail(monkeypatch):
-    def _raise(url):
-        raise URLError("nope")
+def test_filter_live_urls_returns_only_live(monkeypatch):
+    """Each repo gets probed once; only those returning True survive,
+    and the relative ordering is preserved."""
+    calls: list[str] = []
 
-    monkeypatch.setattr(cmdmod, "urlopen", _raise)
-    assert Command.check_url("http://example.com/") is False
+    def _probe(url, *, timeout):
+        calls.append(url)
+        return url.endswith("/live/")
 
+    monkeypatch.setattr(cmdmod, "check_repo_url", _probe)
+    cmd, _ = _make(monkeypatch)
 
-def test_check_url_handles_http_error(monkeypatch):
-    def _raise(url):
-        raise HTTPError(url, 404, "not found", {}, None)
-
-    monkeypatch.setattr(cmdmod, "urlopen", _raise)
-    assert Command.check_url("http://example.com/") is False
-
-
-def test_check_url_returns_true_when_suse_fallback_succeeds(monkeypatch):
-    """If the canonical repomd.xml is missing but the ``suse/`` variant
-    answers, the URL is still considered valid."""
-    called: list[str] = []
-
-    def _selective(url):
-        called.append(url)
-        if "suse/repodata/repomd.xml" in url:
-            return MagicMock()
-        raise URLError("not at root")
-
-    monkeypatch.setattr(cmdmod, "urlopen", _selective)
-    assert Command.check_url("http://example.com/") is True
-    # Both probes should have been attempted, in order.
-    assert called == [
-        "http://example.com/repodata/repomd.xml",
-        "http://example.com/suse/repodata/repomd.xml",
+    repos = [
+        _StubRepo("http://a/dead/"),
+        _StubRepo("http://b/live/"),
+        _StubRepo("http://c/dead/"),
+        _StubRepo("http://d/live/"),
     ]
+    live = cmd._filter_live_urls(repos)
+
+    # One probe per repo (parallelism doesn't change call count).
+    assert sorted(calls) == sorted(r.url for r in repos)
+    # Order preserved among survivors.
+    assert [r.url for r in live] == ["http://b/live/", "http://d/live/"]
 
 
-def test_check_url_short_circuits_on_first_success(monkeypatch):
-    """If the canonical repomd.xml answers we do not probe the fallback."""
-    called: list[str] = []
+def test_filter_live_urls_short_circuits_when_no_probe(monkeypatch):
+    """``--no-probe`` returns the list unchanged and never calls the
+    probe helper."""
+    calls: list[str] = []
 
-    def _ok(url):
-        called.append(url)
-        return MagicMock()
+    def _probe(url, *, timeout):
+        calls.append(url)
+        return False
 
-    monkeypatch.setattr(cmdmod, "urlopen", _ok)
-    assert Command.check_url("http://example.com/") is True
-    assert called == ["http://example.com/repodata/repomd.xml"]
+    monkeypatch.setattr(cmdmod, "check_repo_url", _probe)
+    cmd, _ = _make(monkeypatch, args_overrides={"no_probe": True})
+
+    repos = [_StubRepo("http://a/"), _StubRepo("http://b/")]
+    assert cmd._filter_live_urls(repos) == repos
+    assert calls == []
+
+
+def test_filter_live_urls_forwards_probe_timeout(monkeypatch):
+    """Custom ``--probe-timeout`` reaches the probe helper kwarg."""
+    seen: list[float] = []
+
+    def _probe(url, *, timeout):
+        seen.append(timeout)
+        return True
+
+    monkeypatch.setattr(cmdmod, "check_repo_url", _probe)
+    cmd, _ = _make(monkeypatch, args_overrides={"probe_timeout": 0.25})
+
+    cmd._filter_live_urls([_StubRepo("http://a/"), _StubRepo("http://b/")])
+    assert seen == [0.25, 0.25]
+
+
+def test_filter_live_urls_default_timeout_is_5_seconds(monkeypatch):
+    """Without an explicit flag the default 5s budget is used."""
+    seen: list[float] = []
+
+    def _probe(url, *, timeout):
+        seen.append(timeout)
+        return True
+
+    monkeypatch.setattr(cmdmod, "check_repo_url", _probe)
+    cmd, _ = _make(monkeypatch)
+
+    cmd._filter_live_urls([_StubRepo("http://a/")])
+    assert seen == [5.0]
+
+
+def test_filter_live_urls_empty_input_is_noop(monkeypatch):
+    """Empty input never spawns a pool or calls the probe helper."""
+    calls: list[str] = []
+
+    def _probe(url, *, timeout):
+        calls.append(url)
+        return True
+
+    monkeypatch.setattr(cmdmod, "check_repo_url", _probe)
+    cmd, _ = _make(monkeypatch)
+
+    assert cmd._filter_live_urls([]) == []
+    assert calls == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/command/test_install.py
+++ b/tests/command/test_install.py
@@ -61,6 +61,9 @@ def test_install_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
         MagicMock(return_value=mock_host_group_instance),
     )
     monkeypatch.setattr(Install, "repoq", mock_repoq)
+    monkeypatch.setattr(
+        repose.command._command, "check_repo_url", lambda url, *, timeout: True
+    )
 
     # Run
     install_command = Install(mock_args)
@@ -88,7 +91,7 @@ def test_install_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
     mock_host_group_instance.close.assert_called_once()
 
 
-def _setup_install(monkeypatch, args, repoq_solution, out=None):
+def _setup_install(monkeypatch, args, repoq_solution, out=None, probe=True):
     mock_repoq = MagicMock()
     mock_repoq.solve_repa.return_value = repoq_solution
 
@@ -106,6 +109,11 @@ def _setup_install(monkeypatch, args, repoq_solution, out=None):
         MagicMock(return_value=mock_hg),
     )
     monkeypatch.setattr(Install, "repoq", mock_repoq)
+    monkeypatch.setattr(
+        repose.command._command,
+        "check_repo_url",
+        lambda url, *, timeout: probe,
+    )
     return mock_target, mock_hg, mock_repoq
 
 
@@ -168,6 +176,31 @@ def test_install_command_no_products_logs_error(
     assert any("No products to install" in r.message for r in caplog.records)
 
 
+def test_install_command_dead_probe_skips_ar_but_runs_product_install(
+    monkeypatch, mock_args_and_repa, mock_ssh_client
+):
+    """New in PR 08: probes that fail filter out the ``ar`` command,
+    but the per-product ``in -t product`` step still runs (so a host
+    can still install the product from whatever repos zypper already
+    knows about)."""
+    args, _ = mock_args_and_repa
+
+    target, _, _ = _setup_install(
+        monkeypatch,
+        args,
+        {"product-to-install": [MockRepo("repo1", "http://dead", refresh=False)]},
+        probe=False,
+    )
+
+    assert Install(args).run() == 0
+
+    issued = [c.args[0] for c in target.run.call_args_list]
+    # ar suppressed by probe filter.
+    assert not any(cmd.startswith("zypper -n ar") for cmd in issued)
+    # Product install still issued.
+    assert any("in -t product" in cmd for cmd in issued)
+
+
 def test_install_command_solve_repa_value_error_logged(
     monkeypatch, mock_args_and_repa, caplog, mock_ssh_client
 ):
@@ -189,6 +222,9 @@ def test_install_command_solve_repa_value_error_logged(
         MagicMock(return_value=mock_hg),
     )
     monkeypatch.setattr(Install, "repoq", mock_repoq)
+    monkeypatch.setattr(
+        repose.command._command, "check_repo_url", lambda url, *, timeout: True
+    )
 
     with caplog.at_level("ERROR", logger="repose.command.install"):
         # solve_repa raises AND no products → exit 2.
@@ -231,6 +267,9 @@ def _setup_install_multi(monkeypatch, hosts):
         MagicMock(return_value=hg),
     )
     monkeypatch.setattr(Install, "repoq", mock_repoq)
+    monkeypatch.setattr(
+        repose.command._command, "check_repo_url", lambda url, *, timeout: True
+    )
     return targets, hg
 
 

--- a/tests/command/test_reset.py
+++ b/tests/command/test_reset.py
@@ -76,7 +76,9 @@ def test_reset_command_run(monkeypatch, mock_args, mock_ssh_client):
         MagicMock(return_value=mock_host_group_instance),
     )
     monkeypatch.setattr(Reset, "repoq", mock_repoq)
-    monkeypatch.setattr(Reset, "check_url", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        repose.command._command, "check_repo_url", lambda url, *, timeout: True
+    )
 
     # Instantiate and Run
     reset_command = Reset(mock_args)
@@ -110,7 +112,7 @@ def _setup_reset(
     repoq_solution=None,
     raw_repos=None,
     products=None,
-    check_url=True,
+    probe=True,
     solve_side_effect=None,
     out=None,
 ):
@@ -136,7 +138,11 @@ def _setup_reset(
         MagicMock(return_value=mock_hg),
     )
     monkeypatch.setattr(Reset, "repoq", mock_repoq)
-    monkeypatch.setattr(Reset, "check_url", MagicMock(return_value=check_url))
+    monkeypatch.setattr(
+        repose.command._command,
+        "check_repo_url",
+        lambda url, *, timeout: probe,
+    )
     return mock_target, mock_hg, mock_repoq
 
 
@@ -175,19 +181,19 @@ def test_reset_unsupported_product_logs_error(
     target.run.assert_not_called()
 
 
-def test_reset_check_url_false_skips_add(monkeypatch, mock_args, mock_ssh_client):
+def test_reset_dead_probe_skips_add(monkeypatch, mock_args, mock_ssh_client):
     target, _, _ = _setup_reset(
         monkeypatch,
         mock_args,
         repoq_solution={"product": [MockRepo("r1", "http://bad", refresh=False)]},
-        check_url=False,
+        probe=False,
     )
 
     # rr fires (and succeeds via _ok_out), no ar attempted → exit 0.
     assert Reset(mock_args).run() == 0
 
     issued = [c.args[0] for c in target.run.call_args_list]
-    # rr executed but no ar (filtered out by check_url=False)
+    # rr executed but no ar (filtered out by failing probe).
     assert any(c.startswith("zypper -n rr") for c in issued)
     assert not any(c.startswith("zypper -n ar") for c in issued)
 
@@ -222,7 +228,9 @@ def _setup_reset_multi(monkeypatch, hosts):
         MagicMock(return_value=hg),
     )
     monkeypatch.setattr(Reset, "repoq", mock_repoq)
-    monkeypatch.setattr(Reset, "check_url", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        repose.command._command, "check_repo_url", lambda url, *, timeout: True
+    )
     return targets, hg
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,12 @@ def mock_ssh_client(monkeypatch):
 class ImmediateExecutor:
     __name__ = "ImmediateExecutor"
 
+    def __init__(self, *args, **kwargs):
+        # Accept (and ignore) any ``ThreadPoolExecutor``-style kwargs
+        # so callers that pass ``max_workers=`` keep working under the
+        # stub.
+        pass
+
     def __enter__(self):
         return self
 
@@ -50,6 +56,11 @@ class ImmediateExecutor:
         except Exception as e:
             future.set_exception(e)
         return future
+
+    def map(self, fn, *iterables):
+        # Mirror ``Executor.map`` semantics enough for the production
+        # call sites: run sequentially, eagerly materialise results.
+        return [fn(*args) for args in zip(*iterables)]
 
     @staticmethod
     def wait(futures):

--- a/tests/test_argparsing.py
+++ b/tests/test_argparsing.py
@@ -181,3 +181,86 @@ def test_format_json_accepted(mock_types):
 def test_format_invalid_rejected(mock_types):
     with pytest.raises(SystemExit):
         get_parser().parse_args(["--format", "xml", "add", "-t", "h", "x"])
+
+
+# ---------------------------------------------------------------------------
+# Probe flags (PR 08): --probe-timeout / --no-probe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "subcmd, extra",
+    [
+        ("add", ["x"]),
+        ("install", ["x"]),
+        ("reset", []),
+    ],
+)
+def test_probe_timeout_default_is_5(mock_types, subcmd, extra):
+    args = get_parser().parse_args([subcmd, "-t", "h", *extra])
+    assert args.probe_timeout == 5.0
+
+
+@pytest.mark.parametrize(
+    "subcmd, extra",
+    [
+        ("add", ["x"]),
+        ("install", ["x"]),
+        ("reset", []),
+    ],
+)
+def test_probe_timeout_custom_value_is_float(mock_types, subcmd, extra):
+    args = get_parser().parse_args(
+        [subcmd, "-t", "h", "--probe-timeout", "0.25", *extra]
+    )
+    assert args.probe_timeout == 0.25
+    assert isinstance(args.probe_timeout, float)
+
+
+@pytest.mark.parametrize(
+    "subcmd, extra",
+    [
+        ("add", ["x"]),
+        ("install", ["x"]),
+        ("reset", []),
+    ],
+)
+def test_no_probe_default_is_false(mock_types, subcmd, extra):
+    args = get_parser().parse_args([subcmd, "-t", "h", *extra])
+    assert args.no_probe is False
+
+
+@pytest.mark.parametrize(
+    "subcmd, extra",
+    [
+        ("add", ["x"]),
+        ("install", ["x"]),
+        ("reset", []),
+    ],
+)
+def test_no_probe_flag_sets_true(mock_types, subcmd, extra):
+    args = get_parser().parse_args([subcmd, "-t", "h", "--no-probe", *extra])
+    assert args.no_probe is True
+
+
+@pytest.mark.parametrize(
+    "subcmd, cli_args",
+    [
+        ("clear", ["clear", "-t", "h"]),
+        ("known-products", ["known-products"]),
+        ("list-products", ["list-products", "-t", "h"]),
+        ("list-repos", ["list-repos", "-t", "h"]),
+        ("remove", ["remove", "-t", "h", "x"]),
+        ("uninstall", ["uninstall", "-t", "h", "x"]),
+    ],
+)
+def test_probe_flags_absent_from_non_probing_commands(mock_types, subcmd, cli_args):
+    """``--probe-timeout`` / ``--no-probe`` are scoped to add/reset/install
+    only; passing them to other subcommands errors out, and the parsed
+    namespace doesn't carry them."""
+    args = get_parser().parse_args(cli_args)
+    assert not hasattr(args, "probe_timeout")
+    assert not hasattr(args, "no_probe")
+
+    with pytest.raises(SystemExit):
+        get_parser().parse_args([*cli_args, "--no-probe"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 """Tests for ``repose.utils``."""
 
 import io
+from unittest.mock import MagicMock
+from urllib.error import HTTPError, URLError
 
 import repose.utils
 
@@ -59,3 +61,100 @@ def test_tty_stdout_enables_colors(monkeypatch):
 
     monkeypatch.setattr(repose.utils.sys, "stdout", FakeTTY())
     assert "\033[1;34m" in repose.utils.blue("x")
+
+
+# ---------------------------------------------------------------------------
+# check_repo_url
+# ---------------------------------------------------------------------------
+
+
+def test_check_repo_url_returns_true_when_primary_opens(monkeypatch):
+    """Canonical ``repodata/repomd.xml`` answers -> True, no fallback."""
+    called: list[str] = []
+
+    def _ok(url, timeout):
+        called.append(url)
+        return MagicMock()
+
+    monkeypatch.setattr(repose.utils, "urlopen", _ok)
+    assert repose.utils.check_repo_url("http://example.com/") is True
+    assert called == ["http://example.com/repodata/repomd.xml"]
+
+
+def test_check_repo_url_falls_back_to_suse_layout(monkeypatch):
+    """Primary 404s, ``suse/repodata/repomd.xml`` answers -> True."""
+    called: list[str] = []
+
+    def _selective(url, timeout):
+        called.append(url)
+        if "suse/repodata/repomd.xml" in url:
+            return MagicMock()
+        raise URLError("not at root")
+
+    monkeypatch.setattr(repose.utils, "urlopen", _selective)
+    assert repose.utils.check_repo_url("http://example.com/") is True
+    assert called == [
+        "http://example.com/repodata/repomd.xml",
+        "http://example.com/suse/repodata/repomd.xml",
+    ]
+
+
+def test_check_repo_url_returns_false_when_both_fail_urlerror(monkeypatch):
+    def _raise(url, timeout):
+        raise URLError("nope")
+
+    monkeypatch.setattr(repose.utils, "urlopen", _raise)
+    assert repose.utils.check_repo_url("http://example.com/") is False
+
+
+def test_check_repo_url_returns_false_on_http_error(monkeypatch):
+    def _raise(url, timeout):
+        raise HTTPError(url, 404, "not found", {}, None)
+
+    monkeypatch.setattr(repose.utils, "urlopen", _raise)
+    assert repose.utils.check_repo_url("http://example.com/") is False
+
+
+def test_check_repo_url_returns_false_on_timeout(monkeypatch):
+    """A ``TimeoutError`` raised by ``urlopen`` is caught, not propagated."""
+
+    def _raise(url, timeout):
+        raise TimeoutError("slow")
+
+    monkeypatch.setattr(repose.utils, "urlopen", _raise)
+    assert repose.utils.check_repo_url("http://example.com/") is False
+
+
+def test_check_repo_url_returns_false_on_oserror(monkeypatch):
+    """OSError (e.g. socket refused) is caught, not propagated."""
+
+    def _raise(url, timeout):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(repose.utils, "urlopen", _raise)
+    assert repose.utils.check_repo_url("http://example.com/") is False
+
+
+def test_check_repo_url_default_timeout_is_5_seconds(monkeypatch):
+    seen: list[float] = []
+
+    def _capture(url, timeout):
+        seen.append(timeout)
+        return MagicMock()
+
+    monkeypatch.setattr(repose.utils, "urlopen", _capture)
+    repose.utils.check_repo_url("http://example.com/")
+    assert seen == [5.0]
+
+
+def test_check_repo_url_custom_timeout_is_forwarded(monkeypatch):
+    seen: list[float] = []
+
+    def _capture(url, timeout):
+        seen.append(timeout)
+        raise URLError("first fails to force second attempt")
+
+    monkeypatch.setattr(repose.utils, "urlopen", _capture)
+    repose.utils.check_repo_url("http://example.com/", timeout=0.5)
+    # Both probes attempted, both saw the custom timeout.
+    assert seen == [0.5, 0.5]


### PR DESCRIPTION
## Summary

`Command.check_url` probed 1–2 URLs serially per repository, inside each per-host worker thread, with no socket timeout. A black-holed mirror could hang a worker indefinitely; even healthy-but-slow mirrors serialised the cohort into tens of seconds of probe wall time.

This PR fans the probes out via a bounded `ThreadPoolExecutor`, adds an explicit 5-second per-probe timeout, and gives operators two new flags on the probing subcommands:

- `--probe-timeout SECONDS` (default `5`)
- `--no-probe` (skip the probe phase entirely)

Probe wall time now scales with `max(per-probe latency)` instead of `sum(per-probe latency)`.

## Changes

### Production
- **`repose/utils.py`** — new `check_repo_url(url, *, timeout=5.0) -> bool`. Tries `repodata/repomd.xml` then `suse/repodata/repomd.xml`. Catches `HTTPError`, `URLError`, `TimeoutError`, `OSError`.
- **`repose/command/_command.py`** — dropped static `Command.check_url`; added instance method `_filter_live_urls()` (parallel probe, bounded pool of 16, preserves input order). New `self.probe_timeout` / `self.no_probe` fields plumbed from the parser.
- **`repose/command/add.py`**, **`repose/command/reset.py`** — replaced inline serial `if self.check_url(x.url)` with `live = self._filter_live_urls(repolist)`.
- **`repose/command/install.py`** — **new behavior**: install now probes too. Repos with dead mirrors are skipped from `zypper ar`, but the per-product `in -t product` step still runs so a host can install the product from whatever zypper already knows about.
- **`repose/argparsing.py`** — new `\"probe\"` token in `add_subparser` adds the two flags. Wired into `add`, `install`, `reset` only.

### Tests
- 27 new tests; 320 total (was 293). 100% coverage on `repose/utils.py`; 93% overall.
- `tests/conftest.py::ImmediateExecutor` now accepts arbitrary kwargs and implements `map()` so production code using `ThreadPoolExecutor(max_workers=...).map(...)` keeps working under monkeypatching.
- All `monkeypatch.setattr(<Cmd>, \"check_url\", ...)` sites rewritten to patch `repose.command._command.check_repo_url`.

## Behaviour changes worth release-noting

1. **`urlopen` now has a 5-second default timeout** (was unlimited). Black-holed mirrors no longer hang forever. Tunable via `--probe-timeout`.
2. **`install` now skips `zypper ar` for unreachable repos** (previously added them regardless). The product-install step is unchanged.
3. **New flags** `--probe-timeout SECONDS` and `--no-probe` are available on `add`, `install`, `reset`. Absent from `clear`, `remove`, `uninstall`, `list-*`, `known-products`.

## Verification

\`\`\`
\$ python3 -m pytest -q
320 passed in 0.39s
\$ ruff format --diff .
65 files already formatted
\$ ruff check .
All checks passed!
\$ grep -rn check_url repose/ tests/ --include='*.py'
(no hits)
\`\`\`

CLI surface (backward-compatible — flags are additive, default to current behaviour):
\`\`\`
\$ repose add --help     | grep -E 'probe|timeout'
  --probe-timeout SECONDS
                        seconds to wait per repository URL probe (default: 5)
  --no-probe            skip repository URL liveness probes
\`\`\`

## Plan

Implements [`plans/PLAN-PR-08-parallel-check-url.md`](https://github.com/mimi1vx/repose/blob/plan_9/plans/PLAN-PR-08-parallel-check-url.md) with two corrections to the original spec:
- `Reset._add` was the third call site of `check_url` (spec missed it) — included.
- `Install._run` did NOT call `check_url` today (spec was wrong about that) — adding probe filtering there is a deliberate new behavior, documented above.