### PR TITLE
fix(cli): friendly error for missing/unreadable config file

### DIFF
--- a/repose/main.py
+++ b/repose/main.py
@@ -1,5 +1,7 @@
 import sys
 
+from ruamel.yaml import YAMLError
+
 from .argparsing import get_parser, parse
 from .colorlog import create_logger
 
@@ -20,4 +22,39 @@ def main():
     elif args.quiet:
         logger.setLevel("WARNING")
 
-    sys.exit(args.func(args))
+    # Translate the most common config-load failures into a one-line
+    # user-facing message instead of a raw traceback. ``--debug`` still
+    # propagates the original exception so contributors can see the
+    # full stack. Exit code ``2`` matches the "hard failure" slot in
+    # ``ExitCode`` (Literal[0, 1, 2]) used by the command layer.
+    try:
+        sys.exit(args.func(args))
+    except FileNotFoundError as e:
+        if args.debug:
+            raise
+        logger.error(
+            "config file not found: %s (use -c PATH to point at another)",
+            e.filename or "<unknown>",
+        )
+        sys.exit(2)
+    except PermissionError as e:
+        if args.debug:
+            raise
+        logger.error("permission denied reading config: %s", e.filename or "<unknown>")
+        sys.exit(2)
+    except IsADirectoryError as e:
+        if args.debug:
+            raise
+        logger.error(
+            "config path is a directory, not a file: %s", e.filename or "<unknown>"
+        )
+        sys.exit(2)
+    except YAMLError as e:
+        if args.debug:
+            raise
+        logger.error("invalid YAML in config: %s", e)
+        sys.exit(2)
+    except KeyboardInterrupt:
+        # Standard convention: 128 + SIGINT (2) = 130.
+        logger.error("interrupted")
+        sys.exit(130)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -104,3 +104,88 @@ def test_main_propagates_func_exit_code(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         main_mod.main()
     assert exc.value.code == 7
+
+
+def _raiser(exc):
+    def _f(_args):
+        raise exc
+
+    return _f
+
+
+def test_main_friendly_message_on_missing_config(monkeypatch, caplog):
+    err = FileNotFoundError(2, "No such file or directory", "/etc/repose/products.yml")
+    monkeypatch.setattr(
+        main_mod, "parse", lambda argv: _fake_namespace(func=_raiser(err))
+    )
+    monkeypatch.setattr(sys, "argv", ["repose", "known-products"])
+
+    with caplog.at_level(logging.ERROR, logger="repose"):
+        with pytest.raises(SystemExit) as exc:
+            main_mod.main()
+
+    assert exc.value.code == 2
+    assert "config file not found" in caplog.text
+    assert "/etc/repose/products.yml" in caplog.text
+
+
+def test_main_friendly_message_on_permission_error(monkeypatch, caplog):
+    err = PermissionError(13, "Permission denied", "/etc/repose/products.yml")
+    monkeypatch.setattr(
+        main_mod, "parse", lambda argv: _fake_namespace(func=_raiser(err))
+    )
+    monkeypatch.setattr(sys, "argv", ["repose", "known-products"])
+
+    with caplog.at_level(logging.ERROR, logger="repose"):
+        with pytest.raises(SystemExit) as exc:
+            main_mod.main()
+
+    assert exc.value.code == 2
+    assert "permission denied" in caplog.text.lower()
+
+
+def test_main_friendly_message_on_yaml_error(monkeypatch, caplog):
+    from ruamel.yaml import YAMLError
+
+    monkeypatch.setattr(
+        main_mod,
+        "parse",
+        lambda argv: _fake_namespace(func=_raiser(YAMLError("bad yaml"))),
+    )
+    monkeypatch.setattr(sys, "argv", ["repose", "known-products"])
+
+    with caplog.at_level(logging.ERROR, logger="repose"):
+        with pytest.raises(SystemExit) as exc:
+            main_mod.main()
+
+    assert exc.value.code == 2
+    assert "invalid yaml" in caplog.text.lower()
+
+
+def test_main_debug_propagates_traceback(monkeypatch):
+    """With ``--debug``, the original exception is re-raised intact."""
+    err = FileNotFoundError(2, "No such file or directory", "/nope")
+    monkeypatch.setattr(
+        main_mod,
+        "parse",
+        lambda argv: _fake_namespace(func=_raiser(err), debug=True),
+    )
+    monkeypatch.setattr(sys, "argv", ["repose", "--debug", "known-products"])
+
+    with pytest.raises(FileNotFoundError):
+        main_mod.main()
+
+
+def test_main_keyboard_interrupt_returns_130(monkeypatch, caplog):
+    monkeypatch.setattr(
+        main_mod,
+        "parse",
+        lambda argv: _fake_namespace(func=_raiser(KeyboardInterrupt())),
+    )
+    monkeypatch.setattr(sys, "argv", ["repose", "known-products"])
+
+    with caplog.at_level(logging.ERROR, logger="repose"):
+        with pytest.raises(SystemExit) as exc:
+            main_mod.main()
+
+    assert exc.value.code == 130


### PR DESCRIPTION
## Problem

Running any subcommand without `/etc/repose/products.yml` (or with an unreadable / malformed file) dumps a raw Python traceback at the user:

```
$ repose known-products
Traceback (most recent call last):
  File ".../bin/repose", line 10, in <module>
    sys.exit(main())
  ...
FileNotFoundError: [Errno 2] No such file or directory: '/etc/repose/products.yml'
```

## Fix

Wrap `args.func(args)` in `repose/main.py` with a top-level handler that translates the common config-load failures into a one-line `logger.error` and exits with code `2`:

| Exception | Message |
|---|---|
| `FileNotFoundError` | `config file not found: <path> (use -c PATH to point at another)` |
| `PermissionError` | `permission denied reading config: <path>` |
| `IsADirectoryError` | `config path is a directory, not a file: <path>` |
| `ruamel.yaml.YAMLError` | `invalid YAML in config: <detail>` |
| `KeyboardInterrupt` | `interrupted`, exit 130 (128 + SIGINT) |

`--debug` re-raises the original exception so contributors still get the full stack.

### After

```
$ repose known-products
error: config file not found: /etc/repose/products.yml (use -c PATH to point at another)
$ echo $?
2
```

## Tests

Five new tests in `tests/test_main.py` cover each branch plus the `--debug` re-raise path. Full suite: **343 passed**, ruff format + check clean.

## Scope

Surgical — only `repose/main.py` (+39 lines) and `tests/test_main.py` (+85 lines). No behaviour change for successful invocations, no change to existing exit codes (the `ExitCode = Literal[0, 1, 2]` contract is preserved; `2` was already the hard-failure slot).