### PR TITLE
feat(progress): live per-host status overlay with rich

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ For example:
 SLES 12 SP2: SLES:12-SP2
 You can find more at /etc/repose/products.yml
 
+### Live progress
+
+When stdout is a terminal, repose draws a per-host status table that
+updates as each refhost moves through its work (e.g. *resolving repos*,
+*adding 3 repo(s)*, *done*). The overlay drops back to plain log lines
+automatically when output is piped, `--format=json` is used, or
+`--quiet` is set, so scripts and structured-output consumers see a
+clean stream.
+
 ## Most Common Usage Examples
 Setup of repositories on refhost:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 scripts = { repose = "repose.cli:app" }
 dependencies = [
   "paramiko",
+  "rich>=13",
   "ruamel.yaml",
   "typer>=0.16",
 ]

--- a/repose/command/__init__.py
+++ b/repose/command/__init__.py
@@ -1,4 +1,5 @@
 from ._command import Command as Command
+from ._command import UpdateFn as UpdateFn
 
 # Importing for the side effect of populating ``Command.registry`` via
 # ``__init_subclass__``. Order matters: ``remove`` must import before

--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, ClassVar, Iterable
 
 from ..console import Console
 from ..display import CommandDisplay, JsonCommandDisplay
+from ..progress import Progress
 from ..target.hostgroup import HostGroup
 from ..template import load_template
 from ..template.resolver import Repoq
@@ -18,6 +19,13 @@ from ..types.repa import Repa
 from ..utils import check_repo_url
 
 logger = logging.getLogger("repose.command")
+
+# Per-host progress updater signature. ``_run_parallel`` binds
+# ``Progress.update`` and passes it as the second positional argument
+# to every worker ``_run(host, update, *extra)``. Defined here so the
+# six concrete commands share one canonical alias instead of redefining
+# it locally.
+UpdateFn = Callable[[str, str], None]
 
 
 class Command(ABC):
@@ -88,6 +96,12 @@ class Command(ABC):
         # the flag is absent for probing commands.
         self.probe_timeout: float = getattr(args, "probe_timeout", 5.0)
         self.no_probe: bool = getattr(args, "no_probe", False)
+        # ``quiet`` is read by ``_make_progress`` to suppress the live
+        # progress overlay even on a TTY. The same flag also drives the
+        # logger-level cap in ``repose.cli``; the two effects are
+        # intentionally independent (a quiet user still wants warnings,
+        # just not the live table).
+        self.quiet: bool = getattr(args, "quiet", False)
 
     @functools.cached_property
     def repoq(self) -> Repoq:
@@ -129,21 +143,66 @@ class Command(ABC):
             self.console.report(target, line, ok=False, level="error")
         return False
 
+    def _make_progress(self) -> Progress:
+        """Construct the live-progress overlay for this command run.
+
+        Auto-disables on non-TTY stdout, ``--format=json`` (the
+        machine-readable consumer is the only thing on stdout) and
+        ``--quiet``. When disabled the returned ``Progress`` is a
+        no-op context manager — state still mutates internally but
+        nothing renders and logging is left untouched.
+        """
+        enabled = (
+            sys.stdout.isatty() and self.console.format != "json" and not self.quiet
+        )
+        return Progress(list(self.targets.keys()), enabled=enabled)
+
+    def _worker(
+        self,
+        fn: Callable[..., bool],
+        host: str,
+        prog: Progress,
+        extra: tuple[Any, ...],
+    ) -> bool:
+        """Wrap ``fn(host, update, *extra)`` with progress bookkeeping.
+
+        Posts ``"running"`` before invoking ``fn``, ``"[green]done"`` /
+        ``"[red]failed"`` after, and ``"[red]failed"`` if ``fn`` raises
+        (then re-raises so ``_aggregate`` sees the exception via the
+        future).
+        """
+        prog.update(host, "running")
+        try:
+            ok = fn(host, prog.update, *extra)
+        except Exception:
+            prog.update(host, "[red]failed")
+            raise
+        prog.update(host, "[green]done" if ok else "[red]failed")
+        return ok
+
     def _run_parallel(
         self,
         fn: Callable[..., bool],
         *extra_args: Any,
     ) -> list[Future[bool]]:
-        """Fan ``fn(host, *extra_args)`` across all live targets.
+        """Fan ``fn(host, update, *extra_args)`` across all live targets.
+
+        ``fn`` receives a per-host ``update(host, status)`` callable
+        as its second positional argument; commands call it at
+        meaningful milestones to keep the live overlay informative.
 
         Returns the futures so callers can inspect ``.exception()``
         and ``.result()`` (consumed by ``_aggregate`` for exit-code
         propagation).
         """
-        with concurrent.futures.ThreadPoolExecutor() as ex:
-            futures = [ex.submit(fn, host, *extra_args) for host in self.targets.keys()]
-            concurrent.futures.wait(futures)
-            return futures
+        with self._make_progress() as prog:
+            with concurrent.futures.ThreadPoolExecutor() as ex:
+                futures = [
+                    ex.submit(self._worker, fn, host, prog, extra_args)
+                    for host in self.targets.keys()
+                ]
+                concurrent.futures.wait(futures)
+                return futures
 
     def _aggregate(self, futures: list[Future[bool]]) -> ExitCode:
         """Collapse per-target futures into a process exit code.

--- a/repose/command/add.py
+++ b/repose/command/add.py
@@ -1,7 +1,7 @@
 from itertools import chain
 import logging
 
-from . import Command
+from . import Command, UpdateFn
 from ..types import ExitCode
 
 logger = logging.getLogger("repose.command.add")
@@ -41,8 +41,11 @@ class Add(Command, name="add"):
         )
         return cmds, ok
 
-    def _run(self, target) -> bool:
+    def _run(self, target: str, update: UpdateFn) -> bool:
+        update(target, "resolving repos")
         cmds, ok = self._add(target)
+        if cmds:
+            update(target, f"adding {len(cmds)} repo(s)")
         for cmd in cmds:
             if self.dryrun:
                 self.console.dry(target, cmd)

--- a/repose/command/clear.py
+++ b/repose/command/clear.py
@@ -1,6 +1,6 @@
 import logging
 
-from . import Command
+from . import Command, UpdateFn
 from ..types import ExitCode
 
 
@@ -11,7 +11,8 @@ class Clear(Command, name="clear"):
     def _clear(self, host):
         return set(r.alias for r in self.targets[host].raw_repos)
 
-    def _run(self, host) -> bool:
+    def _run(self, host: str, update: UpdateFn) -> bool:
+        update(host, "clearing repos")
         repoaliases = self._clear(host)
 
         if self.dryrun:

--- a/repose/command/install.py
+++ b/repose/command/install.py
@@ -1,14 +1,15 @@
 from itertools import chain
 import logging
 
-from . import Command
+from . import Command, UpdateFn
 from ..types import ExitCode
 
 logger = logging.getLogger("repose.command.install")
 
 
 class Install(Command, name="install"):
-    def _run(self, target) -> bool:
+    def _run(self, target: str, update: UpdateFn) -> bool:
+        update(target, "resolving repos")
         repositories = {}
         ok = True
         for repa in self.repa:
@@ -29,6 +30,8 @@ class Install(Command, name="install"):
         # from whatever sources zypper already knows about.
         all_repos = list(chain.from_iterable(repositories.values()))
         live_repos = self._filter_live_urls(all_repos)
+        if live_repos:
+            update(target, f"adding {len(live_repos)} repo(s)")
         for repo in live_repos:
             addcmd = self.addcmd.format(
                 name=repo.name, url=repo.url, params="-cfkn" if repo.refresh else "-ckn"
@@ -48,6 +51,7 @@ class Install(Command, name="install"):
                 inscmd = self.ipdtcmd.format(products=" ".join(repositories.keys()))
             else:
                 inscmd = self.ipdcmd.format(products=" ".join(repositories.keys()))
+            update(target, "installing products")
             if self.dryrun:
                 self.console.dry(str(target), inscmd)
             else:

--- a/repose/command/remove.py
+++ b/repose/command/remove.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Iterable
 
-from . import Command
+from . import Command, UpdateFn
 from ..types import ExitCode
 from ..types.repa import Repa
 
@@ -43,13 +43,14 @@ class Remove(Command, name="remove"):
                     repolist.add(repo)
         return repolist
 
-    def _run(self, host: str, *args: Any) -> bool:
+    def _run(self, host: str, update: UpdateFn, *args: Any) -> bool:
         """Compute and (optionally) issue the ``zypper rr`` command.
 
         Returns ``True`` when no work was found (an INFO-level no-op,
         not an error) and ``True``/``False`` from ``_report_target``
         when the command actually ran.
         """
+        update(host, "computing patterns")
         patterns = self._calculate_pattern(self.repa, host)
 
         if not patterns:
@@ -66,6 +67,7 @@ class Remove(Command, name="remove"):
             self.console.dry(host, cmd)
             return True
 
+        update(host, f"removing {len(repolist)} repo(s)")
         self.targets[host].run(cmd)
         return self._report_target(host)
 

--- a/repose/command/reset.py
+++ b/repose/command/reset.py
@@ -1,6 +1,7 @@
 from itertools import chain
 import logging
 
+from . import UpdateFn
 from ..messages import UnsuportedProductMessage
 from ..types import ExitCode
 from .clear import Clear
@@ -26,10 +27,12 @@ class Reset(Clear, name="reset"):
         )
         return cmds
 
-    def _run(self, host) -> bool:
+    def _run(self, host: str, update: UpdateFn) -> bool:
+        update(host, "clearing repos")
         repoaliases = self._clear(host)
         ok = True
         try:
+            update(host, "resolving new repos")
             cmds = self._add(host)
 
             if self.dryrun:
@@ -38,6 +41,8 @@ class Reset(Clear, name="reset"):
                     self.console.dry(host, cmd)
                 return True
 
+            if cmds:
+                update(host, f"re-adding {len(cmds)} repo(s)")
             self.targets[host].run(self.rrcmd.format(repos=" ".join(repoaliases)))
             for cmd in cmds:
                 self.targets[host].run(cmd)

--- a/repose/command/uninstall.py
+++ b/repose/command/uninstall.py
@@ -3,6 +3,7 @@ import logging
 from itertools import chain
 from typing import Any
 
+from . import UpdateFn
 from .remove import Remove
 from ..types import ExitCode
 
@@ -24,9 +25,10 @@ class Uninstall(Remove, name="uninstall"):
                         rdict[repo[1].name] = [repo[0]]
         return rdict
 
-    def _run(self, host: str, *args: Any) -> bool:
+    def _run(self, host: str, update: UpdateFn, *args: Any) -> bool:
         # First positional ``args`` element is the orepa list (see ``run``).
         orepa = args[0]
+        update(host, "computing patterns")
         patterns = self._calculate_pattern(orepa, host)
         if not patterns:
             logger.info("For %s no products for remove found", host)
@@ -58,9 +60,11 @@ class Uninstall(Remove, name="uninstall"):
 
         ok = True
         if rrcmd:
+            update(host, "removing repos")
             self.targets[host].run(rrcmd)
             if not self._report_target(host):
                 ok = False
+        update(host, "removing products")
         self.targets[host].run(pdcmd)
         if not self._report_target(host):
             ok = False

--- a/repose/progress.py
+++ b/repose/progress.py
@@ -1,0 +1,168 @@
+"""Live per-host progress overlay built on ``rich.live.Live``.
+
+Each row of the table is one target host; each cell is the current
+status string posted by the per-host worker. Updates are thread-safe
+(workers run concurrently in a ``ThreadPoolExecutor``).
+
+The overlay auto-disables for non-TTY output, ``--format=json``, and
+``--quiet`` (see :meth:`repose.command._command.Command._make_progress`
+for the gating). When disabled the public surface is a no-op: state
+still mutates in-memory (cheap, useful for future consumers) but
+nothing is rendered and the logging stack is left untouched.
+
+When enabled, the context manager additionally swaps the active
+``logging`` handler on the ``"repose"`` logger family for a
+``rich.logging.RichHandler`` bound to the same ``Console`` Live is
+writing to. This routes log records through Rich's renderer so they
+don't tear the live frame. The previous handler set + level are
+snapshotted and restored on ``__exit__`` (including on exceptions).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from contextlib import AbstractContextManager
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from rich.console import Console as RichConsole
+from rich.live import Live
+from rich.logging import RichHandler
+from rich.table import Table
+
+
+# Loggers we swap handlers on while Live owns the screen. The root
+# logger is intentionally left alone — third-party libraries (paramiko,
+# urllib3) keep emitting through their own configured handlers.
+_MANAGED_LOGGER_NAMES: tuple[str, ...] = ("repose",)
+
+
+@dataclass
+class _LoggingSnapshot:
+    """State needed to restore logging after Live tears down."""
+
+    handlers: dict[str, list[logging.Handler]] = field(default_factory=dict)
+    levels: dict[str, int] = field(default_factory=dict)
+
+
+def _install_rich_logging(console: RichConsole) -> _LoggingSnapshot:
+    """Swap managed loggers' handlers for a ``RichHandler`` on ``console``.
+
+    Snapshots the prior handler list + level for each managed logger
+    so :func:`_restore_logging` can put everything back verbatim.
+    """
+    snap = _LoggingSnapshot()
+    handler = RichHandler(
+        console=console,
+        show_path=False,
+        show_time=False,
+        rich_tracebacks=False,
+        markup=False,
+    )
+    for name in _MANAGED_LOGGER_NAMES:
+        lg = logging.getLogger(name)
+        snap.handlers[name] = list(lg.handlers)
+        snap.levels[name] = lg.level
+        for h in list(lg.handlers):
+            lg.removeHandler(h)
+        lg.addHandler(handler)
+    return snap
+
+
+def _restore_logging(snap: _LoggingSnapshot) -> None:
+    """Restore handlers + level captured by :func:`_install_rich_logging`."""
+    for name, handlers in snap.handlers.items():
+        lg = logging.getLogger(name)
+        for h in list(lg.handlers):
+            lg.removeHandler(h)
+        for h in handlers:
+            lg.addHandler(h)
+        lg.setLevel(snap.levels.get(name, logging.NOTSET))
+
+
+class Progress(AbstractContextManager["Progress"]):
+    """Live per-host status table.
+
+    Construct with the host list and an ``enabled`` flag; mutate per
+    host via :meth:`update`. The context manager owns the
+    ``rich.live.Live`` lifetime and the logging swap.
+
+    ``update`` is safe to call from worker threads.
+    """
+
+    def __init__(
+        self,
+        hosts: Iterable[str],
+        *,
+        enabled: bool,
+        console: RichConsole | None = None,
+    ) -> None:
+        self.enabled = enabled
+        self._state: dict[str, str] = {h: "pending" for h in hosts}
+        self._lock = threading.Lock()
+        self._console = console if console is not None else RichConsole()
+        self._live: Live | None = None
+        self._log_snapshot: _LoggingSnapshot | None = None
+
+    # ------------------------------------------------------------------
+    # Rendering
+    # ------------------------------------------------------------------
+
+    def _render(self) -> Table:
+        t = Table.grid(padding=(0, 2))
+        t.add_column(style="bold")
+        t.add_column()
+        for host in sorted(self._state):
+            t.add_row(host, self._state[host])
+        return t
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def update(self, host: str, status: str) -> None:
+        """Set the status cell for ``host`` and refresh the live frame.
+
+        Thread-safe. When ``enabled`` is False the state dict still
+        mutates so callers can introspect or future consumers can
+        observe progress without rendering.
+        """
+        with self._lock:
+            self._state[host] = status
+            if self._live is not None:
+                self._live.update(self._render())
+
+    @property
+    def state(self) -> dict[str, str]:
+        """Snapshot copy of per-host status (for tests / introspection)."""
+        with self._lock:
+            return dict(self._state)
+
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "Progress":
+        if not self.enabled:
+            return self
+        self._log_snapshot = _install_rich_logging(self._console)
+        live = Live(
+            self._render(),
+            console=self._console,
+            refresh_per_second=8,
+            transient=True,
+        )
+        live.__enter__()
+        self._live = live
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        try:
+            if self._live is not None:
+                self._live.__exit__(exc_type, exc, tb)
+        finally:
+            self._live = None
+            if self._log_snapshot is not None:
+                _restore_logging(self._log_snapshot)
+                self._log_snapshot = None

--- a/tests/command/test_command_base.py
+++ b/tests/command/test_command_base.py
@@ -1,7 +1,7 @@
 """Tests for ``repose.command._command.Command`` base class."""
 
 from concurrent.futures import Future
-from unittest.mock import MagicMock, call
+from unittest.mock import ANY, MagicMock, call
 
 import pytest
 
@@ -214,45 +214,183 @@ def test_repoq_loads_template(monkeypatch, tmp_path):
 
 
 def test_run_parallel_invokes_fn_per_host(monkeypatch):
-    """Helper fans ``fn(host)`` across every live target and returns
-    one completed ``Future`` per host."""
+    """Helper fans ``fn(host, update)`` across every live target and
+    returns one completed ``Future`` per host. The second positional
+    arg is the per-host progress updater (a bound ``Progress.update``).
+    """
     hg = MagicMock()
     hg.keys.return_value = ["h1", "h2", "h3"]
     hg.__getitem__.side_effect = lambda k: MagicMock()
 
     cmd, _ = _make(monkeypatch, host_group=hg)
 
-    fn = MagicMock(return_value=None)
+    fn = MagicMock(return_value=True)
     futures = cmd._run_parallel(fn)
 
-    # Worker threads may interleave, so compare unordered.
-    assert sorted(fn.call_args_list) == sorted([call("h1"), call("h2"), call("h3")])
+    # Worker threads may interleave, so compare unordered. Use ANY
+    # for the bound-method ``update`` arg — equality on bound methods
+    # is identity, which breaks call-equality across threads.
+    assert sorted(fn.call_args_list) == sorted(
+        [call("h1", ANY), call("h2", ANY), call("h3", ANY)]
+    )
     assert len(futures) == 3
     assert all(isinstance(f, Future) for f in futures)
     assert all(f.done() for f in futures)
 
 
 def test_run_parallel_passes_extra_args_after_host(monkeypatch):
-    """Extra positional args are forwarded after ``host`` so callers
-    like ``Uninstall`` keep ``_run(host, *args)`` ergonomics."""
+    """Extra positional args are forwarded after ``host, update`` so
+    callers like ``Uninstall`` keep ``_run(host, update, *args)``
+    ergonomics.
+    """
     hg = MagicMock()
     hg.keys.return_value = ["h1", "h2"]
     hg.__getitem__.side_effect = lambda k: MagicMock()
 
     cmd, _ = _make(monkeypatch, host_group=hg)
 
-    fn = MagicMock(return_value=None)
+    fn = MagicMock(return_value=True)
     sentinel = object()
     futures = cmd._run_parallel(fn, sentinel, "extra")
 
     # Worker threads may interleave, so compare unordered.
     assert sorted(fn.call_args_list) == sorted(
         [
-            call("h1", sentinel, "extra"),
-            call("h2", sentinel, "extra"),
+            call("h1", ANY, sentinel, "extra"),
+            call("h2", ANY, sentinel, "extra"),
         ]
     )
-    assert [f.result() for f in futures] == [None, None]
+    assert [f.result() for f in futures] == [True, True]
+
+
+def test_run_parallel_marks_progress_running_then_done(monkeypatch):
+    """Worker wrapper posts ``running`` → ``[green]done`` on success."""
+    hg = MagicMock()
+    hg.keys.return_value = ["h1"]
+    hg.__getitem__.side_effect = lambda k: MagicMock()
+
+    cmd, _ = _make(monkeypatch, host_group=hg)
+
+    seen: list[tuple[str, str]] = []
+
+    class _StubProgress:
+        enabled = False
+
+        def update(self, host, status):
+            seen.append((host, status))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+    monkeypatch.setattr(cmd, "_make_progress", lambda: _StubProgress())
+
+    fn = MagicMock(return_value=True)
+    futures = cmd._run_parallel(fn)
+
+    assert [f.result() for f in futures] == [True]
+    assert seen == [("h1", "running"), ("h1", "[green]done")]
+
+
+def test_run_parallel_marks_progress_failed_on_false_result(monkeypatch):
+    """Worker wrapper posts ``[red]failed`` when ``fn`` returns False."""
+    hg = MagicMock()
+    hg.keys.return_value = ["h1"]
+    hg.__getitem__.side_effect = lambda k: MagicMock()
+
+    cmd, _ = _make(monkeypatch, host_group=hg)
+
+    seen: list[tuple[str, str]] = []
+
+    class _StubProgress:
+        enabled = False
+
+        def update(self, host, status):
+            seen.append((host, status))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+    monkeypatch.setattr(cmd, "_make_progress", lambda: _StubProgress())
+
+    futures = cmd._run_parallel(MagicMock(return_value=False))
+
+    assert [f.result() for f in futures] == [False]
+    assert seen == [("h1", "running"), ("h1", "[red]failed")]
+
+
+def test_run_parallel_marks_progress_failed_on_exception(monkeypatch):
+    """Worker wrapper posts ``[red]failed`` and re-raises when ``fn``
+    raises, so ``_aggregate`` can see the exception via the future."""
+    hg = MagicMock()
+    hg.keys.return_value = ["h1"]
+    hg.__getitem__.side_effect = lambda k: MagicMock()
+
+    cmd, _ = _make(monkeypatch, host_group=hg)
+
+    seen: list[tuple[str, str]] = []
+
+    class _StubProgress:
+        enabled = False
+
+        def update(self, host, status):
+            seen.append((host, status))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+    monkeypatch.setattr(cmd, "_make_progress", lambda: _StubProgress())
+
+    def _boom(host, update):
+        raise RuntimeError("nope")
+
+    futures = cmd._run_parallel(_boom)
+
+    assert futures[0].exception() is not None
+    assert isinstance(futures[0].exception(), RuntimeError)
+    assert seen == [("h1", "running"), ("h1", "[red]failed")]
+
+
+# ---------------------------------------------------------------------------
+# _make_progress
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "isatty,fmt,quiet,expected",
+    [
+        (True, "text", False, True),  # interactive default
+        (False, "text", False, False),  # pipe
+        (True, "json", False, False),  # --format=json
+        (True, "text", True, False),  # --quiet
+        (False, "json", True, False),  # all off
+    ],
+)
+def test_make_progress_enabled_gating(monkeypatch, isatty, fmt, quiet, expected):
+    cmd, _ = _make(monkeypatch)
+    monkeypatch.setattr("sys.stdout", MagicMock(isatty=MagicMock(return_value=isatty)))
+    cmd.console.format = fmt
+    cmd.quiet = quiet
+    prog = cmd._make_progress()
+    assert prog.enabled is expected
+
+
+def test_quiet_defaults_to_false(monkeypatch):
+    cmd, _ = _make(monkeypatch)
+    assert cmd.quiet is False
+
+
+def test_quiet_pulled_from_args(monkeypatch):
+    cmd, _ = _make(monkeypatch, args_overrides={"quiet": True})
+    assert cmd.quiet is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,153 @@
+"""Tests for ``repose.progress.Progress``."""
+
+import io
+import logging
+import threading
+
+from rich.console import Console as RichConsole
+
+from repose.progress import Progress
+
+
+# ---------------------------------------------------------------------------
+# enabled=False: no-op context manager, state still mutates
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_progress_is_noop_context_manager():
+    prog = Progress(["h1", "h2"], enabled=False)
+    with prog:
+        prog.update("h1", "doing")
+    # state still updates so future consumers can read it
+    assert prog.state == {"h1": "doing", "h2": "pending"}
+
+
+def test_disabled_progress_leaves_logging_untouched():
+    lg = logging.getLogger("repose")
+    before = list(lg.handlers)
+    before_level = lg.level
+    with Progress(["h1"], enabled=False):
+        pass
+    assert list(lg.handlers) == before
+    assert lg.level == before_level
+
+
+# ---------------------------------------------------------------------------
+# update() basics
+# ---------------------------------------------------------------------------
+
+
+def test_update_mutates_state():
+    prog = Progress(["h1"], enabled=False)
+    prog.update("h1", "running")
+    assert prog.state["h1"] == "running"
+
+
+def test_update_thread_safe():
+    """16 threads bashing the same host's cell — no exceptions, final
+    state holds one of the posted values."""
+    prog = Progress(["h"], enabled=False)
+    barrier = threading.Barrier(16)
+
+    def _hammer(i):
+        barrier.wait()
+        prog.update("h", str(i))
+
+    threads = [threading.Thread(target=_hammer, args=(i,)) for i in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    final = prog.state["h"]
+    assert final in {str(i) for i in range(16)}
+
+
+# ---------------------------------------------------------------------------
+# enabled=True: Live renders rows, logging swap restores
+# ---------------------------------------------------------------------------
+
+
+def _capture_console() -> RichConsole:
+    """A Rich Console writing to an in-memory buffer with TTY emulation
+    so Live actually renders."""
+    return RichConsole(
+        file=io.StringIO(),
+        force_terminal=True,
+        width=80,
+    )
+
+
+def test_enabled_progress_renders_rows():
+    rc = _capture_console()
+    prog = Progress(["beta", "alpha"], enabled=True, console=rc)
+    with prog:
+        prog.update("alpha", "working")
+        prog.update("beta", "done")
+    output = rc.file.getvalue()
+    # transient=True clears the live region on exit, but the row text
+    # passes through the buffer at least once.
+    assert "alpha" in output
+    assert "beta" in output
+
+
+def test_enabled_progress_renders_status_text():
+    rc = _capture_console()
+    prog = Progress(["h"], enabled=True, console=rc)
+    with prog:
+        prog.update("h", "milestone-text-XYZ")
+    assert "milestone-text-XYZ" in rc.file.getvalue()
+
+
+def test_enabled_progress_swaps_and_restores_logging():
+    """While Live is active a RichHandler is installed on ``repose``;
+    after exit the original handler set + level come back verbatim."""
+    lg = logging.getLogger("repose")
+    # Snapshot then install a sentinel handler so we can prove restoration.
+    original_handlers = list(lg.handlers)
+    original_level = lg.level
+    sentinel = logging.NullHandler()
+    lg.addHandler(sentinel)
+    lg.setLevel(logging.WARNING)
+    try:
+        rc = _capture_console()
+        with Progress(["h"], enabled=True, console=rc):
+            # During Live the only handler should be a RichHandler.
+            handler_types = {type(h).__name__ for h in lg.handlers}
+            assert "RichHandler" in handler_types
+            assert "NullHandler" not in handler_types
+
+        # After exit our sentinel + the prior handlers are back.
+        assert sentinel in lg.handlers
+        assert lg.level == logging.WARNING
+    finally:
+        # Tidy up the sentinel regardless.
+        if sentinel in lg.handlers:
+            lg.removeHandler(sentinel)
+        # Restore pre-test state.
+        for h in list(lg.handlers):
+            if h not in original_handlers:
+                lg.removeHandler(h)
+        for h in original_handlers:
+            if h not in lg.handlers:
+                lg.addHandler(h)
+        lg.setLevel(original_level)
+
+
+def test_logging_restored_on_exception():
+    """Exceptions inside the ``with`` block must not leak the
+    RichHandler swap."""
+    lg = logging.getLogger("repose")
+    original_handlers = list(lg.handlers)
+    original_level = lg.level
+    rc = _capture_console()
+    try:
+        with Progress(["h"], enabled=True, console=rc):
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+
+    handler_types = {type(h).__name__ for h in lg.handlers}
+    assert "RichHandler" not in handler_types
+    assert list(lg.handlers) == original_handlers
+    assert lg.level == original_level

--- a/uv.lock
+++ b/uv.lock
@@ -507,6 +507,7 @@ name = "repose"
 source = { editable = "." }
 dependencies = [
     { name = "paramiko" },
+    { name = "rich" },
     { name = "ruamel-yaml" },
     { name = "typer" },
 ]
@@ -524,6 +525,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "paramiko" },
+    { name = "rich", specifier = ">=13" },
     { name = "ruamel-yaml" },
     { name = "typer", specifier = ">=0.16" },
 ]


### PR DESCRIPTION
## Summary

Adds a live per-host progress overlay built on `rich.live.Live`. Each row of the table is one target host; cells update as the worker moves through milestones (e.g. *resolving repos* → *adding 3 repo(s)* → *done*). Auto-disables for non-TTY stdout, `--format=json`, and `--quiet` so scripts and structured-output consumers still see a clean stream.

## Why

Retiring the legacy `|/-\` spinner left users with no feedback during multi-host work. A 10-host run with multi-second `zypper ar` calls blocked silently until each host finished and dumped its output through `_report_target` — operators had no way to see whether a slow host was connecting, probing URLs, or just hung. This restores per-host visibility with a modern UX equivalent.

## Implementation

- **New `repose/progress.py`** — thread-safe `Progress` context manager wrapping `rich.live.Live` with a sorted host/status grid. While Live owns the screen, the `repose` logger family's handlers are swapped for a `RichHandler` bound to the same Console (so logs don't tear the live frame), and the prior handler set + level are restored verbatim on exit, including on exceptions.
- **`Command._make_progress()`** gates on `sys.stdout.isatty() and console.format != "json" and not self.quiet`.
- **`Command._run_parallel`** opens the overlay and a per-host `_worker` wrapper posts `running` → `[green]done` / `[red]failed` and re-raises on exception so `_aggregate` still sees the error via the future.
- **Each concrete command** (add, clear, install, remove, reset, uninstall) gains an `update(host, status)` callback parameter and posts 1–3 milestone strings at meaningful boundaries.
- **`self.quiet`** wired through `Command.__init__` from the argparse namespace.
- **`UpdateFn = Callable[[str, str], None]`** defined once in `_command.py` and re-exported via `command/__init__.py`.

## Tests

- `tests/test_progress.py` (8 tests) — enabled/disabled gating, `update()` thread safety with 16 racing threads, rendered output content, logging-swap install/restore, and exception-path restoration.
- `tests/command/test_command_base.py` extended with 4 worker-progress tests (running→done, running→failed on `False`, running→failed on exception) and a `_make_progress` gating parametrize matrix.
- Existing `_run_parallel` tests updated for the new `update` positional arg.

## Quality gate

- 375/375 tests pass (was 357; +18 net).
- `ruff format --diff .` clean.
- `ruff check .` clean.
- Coverage: `repose/progress.py` 100% (74/74 stmts); `repose/command/_command.py` 99% (only the abstract-method body unreached, pre-existing).

## Dependency

- Adds `rich>=13` to `[project].dependencies`. Pure-Python, packaged for openSUSE.

## UX matrix

| Stream             | Behavior                                  |
| ------------------ | ----------------------------------------- |
| Interactive TTY    | Live per-host status table                |
| Piped (`\| cat`)   | Plain log lines, no ANSI                  |
| `--format=json`    | NDJSON only, no overlay                   |
| `--quiet`          | No overlay even on TTY                    |