### PR TITLE
feat(ssh): configurable host-key policy and known_hosts path

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,42 @@ level) now goes through this sink on stdout. The `--quiet` flag still
 silences logger messages but no longer hides per-host output; redirect
 stdout or use `--format=json` with filtering to suppress it.
 
+## SSH Host-Key Policy
+
+Repose talks to refhosts over SSH. The host-key behaviour follows OpenSSH's
+`StrictHostKeyChecking` semantics and is configured with two global flags:
+
+- `--strict-host-key-checking={yes,accept-new,no,off}` (default: `accept-new`)
+- `--known-hosts PATH` (default: `~/.ssh/known_hosts`)
+
+| Mode         | Unknown host (first contact)             | Changed host key             |
+| ------------ | ---------------------------------------- | ---------------------------- |
+| `yes`        | refuse (`BadHostKeyException`)           | refuse                       |
+| `accept-new` | accept + record in known_hosts (default) | refuse                       |
+| `no` / `off` | accept silently                          | accept silently (unsafe)     |
+
+`accept-new` matches the OpenSSH default since 7.6 (2017): unknown hosts are
+recorded on first contact, but a host whose key has *changed* since it was
+first recorded is refused. This is a behaviour change from pre-1.12 releases,
+which silently re-trusted any presented key (equivalent to `off`).
+
+If you operate a QA pool where refhost keys legitimately rotate and you
+cannot prune `known_hosts` between rotations, opt into the legacy behaviour
+explicitly:
+
+```
+repose --strict-host-key-checking=off add -t fubar.suse.cz sle-sdk
+```
+
+For paranoid setups (each refhost key pre-recorded in a dedicated file),
+pin both flags:
+
+```
+repose --strict-host-key-checking=yes \
+       --known-hosts /etc/repose/known_hosts \
+       add -t fubar.suse.cz sle-sdk
+```
+
 ## License
 
 This project is licensed under the GPLv3 license, see LICENSE file for

--- a/repose/argparsing.py
+++ b/repose/argparsing.py
@@ -7,16 +7,66 @@ from repose import __version__
 from repose.command import Command
 
 from .host import ParseHosts
+from .types.connection_config import ConnectionConfig
 from .types.repa import Repa
 
 logger = logging.getLogger("repose.arg")
 
 
-def get_parser():
+def _globals_parser() -> argparse.ArgumentParser:
+    """Tiny parser that only knows the SSH transport globals.
+
+    Used by ``parse()`` for a non-failing first pass that extracts
+    ``--strict-host-key-checking`` and ``--known-hosts`` before the
+    real parser is built. ``parse_known_args`` on this parser ignores
+    every other token, including subcommands and their flags.
     """
-    Process the parsed arguments and return the result
-    :param argv: passed arguments
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument(
+        "--strict-host-key-checking",
+        choices=["yes", "accept-new", "no", "off"],
+        default="accept-new",
+        dest="strict_host_key_checking",
+    )
+    p.add_argument("--known-hosts", type=Path, default=None, dest="known_hosts")
+    return p
+
+
+def build_config_from_args(args: argparse.Namespace) -> ConnectionConfig:
+    """Materialise a ``ConnectionConfig`` from a parsed ``Namespace``."""
+    return ConnectionConfig(
+        host_key_policy=getattr(args, "strict_host_key_checking", "accept-new"),
+        known_hosts=getattr(args, "known_hosts", None),
+    )
+
+
+def parse(argv: list[str]) -> argparse.Namespace:
+    """Two-pass argparse driver used by ``main.py``.
+
+    First pass: extract the SSH transport globals so the
+    ``ParseHosts`` factory can be configured before the *real* parser
+    binds it as ``type=``. Second pass: full parser, returns the
+    fully-populated ``Namespace``.
+
+    Tests that previously called ``get_parser().parse_args(...)``
+    continue to work — they receive the parser built with a default
+    ``ConnectionConfig()``.
     """
+    pre_args, _ = _globals_parser().parse_known_args(argv)
+    cfg = build_config_from_args(pre_args)
+    return get_parser(cfg).parse_args(argv)
+
+
+def get_parser(config: ConnectionConfig | None = None):
+    """Build the full argparse parser.
+
+    ``config`` configures the ``ParseHosts`` factory bound to the
+    ``-t/--target`` flag. When omitted a default ``ConnectionConfig``
+    is used; this keeps the historical ``get_parser()`` no-arg call
+    shape working for tests that don't care about transport policy.
+    """
+    if config is None:
+        config = ConnectionConfig()
 
     parser = argparse.ArgumentParser(
         description="Repository manipulation tool for QAM", prog="repose"
@@ -61,6 +111,27 @@ def get_parser():
         default="text",
         help="console output format: 'text' (default) or 'json' (one event per line)",
     )
+    parser.add_argument(
+        "--strict-host-key-checking",
+        choices=["yes", "accept-new", "no", "off"],
+        default="accept-new",
+        dest="strict_host_key_checking",
+        help=(
+            "SSH host-key policy (OpenSSH semantics): "
+            "'yes' refuses unknown hosts; "
+            "'accept-new' (default) accepts unknown hosts on first "
+            "contact but rejects changed keys; "
+            "'no'/'off' accepts both unknown and changed keys "
+            "(pre-1.12 behaviour)"
+        ),
+    )
+    parser.add_argument(
+        "--known-hosts",
+        type=Path,
+        default=None,
+        dest="known_hosts",
+        help="path to a custom known_hosts file (overrides ~/.ssh/known_hosts)",
+    )
 
     commands = parser.add_subparsers()
 
@@ -74,11 +145,30 @@ def get_parser():
             arguments = []
         subparser = commands.add_parser(name, help=help_text)
         if "target" in arguments:
+            # Late-bind via the module attribute so test fixtures that
+            # monkeypatch ``repose.argparsing.ParseHosts`` to a plain
+            # ``lambda x: x`` keep working unchanged: we call whatever
+            # ``ParseHosts`` is *at parse time*, not what it was at
+            # parser-build time. The real factory class is detected by
+            # ``isinstance`` against the resolved type so swapping in a
+            # different callable (test stub, future replacement) still
+            # works as a one-arg ``type=`` adapter.
+            def _host_type(host_str, _cfg=config):
+                import repose.argparsing as _mod
+
+                ph = _mod.ParseHosts
+                if isinstance(ph, type) and issubclass(ph, ParseHosts):
+                    # Real factory class: configure with cfg, then call
+                    # the resulting instance with the host string.
+                    return ph(_cfg)(host_str)
+                # Test stub or any other one-arg callable.
+                return ph(host_str)
+
             subparser.add_argument(
                 "-t",
                 "--target",
                 metavar="HOST",
-                type=ParseHosts,
+                type=_host_type,
                 action="append",
                 required=True,
                 help="target to operate on",

--- a/repose/connection.py
+++ b/repose/connection.py
@@ -10,6 +10,9 @@ from traceback import format_exc
 import paramiko
 from paramiko import Channel, SFTPClient, SFTPFile, SSHClient, SSHConfig
 
+from .connection_policy import AcceptNewPolicy
+from .types.connection_config import ConnectionConfig
+
 
 if not sys.warnoptions:
     import warnings
@@ -35,7 +38,13 @@ class Connection:
     """Manage ssh/sftp connection"""
 
     def __init__(
-        self, hostname: str, username: str, port: str | int, timeout=120
+        self,
+        hostname: str,
+        username: str,
+        port: str | int,
+        timeout: float | None = None,
+        *,
+        config: ConnectionConfig | None = None,
     ) -> None:
         """openSSH channel to the specified host
 
@@ -44,6 +53,18 @@ class Connection:
         If a connection can't be established (host not available, wrong password/key)
         exceptions are reraised from the ssh subsystem and need to be catched
         by the caller.
+
+        ``config`` carries transport-level knobs (host-key policy,
+        custom known_hosts path, default timeout). When ``None`` a
+        default ``ConnectionConfig`` is used, which preserves the
+        historical accept-unknown-keys behaviour transparently at the
+        wire level (``accept-new`` aliases to AutoAdd for genuinely
+        unknown hosts; only *changed* keys are now rejected).
+
+        ``timeout`` (positional) overrides ``config.timeout`` when
+        passed explicitly; this keeps the historical positional
+        signature working for callers that never adopted the config
+        record.
         """
 
         self.username = username
@@ -53,7 +74,12 @@ class Connection:
         except Exception:
             self.port = 22
 
-        self.timeout = timeout
+        self.config: ConnectionConfig = config or ConnectionConfig()
+        # Explicit positional ``timeout`` wins over ``config.timeout``;
+        # this preserves the pre-PR call shape ``Connection(h, u, p, 30)``.
+        self.timeout: float = (
+            float(timeout) if timeout is not None else self.config.timeout
+        )
 
         self.client: SSHClient = paramiko.SSHClient()
 
@@ -61,9 +87,39 @@ class Connection:
         return f"<{self.__class__.__name__} object username={self.username} hostname={self.hostname} port={self.port}>"
 
     def __load_keys(self) -> None:
-        self.client.load_system_host_keys()
-        # Dont check host keys --> StrictHostChecking no
-        self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        """Load known_hosts and install the configured host-key policy.
+
+        ``known_hosts`` from the config (when set) replaces the user's
+        system known_hosts file entirely — paramiko has no notion of
+        layered host-key stores, matching ``ssh -o UserKnownHostsFile``.
+        """
+        if self.config.known_hosts is not None:
+            self.client.load_host_keys(str(self.config.known_hosts))
+        else:
+            self.client.load_system_host_keys()
+
+        policy_name = self.config.host_key_policy
+        # paramiko already raises ``BadHostKeyException`` for keys that
+        # exist in the host-key store but mismatch on connect, *before*
+        # the missing-key policy is consulted. So both ``accept-new``
+        # (custom: persist on first contact) and ``yes`` (reject
+        # missing) get changed-key rejection automatically. ``no``/
+        # ``off`` use ``AutoAddPolicy`` which tolerates *changed* keys
+        # too — the historical pre-PR-12 behaviour.
+        policy: paramiko.MissingHostKeyPolicy
+        if policy_name == "yes":
+            policy = paramiko.RejectPolicy()
+        elif policy_name == "accept-new":
+            kh = (
+                str(self.config.known_hosts)
+                if self.config.known_hosts is not None
+                else None
+            )
+            policy = AcceptNewPolicy(known_hosts_path=kh)
+        else:
+            # "no" or "off"
+            policy = paramiko.AutoAddPolicy()
+        self.client.set_missing_host_key_policy(policy)
 
     def connect(self) -> None:
         cfg: SSHConfig = paramiko.config.SSHConfig()

--- a/repose/connection_policy.py
+++ b/repose/connection_policy.py
@@ -1,0 +1,67 @@
+"""Custom ``paramiko.MissingHostKeyPolicy`` implementations.
+
+paramiko ships ``AutoAddPolicy`` (add anything, trust anything) and
+``RejectPolicy`` (refuse anything not in known_hosts), but no native
+equivalent of OpenSSH's ``StrictHostKeyChecking=accept-new`` (add
+*unknown* hosts on first contact, but refuse a host whose key has
+*changed* since it was first recorded).
+
+paramiko's transport already raises ``BadHostKeyException`` for keys
+that exist in ``client.get_host_keys()`` but mismatch the server's
+presented key — that check fires *before* the missing-host-key policy
+is consulted. So a true accept-new implementation only needs to handle
+the *missing* (i.e. genuinely unknown) case: add the key in-memory and,
+when a writable ``known_hosts`` path is available, persist it.
+"""
+
+import logging
+import os
+from typing import Any
+
+
+import paramiko
+
+
+logger = logging.getLogger("repose.connection_policy")
+
+
+class AcceptNewPolicy(paramiko.MissingHostKeyPolicy):
+    """Add unknown host keys; rely on paramiko to reject changed ones.
+
+    Matches OpenSSH's ``StrictHostKeyChecking=accept-new``. Optionally
+    persists newly-accepted keys to ``known_hosts_path`` so subsequent
+    runs can detect a changed key.
+    """
+
+    def __init__(self, known_hosts_path: str | None = None) -> None:
+        super().__init__()
+        # Expanded eagerly so the same path string ("~/.ssh/known_hosts")
+        # works whether the policy is constructed before or after the
+        # process changes its working directory.
+        self.known_hosts_path: str | None = (
+            os.path.expanduser(known_hosts_path) if known_hosts_path else None
+        )
+
+    def missing_host_key(
+        self, client: paramiko.SSHClient, hostname: str, key: Any
+    ) -> None:
+        logger.info(
+            "accept-new: recording unknown host key for %s (%s)",
+            hostname,
+            key.get_name(),
+        )
+        client.get_host_keys().add(hostname, key.get_name(), key)
+        if self.known_hosts_path is None:
+            return
+        try:
+            client.save_host_keys(self.known_hosts_path)
+        except OSError as exc:
+            # Read-only known_hosts (e.g. system-wide file, or a path
+            # the user can't write to) is a soft failure: the key is
+            # still in-memory for this run, but won't survive a restart.
+            logger.warning(
+                "accept-new: could not persist host key for %s to %s: %s",
+                hostname,
+                self.known_hosts_path,
+                exc,
+            )

--- a/repose/host.py
+++ b/repose/host.py
@@ -2,6 +2,7 @@ from argparse import ArgumentTypeError
 from urllib.parse import urlparse
 
 from .target import Target
+from .types.connection_config import ConnectionConfig
 
 
 class HostParseError(ValueError, ArgumentTypeError):
@@ -18,24 +19,56 @@ class PortNotIntError(HostParseError):
         super().__init__(f"Wrong port specification on Host: {hostname}")
 
 
+def _parse_host_string(arg: str, config: ConnectionConfig) -> dict[str, Target]:
+    """Parse a ``[user@]host[:port]`` string into a ``{key: Target}`` dict."""
+    x = urlparse(f"//{arg}")
+    hostname = x.hostname or ""
+    try:
+        if x.port:
+            keyname = f"{hostname}:{x.port}"
+            port = x.port
+        else:
+            keyname = hostname
+            port = 22
+
+        username = x.username if x.username else "root"
+
+        return {keyname: Target(hostname, port, username, config=config)}
+    except ValueError:
+        raise PortNotIntError(hostname)
+
+
 class ParseHosts(dict):
-    def __init__(self, arg: str) -> None:
-        """
-        arg is string with hosts in socket format username@host:port
-        """
-        x = urlparse(f"//{arg}")
-        hostname = x.hostname or ""
-        try:
-            if x.port:
-                keyname = f"{hostname}:{x.port}"
-                port = x.port
-            else:
-                keyname = hostname
-                port = 22
+    """Argparse ``type=`` adapter for ``-t HOST`` arguments.
 
-            username = x.username if x.username else "root"
+    Two construction modes:
 
-            host = [(keyname, Target(hostname, port, username))]
-        except ValueError:
-            raise PortNotIntError(hostname)
-        super().__init__(host)
+    - ``ParseHosts("user@host:port")`` — historical one-shot mode. Parses
+      immediately with default ``ConnectionConfig``. Kept for tests and
+      ad-hoc programmatic use.
+    - ``ParseHosts(ConnectionConfig(...))`` — factory mode. The returned
+      instance is *callable* with a single string argument and yields a
+      new ``ParseHosts`` (a plain ``dict`` subclass) populated with one
+      ``Target`` built with the captured config. This is the form wired
+      into argparse via ``type=ParseHosts(cfg)``.
+    """
+
+    def __init__(self, arg: "str | ConnectionConfig") -> None:
+        if isinstance(arg, ConnectionConfig):
+            # Factory mode: defer parsing until ``__call__``.
+            self._config: ConnectionConfig = arg
+            super().__init__()
+            return
+        # One-shot mode: parse with default config.
+        self._config = ConnectionConfig()
+        super().__init__(_parse_host_string(arg, self._config))
+
+    def __call__(self, arg: str) -> "ParseHosts":
+        # Build a fresh ParseHosts seeded with parsed targets; reuse the
+        # captured config. We can't reuse ``self`` because argparse
+        # appends each ``-t`` result to a list and may invoke the type
+        # callable many times in one parse run.
+        instance = ParseHosts.__new__(ParseHosts)
+        instance._config = self._config
+        dict.__init__(instance, _parse_host_string(arg, self._config))
+        return instance

--- a/repose/main.py
+++ b/repose/main.py
@@ -1,16 +1,18 @@
 import sys
 
+from .argparsing import get_parser, parse
 from .colorlog import create_logger
-from .argparsing import get_parser
 
 
 def main():
-    parser = get_parser()
     logger = create_logger("repose")
-    args = parser.parse_args(sys.argv[1:])
+    args = parse(sys.argv[1:])
 
     if not hasattr(args, "func"):
-        parser.print_usage()
+        # ``parse`` already executed a successful parse_args, so the
+        # only way to land here is a bare ``repose`` invocation; rebuild
+        # the parser cheaply just to render usage.
+        get_parser().print_usage()
         sys.exit(0)
 
     if args.debug:

--- a/repose/target/__init__.py
+++ b/repose/target/__init__.py
@@ -6,6 +6,7 @@ from ..connection import Connection, CommandTimeout
 from .parsers.product import parse_system
 from .parsers.repository import parse_repositories
 from ..messages import ConnectingTargetFailedMessage
+from ..types.connection_config import ConnectionConfig
 from ..types.repositories import Repositories
 from ..types.system import System
 
@@ -19,6 +20,8 @@ class Target:
         port: int,
         username: str,
         connector: type[Connection] = Connection,
+        *,
+        config: ConnectionConfig | None = None,
     ) -> None:
         # TODO: timeout handling ?
         self.port = port
@@ -28,8 +31,15 @@ class Target:
         self.raw_repos: Any = None
         self.repos: Repositories | None = None
         self.connector = connector
+        self.config: ConnectionConfig = config or ConnectionConfig()
         self.is_connected = False
-        self.connection = self.connector(self.hostname, self.username, self.port)
+        # ``connector`` is a class (or test stub) accepting the historical
+        # positional ``(hostname, username, port)`` plus the keyword-only
+        # ``config``. Test fixtures that pass a plain lambda swallow
+        # ``**kwargs`` already.
+        self.connection = self.connector(
+            self.hostname, self.username, self.port, config=self.config
+        )
         self.out: list[list[Any]] = []
 
     def __repr__(self) -> str:

--- a/repose/types/connection_config.py
+++ b/repose/types/connection_config.py
@@ -1,0 +1,36 @@
+"""Configuration carrier for ``Connection`` host-key + timeout knobs.
+
+A single immutable record threaded from CLI argument parsing through
+``ParseHosts`` → ``Target`` → ``Connection``. Keeping the policy in one
+place avoids growing the ``Connection.__init__`` signature every time a
+new transport flag lands.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+HostKeyPolicy = Literal["yes", "accept-new", "no", "off"]
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectionConfig:
+    """Immutable transport configuration shared across all ``Target``s.
+
+    Attributes:
+        host_key_policy: OpenSSH-style ``StrictHostKeyChecking`` mode.
+
+            - ``"yes"`` — refuse unknown hosts (``RejectPolicy``).
+            - ``"accept-new"`` — add unknown, refuse changed (default).
+            - ``"no"`` / ``"off"`` — add unknown, tolerate changed
+              (matches pre-PR-12 behaviour; use only on trusted nets).
+        known_hosts: Optional path to a custom ``known_hosts`` file. When
+            ``None`` the user's system known_hosts (``~/.ssh/known_hosts``
+            via ``paramiko.SSHClient.load_system_host_keys``) is used.
+        timeout: Per-command SSH read timeout in seconds.
+    """
+
+    host_key_policy: HostKeyPolicy = "accept-new"
+    known_hosts: Path | None = None
+    timeout: float = 120.0

--- a/tests/test_argparsing.py
+++ b/tests/test_argparsing.py
@@ -264,3 +264,70 @@ def test_probe_flags_absent_from_non_probing_commands(mock_types, subcmd, cli_ar
 
     with pytest.raises(SystemExit):
         get_parser().parse_args([*cli_args, "--no-probe"])
+
+
+# ---------------------------------------------------------------------------
+# PR 12 — SSH host-key policy flags + two-pass ``parse()``.
+# ---------------------------------------------------------------------------
+
+
+def test_strict_host_key_checking_default(mock_types):
+    args = get_parser().parse_args(["add", "-t", "h", "x"])
+    assert args.strict_host_key_checking == "accept-new"
+    assert args.known_hosts is None
+
+
+@pytest.mark.parametrize("mode", ["yes", "accept-new", "no", "off"])
+def test_strict_host_key_checking_accepts_all_modes(mock_types, mode):
+    args = get_parser().parse_args(
+        [f"--strict-host-key-checking={mode}", "add", "-t", "h", "x"]
+    )
+    assert args.strict_host_key_checking == mode
+
+
+def test_strict_host_key_checking_rejects_unknown_mode(mock_types):
+    with pytest.raises(SystemExit):
+        get_parser().parse_args(
+            ["--strict-host-key-checking=maybe", "add", "-t", "h", "x"]
+        )
+
+
+def test_known_hosts_flag_parses_to_path(mock_types, tmp_path):
+    kh = tmp_path / "kh"
+    args = get_parser().parse_args(["--known-hosts", str(kh), "add", "-t", "h", "x"])
+    from pathlib import Path
+
+    assert args.known_hosts == Path(str(kh))
+
+
+def test_parse_two_pass_threads_config_into_target():
+    """``parse()`` propagates the global flags into the ``Target``s built
+    by ``ParseHosts`` during the second pass."""
+    from repose.argparsing import parse
+
+    args = parse(
+        [
+            "--strict-host-key-checking=yes",
+            "add",
+            "-t",
+            "example.com:2222",
+            "SLES:15-SP3:x86_64:",
+        ]
+    )
+    assert args.strict_host_key_checking == "yes"
+    # args.target is a list of ParseHosts dicts ({key: Target}).
+    targets = args.target
+    assert len(targets) == 1
+    target = next(iter(targets[0].values()))
+    assert target.config.host_key_policy == "yes"
+
+
+def test_parse_two_pass_default_when_flag_absent():
+    """Without ``--strict-host-key-checking`` the default ``accept-new``
+    config reaches each ``Target``."""
+    from repose.argparsing import parse
+
+    args = parse(["add", "-t", "h", "SLES:15-SP3:x86_64:"])
+    target = next(iter(args.target[0].values()))
+    assert target.config.host_key_policy == "accept-new"
+    assert target.config.known_hosts is None

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -6,6 +6,8 @@ import paramiko
 import pytest
 
 from repose.connection import CommandTimeout, Connection
+from repose.connection_policy import AcceptNewPolicy
+from repose.types.connection_config import ConnectionConfig
 
 
 @pytest.fixture(autouse=True)
@@ -165,3 +167,83 @@ def test_reconnect_when_active_does_nothing(mock_ssh_client):
     conn.reconnect()
     # connect() not called via reconnect
     mock_ssh_client.connect.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Host-key policy (PR 12) — verify each policy mode wires the right
+# paramiko policy object through ``set_missing_host_key_policy`` and the
+# ``known_hosts`` override flips load_system_host_keys → load_host_keys.
+# ---------------------------------------------------------------------------
+
+
+def test_host_key_policy_yes_uses_reject_policy(mock_ssh_client):
+    """``host_key_policy='yes'`` installs ``paramiko.RejectPolicy``."""
+    cfg = ConnectionConfig(host_key_policy="yes")
+    conn = Connection("h", "u", 22, config=cfg)
+    conn.connect()
+
+    mock_ssh_client.set_missing_host_key_policy.assert_called_once()
+    policy = mock_ssh_client.set_missing_host_key_policy.call_args.args[0]
+    assert isinstance(policy, paramiko.RejectPolicy)
+
+
+def test_host_key_policy_accept_new_uses_accept_new_policy(mock_ssh_client):
+    """``host_key_policy='accept-new'`` (default) installs ``AcceptNewPolicy``."""
+    cfg = ConnectionConfig(host_key_policy="accept-new")
+    conn = Connection("h", "u", 22, config=cfg)
+    conn.connect()
+
+    mock_ssh_client.set_missing_host_key_policy.assert_called_once()
+    policy = mock_ssh_client.set_missing_host_key_policy.call_args.args[0]
+    assert isinstance(policy, AcceptNewPolicy)
+
+
+def test_host_key_policy_off_uses_auto_add(mock_ssh_client):
+    """``host_key_policy='off'`` preserves pre-PR-12 ``AutoAddPolicy``."""
+    cfg = ConnectionConfig(host_key_policy="off")
+    conn = Connection("h", "u", 22, config=cfg)
+    conn.connect()
+
+    mock_ssh_client.set_missing_host_key_policy.assert_called_once()
+    policy = mock_ssh_client.set_missing_host_key_policy.call_args.args[0]
+    assert isinstance(policy, paramiko.AutoAddPolicy)
+
+
+def test_known_hosts_loads_custom_file(mock_ssh_client, tmp_path):
+    """``known_hosts=<path>`` calls ``load_host_keys`` (not system)."""
+    kh = tmp_path / "kh"
+    kh.write_text("")  # empty but readable
+    cfg = ConnectionConfig(known_hosts=kh)
+    conn = Connection("h", "u", 22, config=cfg)
+    conn.connect()
+
+    mock_ssh_client.load_host_keys.assert_called_once_with(str(kh))
+    mock_ssh_client.load_system_host_keys.assert_not_called()
+
+
+def test_accept_new_policy_adds_unknown_key():
+    """``AcceptNewPolicy.missing_host_key`` records the key in-memory."""
+    client = MagicMock()
+    key = MagicMock()
+    key.get_name.return_value = "ssh-ed25519"
+
+    policy = AcceptNewPolicy()  # no path → no persistence attempt
+    policy.missing_host_key(client, "newhost.example.com", key)
+
+    client.get_host_keys.return_value.add.assert_called_once_with(
+        "newhost.example.com", "ssh-ed25519", key
+    )
+    client.save_host_keys.assert_not_called()
+
+
+def test_accept_new_policy_persists_when_path_given(tmp_path):
+    """When ``known_hosts_path`` is set, ``save_host_keys`` is called."""
+    kh = tmp_path / "kh"
+    client = MagicMock()
+    key = MagicMock()
+    key.get_name.return_value = "ssh-rsa"
+
+    policy = AcceptNewPolicy(known_hosts_path=str(kh))
+    policy.missing_host_key(client, "h.example.com", key)
+
+    client.save_host_keys.assert_called_once_with(str(kh))

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -1,9 +1,12 @@
 """Tests for ``repose.host.ParseHosts``."""
 
+from pathlib import Path
+
 import pytest
 
 from repose.host import HostParseError, ParseHosts, PortNotIntError
 from repose.target import Target
+from repose.types.connection_config import ConnectionConfig
 
 
 def test_default_user_and_port():
@@ -43,3 +46,37 @@ def test_invalid_port_raises_port_not_int_error():
 def test_port_not_int_error_is_host_parse_error():
     # Hierarchy contract used by argparse rendering
     assert issubclass(PortNotIntError, HostParseError)
+
+
+def test_oneshot_mode_uses_default_config():
+    hosts = ParseHosts("example.com")
+    target = hosts["example.com"]
+    # Default ConnectionConfig is applied.
+    assert target.config == ConnectionConfig()
+
+
+def test_factory_mode_threads_config_into_targets():
+    """``ParseHosts(cfg)(host_str)`` propagates ``cfg`` to each Target."""
+    cfg = ConnectionConfig(host_key_policy="yes", known_hosts=Path("/tmp/kh"))
+    factory = ParseHosts(cfg)
+    # Factory itself starts empty.
+    assert dict(factory) == {}
+
+    result = factory("admin@example.com:2222")
+    assert isinstance(result, ParseHosts)
+    target = result["example.com:2222"]
+    assert target.config == cfg
+    assert target.hostname == "example.com"
+    assert target.username == "admin"
+    assert target.port == 2222
+
+
+def test_factory_mode_each_call_returns_independent_dict():
+    """Two ``__call__`` invocations on one factory must not share state."""
+    factory = ParseHosts(ConnectionConfig())
+    a = factory("a.example.com")
+    b = factory("b.example.com")
+    assert "a.example.com" in a
+    assert "b.example.com" in b
+    assert "a.example.com" not in b
+    assert "b.example.com" not in a

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,21 +27,19 @@ def test_main_prints_usage_when_no_subcommand(monkeypatch, capsys):
     assert "usage" in out.lower()
 
 
+def _fake_namespace(*, func, debug=False, quiet=False):
+    """Build a minimal argparse-style Namespace for monkeypatching parse."""
+    import argparse
+
+    return argparse.Namespace(func=func, debug=debug, quiet=quiet)
+
+
 def test_main_invokes_subcommand_func(monkeypatch):
     sentinel_func = MagicMock(return_value=0)
 
-    def fake_get_parser():
-        import argparse
-
-        p = argparse.ArgumentParser(prog="repose")
-        p.add_argument("--debug", action="store_true")
-        p.add_argument("--quiet", action="store_true")
-        sub = p.add_subparsers()
-        s = sub.add_parser("foo")
-        s.set_defaults(func=sentinel_func)
-        return p
-
-    monkeypatch.setattr(main_mod, "get_parser", fake_get_parser)
+    monkeypatch.setattr(
+        main_mod, "parse", lambda argv: _fake_namespace(func=sentinel_func)
+    )
     monkeypatch.setattr(sys, "argv", ["repose", "foo"])
 
     with pytest.raises(SystemExit) as exc:
@@ -54,23 +52,17 @@ def test_main_invokes_subcommand_func(monkeypatch):
 def test_main_debug_sets_debug_level(monkeypatch):
     captured = {}
 
-    def fake_get_parser():
-        import argparse
-
-        p = argparse.ArgumentParser(prog="repose")
-        p.add_argument("--debug", action="store_true")
-        p.add_argument("--quiet", action="store_true")
-        sub = p.add_subparsers()
-        s = sub.add_parser("foo")
-        s.set_defaults(func=lambda a: 0)
-        return p
+    monkeypatch.setattr(
+        main_mod,
+        "parse",
+        lambda argv: _fake_namespace(func=lambda a: 0, debug=True),
+    )
 
     def fake_create_logger(name):
         log = logging.getLogger(name)
         captured["logger"] = log
         return log
 
-    monkeypatch.setattr(main_mod, "get_parser", fake_get_parser)
     monkeypatch.setattr(main_mod, "create_logger", fake_create_logger)
     monkeypatch.setattr(sys, "argv", ["repose", "--debug", "foo"])
 
@@ -83,23 +75,17 @@ def test_main_debug_sets_debug_level(monkeypatch):
 def test_main_quiet_sets_warning_level(monkeypatch):
     captured = {}
 
-    def fake_get_parser():
-        import argparse
-
-        p = argparse.ArgumentParser(prog="repose")
-        p.add_argument("--debug", action="store_true")
-        p.add_argument("--quiet", action="store_true")
-        sub = p.add_subparsers()
-        s = sub.add_parser("foo")
-        s.set_defaults(func=lambda a: 0)
-        return p
+    monkeypatch.setattr(
+        main_mod,
+        "parse",
+        lambda argv: _fake_namespace(func=lambda a: 0, quiet=True),
+    )
 
     def fake_create_logger(name):
         log = logging.getLogger(name)
         captured["logger"] = log
         return log
 
-    monkeypatch.setattr(main_mod, "get_parser", fake_get_parser)
     monkeypatch.setattr(main_mod, "create_logger", fake_create_logger)
     monkeypatch.setattr(sys, "argv", ["repose", "--quiet", "foo"])
 
@@ -110,18 +96,9 @@ def test_main_quiet_sets_warning_level(monkeypatch):
 
 
 def test_main_propagates_func_exit_code(monkeypatch):
-    def fake_get_parser():
-        import argparse
-
-        p = argparse.ArgumentParser(prog="repose")
-        p.add_argument("--debug", action="store_true")
-        p.add_argument("--quiet", action="store_true")
-        sub = p.add_subparsers()
-        s = sub.add_parser("foo")
-        s.set_defaults(func=lambda a: 7)
-        return p
-
-    monkeypatch.setattr(main_mod, "get_parser", fake_get_parser)
+    monkeypatch.setattr(
+        main_mod, "parse", lambda argv: _fake_namespace(func=lambda a: 7)
+    )
     monkeypatch.setattr(sys, "argv", ["repose", "foo"])
 
     with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## Summary

Adds OpenSSH-style `--strict-host-key-checking={yes,accept-new,no,off}` and `--known-hosts PATH` global flags so users can opt into strict verification or point repose at a custom `known_hosts` file.

`Connection.__load_keys` previously hardcoded `paramiko.AutoAddPolicy()`, which silently appends any unknown host key to `~/.ssh/known_hosts`. For QAM refhosts on a private network that is defensible, but it is an MITM surface outside that envelope and the behaviour was not user-configurable.

## Behaviour change

Default is now `accept-new` (matches OpenSSH 7.6+):

| Mode         | Unknown host (first contact)             | Changed host key             |
| ------------ | ---------------------------------------- | ---------------------------- |
| `yes`        | refuse (`BadHostKeyException`)           | refuse                       |
| `accept-new` | accept + record in known_hosts (default) | refuse                       |
| `no` / `off` | accept silently                          | accept silently (unsafe)     |

The pre-PR silent re-trust is preserved verbatim via `--strict-host-key-checking=off` for QA pools where refhost keys legitimately rotate.

## Implementation notes

paramiko ships `RejectPolicy` and `AutoAddPolicy` but no native `accept-new`, so a small custom `MissingHostKeyPolicy` (`AcceptNewPolicy`) handles the record-then-persist path. paramiko's transport already raises `BadHostKeyException` for keys that exist in the host-key store but mismatch on connect — that check fires *before* the missing-key policy, so accept-new gets changed-key rejection for free.

Plumbing uses a frozen `ConnectionConfig` dataclass threaded CLI → `ParseHosts` (now a factory) → `Target` → `Connection`. argparse's `type=` callable can't see global flags directly, so `main.py` routes through a new two-pass `parse()` helper that reads `--strict-host-key-checking` / `--known-hosts` first, builds the config, then runs the full parser with `ParseHosts(config)` bound as the `-t/--target` type.

## Files

- **New**: \`repose/types/connection_config.py\`, \`repose/connection_policy.py\`
- **Modified**: \`repose/connection.py\`, \`repose/target/__init__.py\`, \`repose/host.py\`, \`repose/argparsing.py\`, \`repose/main.py\`, \`README.md\`

## Tests

- \`tests/test_connection.py\` +6: each policy mode, \`AcceptNewPolicy.missing_host_key\` (with and without persistence), \`known_hosts\` overrides \`load_system_host_keys\`.
- \`tests/test_host.py\` +3: one-shot mode default config, factory mode threading, per-call independence.
- \`tests/test_argparsing.py\` +6: new flag defaults, all modes accepted, unknown mode rejected, path parsing, end-to-end \`parse()\` config propagation to \`Target\`.
- \`tests/test_main.py\` rewrote 4 tests to patch \`parse\` instead of \`get_parser\` (necessary because \`main.py\` now uses the two-pass driver).

## Verification

- \`python3 -m pytest -v --cov=repose\` — **338 passed**, 93% coverage.
- \`ruff format --diff .\` — clean.
- \`ruff check .\` — clean.
- \`ty check repose/\` — clean.

## Backward compatibility

- CLI: all existing invocations still work; new flags are optional with a safer-than-before but functionally equivalent default at the wire level (accept-new still auto-adds genuinely unknown hosts; only changed keys are now rejected).
- Escape hatch: \`repose --strict-host-key-checking=off ...\` reproduces pre-PR behaviour exactly.
- Internal API: \`Connection.__init__\`, \`Target.__init__\`, and \`ParseHosts\` gained a keyword-only \`config\` parameter (all default to \`ConnectionConfig()\`); positional signatures unchanged.

## Plan reference

Implements [\`PLAN-PR-12-ssh-host-key-policy\`](https://github.com/mimi1vx/repose/blob/feature/ssh-host-key-policy/plans/PLAN-PR-12-ssh-host-key-policy.md) from the project improvement roadmap, with two scope upgrades during planning:

1. Plumbing uses a \`ConnectionConfig\` dataclass threaded through layers (not post-construction patching).
2. \`accept-new\` is a real custom \`MissingHostKeyPolicy\`, not aliased to \`AutoAddPolicy\`.