### PR TITLE
feat(ssh): rewrite SSH layer on asyncssh with structured concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,29 @@ repose --strict-host-key-checking=yes \
        add -t fubar.suse.cz sle-sdk
 ```
 
+## SSH Backend
+
+Repose ships two SSH implementations selectable with `--ssh-backend`:
+
+- `asyncssh` (default) — structured concurrency on top of `asyncio`. No
+  threadpool, so it scales to hundreds of refhosts without thread
+  pressure. Ctrl-C cancels every in-flight host coroutine cleanly.
+- `paramiko` — the legacy threaded backend. Available for one release
+  as a safety net while `asyncssh` settles in real-world deployments;
+  scheduled for removal in the following release.
+
+Both backends honour the same `--strict-host-key-checking`,
+`--known-hosts`, and `~/.ssh/config` directives, so the only
+user-visible difference should be runtime characteristics. If you hit
+a behaviour regression after upgrading, switch back temporarily:
+
+```
+repose --ssh-backend=paramiko reset -t fubar.suse.cz
+```
+
+…and please file a bug so the parity gap can be closed before the
+paramiko backend is removed.
+
 ## License
 
 This project is licensed under the GPLv3 license, see LICENSE file for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ classifiers = [
 ]
 scripts = { repose = "repose.cli:app" }
 dependencies = [
+  "asyncssh>=2.14",
+  "httpx>=0.27",
   "paramiko",
   "rich>=13",
   "ruamel.yaml",
@@ -29,6 +31,7 @@ Repository = "https://github.com/openSUSE/repose"
 dev = [
   "hypothesis",
   "pytest",
+  "pytest-asyncio>=0.23",
   "pytest-cov",
   "pytest-mock",
   "ruff",
@@ -47,6 +50,7 @@ version = { attr = "repose.__version__" }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"
 addopts = [
   "-v",
   "--strict-markers",

--- a/repose/aiossh.py
+++ b/repose/aiossh.py
@@ -1,0 +1,491 @@
+"""Async SSH backend on top of :mod:`asyncssh`.
+
+Mirrors the public surface of :class:`repose.connection.Connection`
+(``connect``, ``run``, ``listdir``, ``open``, ``readlink``, ``close``,
+``is_active``) so :class:`repose.target.async_target.AsyncTarget` and
+the rest of the codebase can swap backends behind a single CLI flag.
+
+The intent is byte-for-byte behavioural parity with the paramiko path,
+not a re-imagining: same exit-code surface, same exception types
+(``CommandTimeout`` is re-exported here so callers ``except`` it
+regardless of backend), same host-key policy semantics
+(``yes``/``accept-new``/``no``/``off``).
+
+Everything I/O bound is ``async``; CPU work (parsing, formatting)
+stays sync and lives in the parsers as it did before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import errno
+import getpass
+import logging
+import os
+import socket
+from pathlib import Path
+from typing import Any
+
+import asyncssh
+
+from .connection import CommandTimeout  # re-export for backend-neutral except clauses
+from .types.connection_config import ConnectionConfig
+
+
+__all__ = ["AsyncConnection", "CommandTimeout"]
+
+
+logger = logging.getLogger("repose.aiossh")
+
+
+def _parse_openssh_config(hostname: str) -> dict[str, Any]:
+    """Look up ``hostname`` in the user's ``~/.ssh/config``.
+
+    Returns the same dict-of-lowercased-keys shape that paramiko's
+    ``SSHConfig.lookup`` returns, so the call sites that consult
+    ``opts.get("hostname", ...)`` / ``opts.get("port", ...)`` /
+    ``opts.get("user", ...)`` / ``opts.get("identityfile", ...)`` /
+    ``opts.get("proxycommand", ...)`` keep working unchanged.
+
+    Missing config file → empty dict (no overrides). Permission errors
+    or malformed entries are logged at WARNING and treated as empty.
+    """
+    cfg_path = os.path.expanduser("~/.ssh/config")
+    try:
+        # Local import: paramiko stays a runtime dep during the
+        # dual-backend window. Reusing its parser keeps the asyncssh
+        # path 100% behaviour-compatible with the paramiko path for
+        # the long tail of ``~/.ssh/config`` directives.
+        import paramiko
+
+        cfg = paramiko.config.SSHConfig()
+        with open(cfg_path) as fd:
+            cfg.parse(fd)
+        return cfg.lookup(hostname)
+    except OSError as exc:
+        if exc.errno != errno.ENOENT:
+            logger.warning("could not read %s: %s", cfg_path, exc)
+        return {}
+    except Exception as exc:
+        # Defensive: a malformed ssh_config should not take down the
+        # entire run. Match paramiko-side behaviour where a parse
+        # error logs and continues.
+        logger.warning("could not parse %s: %s", cfg_path, exc)
+        return {}
+
+
+def _default_known_hosts_path() -> Path:
+    return Path(os.path.expanduser("~/.ssh/known_hosts"))
+
+
+def _build_known_hosts_arg(policy: str, known_hosts: Path | None) -> Any:
+    """Translate ConnectionConfig host-key knobs into asyncssh ``known_hosts``.
+
+    - ``yes``        → use the configured file (or default
+      ``~/.ssh/known_hosts``); asyncssh refuses unknown hosts and
+      mismatches natively.
+    - ``accept-new`` → return ``None`` so asyncssh's native checker
+      stays out of the way; validation runs in a custom ``SSHClient``
+      subclass installed via ``client_factory=`` (see
+      :func:`_make_accept_new_client`). Same end behaviour as OpenSSH's
+      ``StrictHostKeyChecking=accept-new``: unknown hosts are accepted
+      and persisted; changed keys are rejected.
+    - ``no``/``off`` → ``None``: asyncssh disables host-key validation
+      entirely. Matches the historical pre-PR-12 behaviour.
+    """
+    if policy in ("no", "off", "accept-new"):
+        return None
+    if known_hosts is None:
+        return ()  # asyncssh default: ``~/.ssh/known_hosts``
+    return str(known_hosts)
+
+
+def _make_accept_new_client(
+    known_hosts_path: Path, expected_host: str
+) -> type[asyncssh.SSHClient]:
+    """Return an ``SSHClient`` subclass enforcing ``accept-new`` semantics.
+
+    The returned class is what gets passed to
+    ``asyncssh.connect(client_factory=...)``; asyncssh instantiates it
+    for the new connection and consults
+    :meth:`SSHClient.validate_host_public_key` for every offered host
+    key.
+
+    Read the known_hosts file once at factory time. Subsequent
+    validation:
+
+    - accepts a key whose bytes match a pinned entry for this host,
+    - rejects a key when entries exist for this host but none match
+      (the canonical changed-key scenario),
+    - accepts and persists when no entry exists for this host (first
+      contact).
+
+    The match is done via asyncssh's public ``SSHKnownHosts.match``
+    API, which already handles host-pattern matching, hashed entries,
+    and revoked-key flags correctly.
+    """
+    trusted_pubkeys: list[bytes] = []
+    if known_hosts_path.exists():
+        try:
+            khosts = asyncssh.read_known_hosts(str(known_hosts_path))
+            # ``match(host, addr, port)`` returns a 7-tuple; the first
+            # element is the trusted-keys list for this host. Address
+            # and port are not significant for accept-new (we trust by
+            # host pattern), so feed dummies — asyncssh accepts them.
+            trusted, _ca, _revoked, *_ = khosts.match(expected_host, "0.0.0.0", 22)
+            trusted_pubkeys = [k.export_public_key() for k in trusted]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "accept-new: could not read %s: %s",
+                known_hosts_path,
+                exc,
+            )
+
+    class _AcceptNewClient(asyncssh.SSHClient):
+        def validate_host_public_key(
+            self,
+            host: str,
+            addr: str,
+            port: int,
+            key: asyncssh.SSHKey,
+        ) -> bool:
+            offered = key.export_public_key()
+            if trusted_pubkeys:
+                # Some key already pinned for this host. accept-new
+                # only accepts a *matching* one; a mismatch is the
+                # canonical changed-key scenario.
+                if offered in trusted_pubkeys:
+                    return True
+                logger.error(
+                    "accept-new: host key for %s changed; refusing",
+                    expected_host,
+                )
+                return False
+            # First contact for this host: accept and persist.
+            try:
+                with open(known_hosts_path, "a") as fh:
+                    fh.write(f"{expected_host} {offered.decode().strip()}\n")
+                logger.info(
+                    "accept-new: persisted host key for %s to %s",
+                    expected_host,
+                    known_hosts_path,
+                )
+            except OSError as werr:
+                logger.warning(
+                    "accept-new: could not persist host key for %s to %s: %s",
+                    expected_host,
+                    known_hosts_path,
+                    werr,
+                )
+            return True
+
+    return _AcceptNewClient
+
+
+class AsyncConnection:
+    """Async equivalent of :class:`repose.connection.Connection`.
+
+    Public surface mirrors the paramiko backend exactly: all I/O
+    methods are coroutines, but the same arguments and the same return
+    shapes apply. ``close()`` is idempotent.
+    """
+
+    def __init__(
+        self,
+        hostname: str,
+        username: str,
+        port: str | int,
+        timeout: float | None = None,
+        *,
+        config: ConnectionConfig | None = None,
+    ) -> None:
+        self.username = username
+        self.hostname = hostname
+        try:
+            self.port = int(port)
+        except Exception:
+            self.port = 22
+
+        self.config: ConnectionConfig = config or ConnectionConfig()
+        # Explicit positional ``timeout`` wins over ``config.timeout``;
+        # mirror the paramiko ``Connection`` semantics so the two
+        # backends accept the exact same call shape.
+        self.timeout: float = (
+            float(timeout) if timeout is not None else self.config.timeout
+        )
+
+        self._conn: asyncssh.SSHClientConnection | None = None
+        self._sftp: asyncssh.SFTPClient | None = None
+
+    def __repr__(self) -> str:
+        return (
+            f"<{self.__class__.__name__} object username={self.username} "
+            f"hostname={self.hostname} port={self.port}>"
+        )
+
+    # ------------------------------------------------------------------
+    # connect / auth
+    # ------------------------------------------------------------------
+
+    async def _do_connect(
+        self,
+        *,
+        known_hosts: Any,
+        client_factory: type[asyncssh.SSHClient] | None = None,
+        password: str | None = None,
+    ) -> asyncssh.SSHClientConnection:
+        """Single ``asyncssh.connect`` call honoring ``~/.ssh/config``.
+
+        Centralised so the key-auth and password-auth attempts share
+        the exact same option-resolution logic (host alias, port,
+        username override, identityfile, proxycommand).
+        """
+        opts = _parse_openssh_config(self.hostname)
+
+        # When a ProxyCommand is configured, paramiko explicitly passes
+        # the *original* hostname (because the proxy resolves it on the
+        # other side). Mirror that here.
+        target_host: str = (
+            opts.get("hostname", self.hostname)
+            if "proxycommand" not in opts
+            else self.hostname
+        )
+        target_port = int(opts.get("port", self.port))
+        target_user = opts.get("user", self.username)
+        client_keys = opts.get("identityfile") or ()
+        tunnel = opts.get("proxycommand")
+
+        kwargs: dict[str, Any] = {
+            "host": target_host,
+            "port": target_port,
+            "username": target_user,
+            "known_hosts": known_hosts,
+        }
+        if client_factory is not None:
+            kwargs["client_factory"] = client_factory
+        if password is not None:
+            kwargs["password"] = password
+            # Disable public-key auth when we already know we need the
+            # password path; otherwise asyncssh may try the agent first
+            # and fail before getting to the password.
+            kwargs["client_keys"] = ()
+        elif client_keys:
+            kwargs["client_keys"] = client_keys
+        if tunnel:
+            # asyncssh supports proxy_command directly (no tunnel= dance
+            # like the paramiko ProxyCommand class).
+            kwargs["proxy_command"] = tunnel
+
+        return await asyncssh.connect(**kwargs)
+
+    async def connect(self) -> None:
+        """Open the SSH session with key-auth → password-auth fallback.
+
+        Mirrors :meth:`Connection.connect`: tries public key first,
+        falls back to a single interactive password prompt on
+        authentication failure, and re-raises everything else. The
+        ``accept-new`` policy is implemented by an ``SSHClient``
+        subclass (``_make_accept_new_client``) installed via
+        ``client_factory=``.
+        """
+        policy = self.config.host_key_policy
+        kh_arg = _build_known_hosts_arg(policy, self.config.known_hosts)
+        client_factory: type[asyncssh.SSHClient] | None = None
+        if policy == "accept-new":
+            kh_path = self.config.known_hosts or _default_known_hosts_path()
+            client_factory = _make_accept_new_client(kh_path, self.hostname)
+
+        try:
+            logger.debug("connecting to %s:%s", self.hostname, self.port)
+            self._conn = await self._do_connect(
+                known_hosts=kh_arg, client_factory=client_factory
+            )
+            return
+        except asyncssh.HostKeyNotVerifiable:
+            # accept-new and no/off never reach here (they disable the
+            # native checker). Only ``yes`` produces this; bubble up
+            # like paramiko's ``BadHostKeyException``/``RejectPolicy``.
+            logger.error(
+                "host key for %s not in known_hosts (policy=%s)",
+                self.hostname,
+                policy,
+            )
+            raise
+        except asyncssh.PermissionDenied:
+            logger.warning(
+                "Authentication failed on %s: AuthKey missing.", self.hostname
+            )
+            logger.warning("Trying manually, please enter the root password")
+        except asyncssh.DisconnectError as exc:
+            # asyncssh raises DisconnectError for misc transport errors
+            # (closed socket, banner mismatch, ...). Treat as the
+            # paramiko ``SSHException`` equivalent: log + re-raise.
+            logger.error("SSH error while connecting to %s: %s", self.hostname, exc)
+            raise
+        except (OSError, socket.gaierror) as exc:
+            # DNS / connect-refused / network unreachable. Mirror
+            # paramiko's "generic Exception" branch.
+            logger.error("%s: %s", self.hostname, exc)
+            raise
+
+        # Password fallback path. Reached only via the
+        # ``PermissionDenied`` branch above.
+        password = await asyncio.to_thread(getpass.getpass)
+        try:
+            self._conn = await self._do_connect(
+                known_hosts=kh_arg,
+                client_factory=client_factory,
+                password=password,
+            )
+        except asyncssh.PermissionDenied:
+            logger.error("Authentication failed on %s: wrong password", self.hostname)
+            raise
+
+    # ------------------------------------------------------------------
+    # exec / sftp
+    # ------------------------------------------------------------------
+
+    async def run(self, command: str, lock: Any = None) -> tuple[str, str, int]:
+        """Execute ``command`` over the established session.
+
+        Returns ``(stdout, stderr, exitcode)``. Raises ``CommandTimeout``
+        when the per-command timeout fires, matching the paramiko
+        backend's exception type so callers can ``except CommandTimeout``
+        without caring which backend ran.
+
+        ``lock`` is accepted for signature parity with
+        :meth:`Connection.run` and ignored — asyncssh's read loop never
+        prompts the user mid-command (the paramiko backend's
+        "wait? (y/N)" UX is intentionally dropped; a hard timeout is
+        clearer and scripts-friendly).
+        """
+        assert self._conn is not None, "connect() must run first"
+        try:
+            result = await self._conn.run(command, check=False, timeout=self.timeout)
+        except asyncio.TimeoutError as exc:
+            # asyncssh raises asyncio.TimeoutError when its own timeout
+            # fires; translate to the project-wide exception type.
+            raise CommandTimeout(command) from exc
+
+        # asyncssh decodes by default (encoding='utf-8'); stdout/stderr
+        # are str. exit_status may be None for a session torn down
+        # without a normal exit (mirror paramiko's ``-1`` sentinel).
+        stdout = (
+            result.stdout
+            if isinstance(result.stdout, str)
+            else (result.stdout.decode("utf-8", "ignore") if result.stdout else "")
+        )
+        stderr = (
+            result.stderr
+            if isinstance(result.stderr, str)
+            else (result.stderr.decode("utf-8", "ignore") if result.stderr else "")
+        )
+        exitcode = result.exit_status if result.exit_status is not None else -1
+        return stdout, stderr, exitcode
+
+    async def _sftp_open(self) -> asyncssh.SFTPClient:
+        """Open (or reuse) a single SFTP subsystem for this connection.
+
+        Caching mirrors paramiko's ``__sftp_reconnect`` reuse pattern,
+        avoiding the per-call subsystem-setup cost when a command does
+        a flurry of ``listdir`` + multiple ``open`` (see
+        :func:`parse_system`).
+        """
+        assert self._conn is not None, "connect() must run first"
+        if self._sftp is None:
+            self._sftp = await self._conn.start_sftp_client()
+        return self._sftp
+
+    async def listdir(self, path: str = ".") -> list[str]:
+        logger.debug("getting %s:%s:%s listing", self.hostname, self.port, path)
+        sftp = await self._sftp_open()
+        # asyncssh returns ``Sequence[str|bytes]`` depending on the
+        # input encoding; we always pass str, so we always get str.
+        # Filter out ``.`` and ``..`` for paramiko parity (paramiko's
+        # SFTPClient.listdir does so by default).
+        entries = await sftp.listdir(path)
+        return [e for e in entries if e not in (".", "..")]
+
+    async def readlink(self, path: str) -> str | None:
+        logger.debug("read link %s:%s:%s", self.hostname, self.port, path)
+        sftp = await self._sftp_open()
+        link = await sftp.readlink(path)
+        return link if isinstance(link, str) or link is None else link.decode()
+
+    def open(self, filename: str, mode: str = "r") -> "_AsyncSFTPFileCtx":
+        """Return an async context manager yielding a file-like proxy.
+
+        Call sites in :mod:`repose.target.parsers.product` use the
+        async variant via ``async with await target_open(...) as f:``
+        on the async side; the sync paramiko backend still exposes the
+        synchronous version. The proxy returned here implements
+        ``async with`` plus ``for line in f`` (sync iteration over
+        cached lines), and an awaitable ``.read()``. The files we
+        touch (``/etc/os-release``, ``/etc/products.d/*.prod``) are
+        tiny (< 8 KiB), so the eager read on ``__aenter__`` is fine
+        and lets the async parser body stay structurally identical to
+        the sync paramiko parser.
+        """
+        return _AsyncSFTPFileCtx(self, filename, mode)
+
+    def is_active(self) -> bool:
+        return self._conn is not None and not self._conn.is_closed()
+
+    async def close(self) -> None:
+        """Close SFTP (if open) and the SSH session. Idempotent."""
+        logger.debug("closing connection to %s:%s", self.hostname, self.port)
+        if self._sftp is not None:
+            try:
+                self._sftp.exit()
+            except Exception:  # noqa: BLE001
+                pass
+            self._sftp = None
+        if self._conn is not None:
+            self._conn.close()
+            try:
+                await self._conn.wait_closed()
+            except Exception:  # noqa: BLE001
+                pass
+            self._conn = None
+
+
+class _AsyncSFTPFileCtx:
+    """Async context manager backing :meth:`AsyncConnection.open`.
+
+    Designed for two consumption shapes used by the parsers:
+
+    - ``for line in f`` (iterating a small text file)
+    - ``await f.read()`` (slurping the whole file)
+
+    The file is pre-read into memory on ``__aenter__`` so the *async*
+    parser body can stay a near-mirror of the sync paramiko parser.
+    The files we touch are tiny (< 8 KiB) so this is cheap.
+    """
+
+    def __init__(self, conn: AsyncConnection, filename: str, mode: str) -> None:
+        self._conn = conn
+        self._filename = filename
+        self._mode = mode
+        self._content: str | bytes | None = None
+
+    async def __aenter__(self) -> "_AsyncSFTPFileCtx":
+        sftp = await self._conn._sftp_open()
+        async with sftp.open(self._filename, self._mode) as f:
+            data = await f.read()
+        self._content = data
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        self._content = None
+
+    def __iter__(self):
+        if self._content is None:
+            return iter(())
+        if isinstance(self._content, bytes):
+            return iter(
+                self._content.decode("utf-8", "ignore").splitlines(keepends=True)
+            )
+        return iter(self._content.splitlines(keepends=True))
+
+    async def read(self) -> str | bytes:
+        return self._content if self._content is not None else ""

--- a/repose/cli.py
+++ b/repose/cli.py
@@ -52,6 +52,11 @@ class HostKeyPolicyChoice(str, Enum):
     off = "off"
 
 
+class SSHBackendChoice(str, Enum):
+    asyncssh = "asyncssh"
+    paramiko = "paramiko"
+
+
 # ---------------------------------------------------------------------------
 # Global state carrier
 # ---------------------------------------------------------------------------
@@ -73,9 +78,11 @@ class CliGlobals:
     format: str = "text"
     strict_host_key_checking: str = "accept-new"
     known_hosts: Optional[Path] = None
+    ssh_backend: str = "asyncssh"
     # The ``ConnectionConfig`` derived from ``strict_host_key_checking``
-    # + ``known_hosts``; threaded into ``ParseHosts`` so ``-t`` parsing
-    # builds ``Target``s with the correct transport policy.
+    # + ``known_hosts`` + ``ssh_backend``; threaded into ``ParseHosts``
+    # so ``-t`` parsing builds ``Target``/``AsyncTarget``s with the
+    # correct transport policy.
     conn_config: ConnectionConfig = ConnectionConfig()
 
 
@@ -155,6 +162,7 @@ def _build_ns(ctx: typer.Context, **subcmd_kwargs: object) -> argparse.Namespace
         format=g.format,
         strict_host_key_checking=g.strict_host_key_checking,
         known_hosts=g.known_hosts,
+        ssh_backend=g.ssh_backend,
         **subcmd_kwargs,
     )
     return ns
@@ -311,6 +319,19 @@ def main_callback(
             help="path to a custom known_hosts file (overrides ~/.ssh/known_hosts)",
         ),
     ] = None,
+    ssh_backend: Annotated[
+        SSHBackendChoice,
+        typer.Option(
+            "--ssh-backend",
+            case_sensitive=False,
+            help=(
+                "SSH backend implementation: "
+                "'asyncssh' (default, structured concurrency, no thread "
+                "pool) or 'paramiko' (legacy, available for one release "
+                "as a safety net while asyncssh settles)"
+            ),
+        ),
+    ] = SSHBackendChoice.asyncssh,
 ) -> None:
     """Repository manipulation tool for QAM."""
     # Mutual exclusion: argparse used a ``mutually_exclusive_group``;
@@ -327,9 +348,11 @@ def main_callback(
     # keeps comparing against ``"json"`` / ``"yes"`` and friends.
     fmt_str = format_.value
     hkp_str = strict_host_key_checking.value
+    backend_str = ssh_backend.value
     cfg = ConnectionConfig(
         host_key_policy=hkp_str,  # type: ignore[arg-type]
         known_hosts=known_hosts,
+        ssh_backend=backend_str,  # type: ignore[arg-type]
     )
     ctx.obj = CliGlobals(
         dry=dry,
@@ -340,6 +363,7 @@ def main_callback(
         format=fmt_str,
         strict_host_key_checking=hkp_str,
         known_hosts=known_hosts,
+        ssh_backend=backend_str,
         conn_config=cfg,
     )
 

--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -1,22 +1,24 @@
 from abc import ABC, abstractmethod
 from argparse import Namespace
+import asyncio
 import concurrent.futures
 from concurrent.futures import Future
 import functools
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Iterable
+from typing import Any, Awaitable, Callable, ClassVar, Iterable
 
 from ..console import Console
 from ..display import CommandDisplay, JsonCommandDisplay
 from ..progress import Progress
+from ..target.async_hostgroup import AsyncHostGroup
 from ..target.hostgroup import HostGroup
 from ..template import load_template
 from ..template.resolver import Repoq
 from ..types import ExitCode
 from ..types.repa import Repa
-from ..utils import check_repo_url
+from ..utils import check_repo_url, check_repo_url_async
 
 logger = logging.getLogger("repose.command")
 
@@ -59,14 +61,28 @@ class Command(ABC):
             for x in args.target:
                 __dtargets.update(x)
 
-        targets = HostGroup(__dtargets)
-        targets.connect()
+        # Backend selection. ``ssh_backend`` is set unconditionally by
+        # the typer CLI; tests that build a Namespace directly may
+        # omit it — default to "paramiko" there so the sync path
+        # remains the unchanged baseline for legacy fixtures.
+        self.ssh_backend: str = getattr(args, "ssh_backend", "paramiko")
+        self._is_async: bool = self.ssh_backend == "asyncssh"
 
-        # cann't  use dict comprehension - custom dict for hostgroup:(
-        for target in list(targets.keys()):
-            if not targets[target]:
-                del targets[target]
-        self.targets = targets
+        if self._is_async:
+            targets_a: AsyncHostGroup = AsyncHostGroup(__dtargets)
+            asyncio.run(targets_a.connect())
+            for target in list(targets_a.keys()):
+                if not targets_a[target]:
+                    del targets_a[target]
+            self.targets = targets_a  # type: ignore[assignment]
+        else:
+            targets_s: HostGroup = HostGroup(__dtargets)
+            targets_s.connect()
+            # cann't  use dict comprehension - custom dict for hostgroup:(
+            for target in list(targets_s.keys()):
+                if not targets_s[target]:
+                    del targets_s[target]
+            self.targets = targets_s  # type: ignore[assignment]
 
         self.dryrun: bool = args.dry
         # ``args.config`` is already a ``Path`` (argparse ``type=Path``);
@@ -233,6 +249,98 @@ class Command(ABC):
             return 2
         return 1
 
+    async def _aworker(
+        self,
+        fn: Callable[..., Awaitable[bool]],
+        host: str,
+        prog: Progress,
+        extra: tuple[Any, ...],
+    ) -> bool:
+        """Async sibling of :meth:`_worker`.
+
+        Same progress-bookkeeping contract; awaits the coroutine
+        produced by ``fn`` instead of calling a sync function. Used
+        by :meth:`_arun_parallel` on the asyncssh backend.
+        """
+        prog.update(host, "running")
+        try:
+            ok = await fn(host, prog.update, *extra)
+        except Exception:
+            prog.update(host, "[red]failed")
+            raise
+        prog.update(host, "[green]done" if ok else "[red]failed")
+        return ok
+
+    async def _arun_parallel(
+        self,
+        fn: Callable[..., Awaitable[bool]],
+        *extra_args: Any,
+    ) -> list[asyncio.Task[bool]]:
+        """Async fan-out via :class:`asyncio.TaskGroup`.
+
+        Mirror of :meth:`_run_parallel` but every worker is a
+        coroutine. Per-host exceptions are *not* swallowed here — they
+        surface on the returned tasks and feed :meth:`_aggregate_tasks`
+        for exit-code propagation, exactly like the sync path's
+        ``Future.exception()`` flow.
+
+        The progress overlay (rich ``Live``) is started on the main
+        thread before any coroutine runs; this is the same invariant
+        the sync path relies on and keeps the asyncssh path free of
+        thread-vs-event-loop renderer interactions.
+        """
+
+        # Trap exceptions inside the per-task wrapper so the TaskGroup
+        # default cancel-siblings semantic doesn't tear down hosts
+        # that are still making forward progress when one fails.
+        async def _trap(coro: Awaitable[bool]) -> bool | BaseException:
+            try:
+                return await coro
+            except BaseException as exc:  # noqa: BLE001
+                return exc
+
+        with self._make_progress() as prog:
+            async with asyncio.TaskGroup() as tg:
+                tasks = [
+                    tg.create_task(
+                        _trap(self._aworker(fn, host, prog, extra_args)),
+                        name=f"arun:{host}",
+                    )
+                    for host in self.targets.keys()
+                ]
+        return tasks  # type: ignore[return-value]
+
+    def _aggregate_tasks(self, tasks: list[asyncio.Task[Any]]) -> ExitCode:
+        """Collapse async task results into a process exit code.
+
+        Mirror of :meth:`_aggregate` but consumes ``asyncio.Task`` —
+        plus the ``_trap`` wrapper in :meth:`_arun_parallel` may have
+        returned a ``BaseException`` instance instead of raising;
+        treat such returns as failures.
+
+        Returns the same 0/1/2 triplet as the sync aggregator.
+        """
+        total = len(tasks)
+        if total == 0:
+            return 0
+        failed = 0
+        for t in tasks:
+            # Tasks always finished by the time TaskGroup exited.
+            if t.exception() is not None:
+                failed += 1
+                continue
+            result = t.result()
+            if isinstance(result, BaseException):
+                failed += 1
+                continue
+            if result is False:
+                failed += 1
+        if failed == 0:
+            return 0
+        if failed == total:
+            return 2
+        return 1
+
     def _filter_live_urls(self, repos: Iterable[Any]) -> list[Any]:
         """Return only the repos whose URL passes ``check_repo_url``.
 
@@ -259,6 +367,57 @@ class Command(ABC):
             )
         return [r for r, ok in zip(repos, alive) if ok]
 
-    @abstractmethod
+    async def _afilter_live_urls(self, repos: Iterable[Any]) -> list[Any]:
+        """Async equivalent of :meth:`_filter_live_urls` using ``httpx``.
+
+        Same contract — ``no_probe`` short-circuits, ``probe_timeout``
+        bounds each probe, the returned list preserves input order —
+        and the same effective concurrency cap of 16 (via a
+        ``asyncio.Semaphore``) so a single mirror doesn't see a
+        thundering herd of connections from one cohort.
+        """
+        repos = list(repos)
+        if self.no_probe or not repos:
+            return repos
+        sem = asyncio.Semaphore(min(16, len(repos)))
+
+        async def _gated(repo: Any) -> bool:
+            async with sem:
+                return await check_repo_url_async(repo.url, timeout=self.probe_timeout)
+
+        alive = await asyncio.gather(*(_gated(r) for r in repos))
+        return [r for r, ok in zip(repos, alive) if ok]
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
     def run(self) -> ExitCode:
+        """Dispatch to the sync or async command body.
+
+        Concrete subclasses implement :meth:`_srun` (sync, paramiko
+        backend) and optionally :meth:`_arun` (async, asyncssh
+        backend). When a subclass omits ``_arun`` we fall through to
+        ``_srun`` even on the async backend — this is the safety net
+        for read-only commands whose work is in-memory only (list,
+        known-products) and don't benefit from an async rewrite.
+        """
+        if self._is_async and type(self)._arun is not Command._arun:
+            return asyncio.run(self._arun())
+        return self._srun()
+
+    @abstractmethod
+    def _srun(self) -> ExitCode:
+        """Sync command body — runs on the paramiko backend."""
         return 0
+
+    async def _arun(self) -> ExitCode:
+        """Async command body — overridden by subclasses that need it.
+
+        The default raises ``NotImplementedError``; commands that don't
+        override it must still work because :meth:`run` only routes
+        here when ``_arun`` is overridden (the ``Command._arun`` identity
+        check above). The body remains so subclasses have a canonical
+        signature to override against.
+        """
+        raise NotImplementedError(f"{type(self).__name__}._arun() is not implemented")

--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -54,6 +54,13 @@ class Command(ABC):
     rrpdtcmd: str = "transactional-update pkg rm -t product -l -f {products}"
     reboot: str = "rebootmgrctl reboot now"
 
+    # Runtime backend selection produces one of two concrete dict-like
+    # host groups. Commands' ``_srun``/``_arun`` bodies pick the
+    # appropriate branch (see :meth:`run`); the union is declared here
+    # so callers narrow it with ``isinstance`` instead of leaning on
+    # blanket type-checker suppressions.
+    targets: AsyncHostGroup | HostGroup
+
     def __init__(self, args: Namespace) -> None:
         __dtargets: dict = {}
 
@@ -74,7 +81,7 @@ class Command(ABC):
             for target in list(targets_a.keys()):
                 if not targets_a[target]:
                     del targets_a[target]
-            self.targets = targets_a  # type: ignore[assignment]
+            self.targets = targets_a
         else:
             targets_s: HostGroup = HostGroup(__dtargets)
             targets_s.connect()
@@ -82,7 +89,7 @@ class Command(ABC):
             for target in list(targets_s.keys()):
                 if not targets_s[target]:
                     del targets_s[target]
-            self.targets = targets_s  # type: ignore[assignment]
+            self.targets = targets_s
 
         self.dryrun: bool = args.dry
         # ``args.config`` is already a ``Path`` (argparse ``type=Path``);
@@ -275,7 +282,7 @@ class Command(ABC):
         self,
         fn: Callable[..., Awaitable[bool]],
         *extra_args: Any,
-    ) -> list[asyncio.Task[bool]]:
+    ) -> list[asyncio.Task[bool | BaseException]]:
         """Async fan-out via :class:`asyncio.TaskGroup`.
 
         Mirror of :meth:`_run_parallel` but every worker is a
@@ -308,7 +315,7 @@ class Command(ABC):
                     )
                     for host in self.targets.keys()
                 ]
-        return tasks  # type: ignore[return-value]
+        return tasks
 
     def _aggregate_tasks(self, tasks: list[asyncio.Task[Any]]) -> ExitCode:
         """Collapse async task results into a process exit code.

--- a/repose/command/add.py
+++ b/repose/command/add.py
@@ -2,6 +2,7 @@ from itertools import chain
 import logging
 
 from . import Command, UpdateFn
+from ..target.async_hostgroup import AsyncHostGroup
 from ..types import ExitCode
 
 logger = logging.getLogger("repose.command.add")
@@ -127,6 +128,8 @@ class Add(Command, name="add"):
         # Same orchestration as ``_srun``, but every fan-out is an
         # ``await`` on the AsyncHostGroup. Repoq is still materialised
         # up-front so workers all observe the same instance.
+        if not isinstance(self.targets, AsyncHostGroup):
+            raise TypeError("_arun requires the asyncssh backend")
         _ = self.repoq
         await self.targets.read_products()
         tasks = await self._arun_parallel(self._arun_one)

--- a/repose/command/add.py
+++ b/repose/command/add.py
@@ -55,7 +55,62 @@ class Add(Command, name="add"):
                     ok = False
         return ok
 
-    def run(self) -> ExitCode:
+    async def _aadd(self, target) -> tuple[set[str], bool]:
+        """Async sibling of ``_add`` — uses async URL probing.
+
+        Identical to ``_add`` except for ``_afilter_live_urls`` in
+        place of the threaded ``_filter_live_urls``. Kept in sync
+        manually; the test suite covers both code paths.
+        """
+        from itertools import chain
+
+        repolist = []
+        cmds: set[str] = set()
+        ok = True
+        for repa in self.repa:
+            try:
+                repolist += chain.from_iterable(
+                    x
+                    for x in self.repoq.solve_repa(
+                        repa, self.targets[target].products.get_base()
+                    ).values()
+                )
+            except ValueError as error:
+                logger.error(error)
+                ok = False
+        live = await self._afilter_live_urls(repolist)
+        cmds.update(
+            self.addcmd.format(
+                name=x.name,
+                url=x.url,
+                params="-cfkn" if x.refresh else "-ckn",
+            )
+            for x in live
+        )
+        return cmds, ok
+
+    async def _arun_one(self, target: str, update: UpdateFn) -> bool:
+        """Async per-host worker — mirror of ``_run`` for asyncssh.
+
+        Structurally identical to ``_run``; the differences are the
+        ``await``s on the SSH calls and the async URL probing inside
+        ``_aadd``. ``_report_target`` stays sync because it touches
+        in-memory state only.
+        """
+        update(target, "resolving repos")
+        cmds, ok = await self._aadd(target)
+        if cmds:
+            update(target, f"adding {len(cmds)} repo(s)")
+        for cmd in cmds:
+            if self.dryrun:
+                self.console.dry(target, cmd)
+            else:
+                await self.targets[target].run(cmd)
+                if not self._report_target(target):
+                    ok = False
+        return ok
+
+    def _srun(self) -> ExitCode:
         # Materialise the shared ``Repoq`` on the main thread before
         # ``_run_parallel`` spawns workers (see ``Command.repoq``).
         _ = self.repoq
@@ -67,3 +122,17 @@ class Add(Command, name="add"):
         self.targets.close()
 
         return self._aggregate(futures)
+
+    async def _arun(self) -> ExitCode:
+        # Same orchestration as ``_srun``, but every fan-out is an
+        # ``await`` on the AsyncHostGroup. Repoq is still materialised
+        # up-front so workers all observe the same instance.
+        _ = self.repoq
+        await self.targets.read_products()
+        tasks = await self._arun_parallel(self._arun_one)
+
+        if not self.dryrun:
+            await self.targets.run(self.refcmd)
+        await self.targets.close()
+
+        return self._aggregate_tasks(tasks)

--- a/repose/command/clear.py
+++ b/repose/command/clear.py
@@ -1,6 +1,7 @@
 import logging
 
 from . import Command, UpdateFn
+from ..target.async_hostgroup import AsyncHostGroup
 from ..types import ExitCode
 
 
@@ -42,6 +43,8 @@ class Clear(Command, name="clear"):
         return self._aggregate(futures)
 
     async def _arun(self) -> ExitCode:
+        if not isinstance(self.targets, AsyncHostGroup):
+            raise TypeError("_arun requires the asyncssh backend")
         await self.targets.read_repos()
         tasks = await self._arun_parallel(self._arun_one)
         await self.targets.close()

--- a/repose/command/clear.py
+++ b/repose/command/clear.py
@@ -23,8 +23,26 @@ class Clear(Command, name="clear"):
         logger.info("Repositories cleared from %s", host)
         return True
 
-    def run(self) -> ExitCode:
+    async def _arun_one(self, host: str, update: UpdateFn) -> bool:
+        update(host, "clearing repos")
+        repoaliases = self._clear(host)
+
+        if self.dryrun:
+            self.console.dry(host, self.rrcmd.format(repos=" ".join(repoaliases)))
+            return True
+
+        await self.targets[host].run(self.rrcmd.format(repos=" ".join(repoaliases)))
+        logger.info("Repositories cleared from %s", host)
+        return True
+
+    def _srun(self) -> ExitCode:
         self.targets.read_repos()
         futures = self._run_parallel(self._run)
         self.targets.close()
         return self._aggregate(futures)
+
+    async def _arun(self) -> ExitCode:
+        await self.targets.read_repos()
+        tasks = await self._arun_parallel(self._arun_one)
+        await self.targets.close()
+        return self._aggregate_tasks(tasks)

--- a/repose/command/install.py
+++ b/repose/command/install.py
@@ -67,7 +67,69 @@ class Install(Command, name="install"):
             ok = False
         return ok
 
-    def run(self) -> ExitCode:
+    async def _arun_one(self, target: str, update: UpdateFn) -> bool:
+        """Async per-host worker — mirror of ``_run`` for asyncssh.
+
+        Identical structure; only the ``targets[target].run(...)``
+        calls become ``await``s.
+        """
+        update(target, "resolving repos")
+        repositories: dict = {}
+        ok = True
+        for repa in self.repa:
+            try:
+                repositories.update(
+                    self.repoq.solve_repa(
+                        repa, self.targets[target].products.get_base()
+                    )
+                )
+            except ValueError as error:
+                logger.error(error)
+                ok = False
+
+        all_repos = list(chain.from_iterable(repositories.values()))
+        live_repos = await self._afilter_live_urls(all_repos)
+        if live_repos:
+            update(target, f"adding {len(live_repos)} repo(s)")
+        for repo in live_repos:
+            addcmd = self.addcmd.format(
+                name=repo.name,
+                url=repo.url,
+                params="-cfkn" if repo.refresh else "-ckn",
+            )
+            if self.dryrun:
+                self.console.dry(target, addcmd)
+            else:
+                await self.targets[target].run(addcmd)
+                if not self._report_target(target):
+                    ok = False
+                await self.targets[target].run(self.refcmd)
+
+        if repositories.keys():
+            transactional = False
+            if "SL-Micro" in repositories.keys():
+                transactional = True
+                inscmd = self.ipdtcmd.format(products=" ".join(repositories.keys()))
+            else:
+                inscmd = self.ipdcmd.format(products=" ".join(repositories.keys()))
+            update(target, "installing products")
+            if self.dryrun:
+                self.console.dry(str(target), inscmd)
+            else:
+                await self.targets[target].run(inscmd)
+                if not self._report_target(target):
+                    ok = False
+                if transactional:
+                    logger.info(
+                        "Reboot %s to switch into correct snapshot",
+                        str(target),
+                    )
+        else:
+            logger.error("No products to install")
+            ok = False
+        return ok
+
+    def _srun(self) -> ExitCode:
         # Materialise the shared ``Repoq`` on the main thread before
         # ``_run_parallel`` spawns workers (see ``Command.repoq``).
         _ = self.repoq
@@ -76,3 +138,11 @@ class Install(Command, name="install"):
         futures = self._run_parallel(self._run)
         self.targets.close()
         return self._aggregate(futures)
+
+    async def _arun(self) -> ExitCode:
+        _ = self.repoq
+        await self.targets.read_products()
+        await self.targets.read_repos()
+        tasks = await self._arun_parallel(self._arun_one)
+        await self.targets.close()
+        return self._aggregate_tasks(tasks)

--- a/repose/command/install.py
+++ b/repose/command/install.py
@@ -2,6 +2,7 @@ from itertools import chain
 import logging
 
 from . import Command, UpdateFn
+from ..target.async_hostgroup import AsyncHostGroup
 from ..types import ExitCode
 
 logger = logging.getLogger("repose.command.install")
@@ -140,6 +141,8 @@ class Install(Command, name="install"):
         return self._aggregate(futures)
 
     async def _arun(self) -> ExitCode:
+        if not isinstance(self.targets, AsyncHostGroup):
+            raise TypeError("_arun requires the asyncssh backend")
         _ = self.repoq
         await self.targets.read_products()
         await self.targets.read_repos()

--- a/repose/command/known.py
+++ b/repose/command/known.py
@@ -4,7 +4,7 @@ from ..types import ExitCode
 
 
 class KnownProducts(Command, name="known-products"):
-    def run(self) -> ExitCode:
+    def _srun(self) -> ExitCode:
         template = load_template(self.template_path)
         self.display.list_known_products(sorted(template.keys()))
         return 0

--- a/repose/command/list.py
+++ b/repose/command/list.py
@@ -7,19 +7,36 @@ logger = logging.getLogger("repose.command.list")
 
 
 class ListRepos(Command, name="list-repos"):
-    def run(self) -> ExitCode:
+    def _srun(self) -> ExitCode:
         self.targets.read_repos()
         self.targets.report_repos(self.display.list_update_repos)
         self.targets.close()
         return 0
 
+    async def _arun(self) -> ExitCode:
+        await self.targets.read_repos()
+        # ``report_repos`` stays sync on both backends (touches
+        # in-memory state only).
+        self.targets.report_repos(self.display.list_update_repos)
+        await self.targets.close()
+        return 0
+
 
 class ListProducts(Command, name="list-products"):
-    def run(self) -> ExitCode:
+    def _srun(self) -> ExitCode:
         self.targets.read_products()
         if self.yaml:
             self.targets.report_products_yaml(self.display.list_products_yaml)
         else:
             self.targets.report_products(self.display.list_products)
         self.targets.close()
+        return 0
+
+    async def _arun(self) -> ExitCode:
+        await self.targets.read_products()
+        if self.yaml:
+            self.targets.report_products_yaml(self.display.list_products_yaml)
+        else:
+            self.targets.report_products(self.display.list_products)
+        await self.targets.close()
         return 0

--- a/repose/command/list.py
+++ b/repose/command/list.py
@@ -1,6 +1,7 @@
 import logging
 
 from . import Command
+from ..target.async_hostgroup import AsyncHostGroup
 from ..types import ExitCode
 
 logger = logging.getLogger("repose.command.list")
@@ -14,6 +15,8 @@ class ListRepos(Command, name="list-repos"):
         return 0
 
     async def _arun(self) -> ExitCode:
+        if not isinstance(self.targets, AsyncHostGroup):
+            raise TypeError("_arun requires the asyncssh backend")
         await self.targets.read_repos()
         # ``report_repos`` stays sync on both backends (touches
         # in-memory state only).
@@ -33,6 +36,8 @@ class ListProducts(Command, name="list-products"):
         return 0
 
     async def _arun(self) -> ExitCode:
+        if not isinstance(self.targets, AsyncHostGroup):
+            raise TypeError("_arun requires the asyncssh backend")
         await self.targets.read_products()
         if self.yaml:
             self.targets.report_products_yaml(self.display.list_products_yaml)

--- a/repose/command/remove.py
+++ b/repose/command/remove.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Iterable
 
 from . import Command, UpdateFn
+from ..target.async_hostgroup import AsyncHostGroup
 from ..types import ExitCode
 from ..types.repa import Repa
 
@@ -101,6 +102,8 @@ class Remove(Command, name="remove"):
         return self._aggregate(futures)
 
     async def _arun(self) -> ExitCode:
+        if not isinstance(self.targets, AsyncHostGroup):
+            raise TypeError("_arun requires the asyncssh backend")
         await self.targets.read_repos()
         await self.targets.parse_repos()
         tasks = await self._arun_parallel(self._arun_one)

--- a/repose/command/remove.py
+++ b/repose/command/remove.py
@@ -71,9 +71,38 @@ class Remove(Command, name="remove"):
         self.targets[host].run(cmd)
         return self._report_target(host)
 
-    def run(self) -> ExitCode:
+    async def _arun_one(self, host: str, update: UpdateFn, *args: Any) -> bool:
+        update(host, "computing patterns")
+        patterns = self._calculate_pattern(self.repa, host)
+
+        if not patterns:
+            logger.info("For %s no repos for remove found", host)
+            return True
+        repolist = self._calculate_repolist(host, patterns)
+
+        if not repolist:
+            logger.info("For %s no repos for remove found", host)
+            return True
+        cmd = self.rrcmd.format(repos=" ".join(repolist))
+
+        if self.dryrun:
+            self.console.dry(host, cmd)
+            return True
+
+        update(host, f"removing {len(repolist)} repo(s)")
+        await self.targets[host].run(cmd)
+        return self._report_target(host)
+
+    def _srun(self) -> ExitCode:
         self.targets.read_repos()
         self.targets.parse_repos()
         futures = self._run_parallel(self._run)
         self.targets.close()
         return self._aggregate(futures)
+
+    async def _arun(self) -> ExitCode:
+        await self.targets.read_repos()
+        await self.targets.parse_repos()
+        tasks = await self._arun_parallel(self._arun_one)
+        await self.targets.close()
+        return self._aggregate_tasks(tasks)

--- a/repose/command/reset.py
+++ b/repose/command/reset.py
@@ -3,6 +3,7 @@ import logging
 
 from . import UpdateFn
 from ..messages import UnsuportedProductMessage
+from ..target.async_hostgroup import AsyncHostGroup
 from ..types import ExitCode
 from .clear import Clear
 
@@ -107,6 +108,8 @@ class Reset(Clear, name="reset"):
         return self._aggregate(futures)
 
     async def _arun(self) -> ExitCode:
+        if not isinstance(self.targets, AsyncHostGroup):
+            raise TypeError("_arun requires the asyncssh backend")
         _ = self.repoq
         await self.targets.read_products()
         await self.targets.read_repos()

--- a/repose/command/reset.py
+++ b/repose/command/reset.py
@@ -53,7 +53,50 @@ class Reset(Clear, name="reset"):
             ok = False
         return ok
 
-    def run(self) -> ExitCode:
+    async def _aadd(self, target) -> set[str]:
+        """Async sibling of ``_add`` — uses async URL probing."""
+        cmds: set[str] = set()
+        repolist = chain.from_iterable(
+            x for x in self.repoq.solve_product(self.targets[target].products).values()
+        )
+        live = await self._afilter_live_urls(repolist)
+        cmds.update(
+            self.addcmd.format(
+                name=x.name,
+                url=x.url,
+                params="-cfkn" if x.refresh else "-ckn",
+            )
+            for x in live
+        )
+        return cmds
+
+    async def _arun_one(self, host: str, update: UpdateFn) -> bool:
+        update(host, "clearing repos")
+        repoaliases = self._clear(host)
+        ok = True
+        try:
+            update(host, "resolving new repos")
+            cmds = await self._aadd(host)
+
+            if self.dryrun:
+                self.console.dry(host, self.rrcmd.format(repos=" ".join(repoaliases)))
+                for cmd in cmds:
+                    self.console.dry(host, cmd)
+                return True
+
+            if cmds:
+                update(host, f"re-adding {len(cmds)} repo(s)")
+            await self.targets[host].run(self.rrcmd.format(repos=" ".join(repoaliases)))
+            for cmd in cmds:
+                await self.targets[host].run(cmd)
+                if not self._report_target(host):
+                    ok = False
+        except UnsuportedProductMessage as e:
+            logger.error("Refhost %s - %s", host, e)
+            ok = False
+        return ok
+
+    def _srun(self) -> ExitCode:
         # Materialise the shared ``Repoq`` on the main thread before
         # ``_run_parallel`` spawns workers (see ``Command.repoq``).
         _ = self.repoq
@@ -62,3 +105,11 @@ class Reset(Clear, name="reset"):
         futures = self._run_parallel(self._run)
         self.targets.close()
         return self._aggregate(futures)
+
+    async def _arun(self) -> ExitCode:
+        _ = self.repoq
+        await self.targets.read_products()
+        await self.targets.read_repos()
+        tasks = await self._arun_parallel(self._arun_one)
+        await self.targets.close()
+        return self._aggregate_tasks(tasks)

--- a/repose/command/uninstall.py
+++ b/repose/command/uninstall.py
@@ -72,7 +72,51 @@ class Uninstall(Remove, name="uninstall"):
             logger.info("Reboot %s to switch into updated snapshot", host)
         return ok
 
-    def run(self) -> ExitCode:
+    async def _arun_one(self, host: str, update: UpdateFn, *args: Any) -> bool:
+        orepa = args[0]
+        update(host, "computing patterns")
+        patterns = self._calculate_pattern(orepa, host)
+        if not patterns:
+            logger.info("For %s no products for remove found", host)
+            return True
+
+        rdict = self._calculate_repodict(host, patterns)
+        if not rdict:
+            logger.info("For %s no repos for remove found", host)
+            rrcmd = False
+        else:
+            rrcmd = self.rrcmd.format(
+                repos=" ".join(chain.from_iterable(rdict.values()))
+            )
+
+        transactional = any(p.split(":", 1)[0] == "SL-Micro" for p in patterns)
+        products_arg = " ".join(x.split(":")[0] for x in patterns)
+        if transactional:
+            pdcmd = self.rrpdtcmd.format(products=products_arg)
+        else:
+            pdcmd = self.rrpcmd.format(products=products_arg)
+
+        if self.dryrun:
+            if rrcmd:
+                self.console.dry(host, rrcmd)
+            self.console.dry(host, pdcmd)
+            return True
+
+        ok = True
+        if rrcmd:
+            update(host, "removing repos")
+            await self.targets[host].run(rrcmd)
+            if not self._report_target(host):
+                ok = False
+        update(host, "removing products")
+        await self.targets[host].run(pdcmd)
+        if not self._report_target(host):
+            ok = False
+        if transactional:
+            logger.info("Reboot %s to switch into updated snapshot", host)
+        return ok
+
+    def _srun(self) -> ExitCode:
         self.targets.read_repos()
         self.targets.parse_repos()
         orepa = [dataclasses.replace(r, repo=None) for r in self.repa]
@@ -80,3 +124,12 @@ class Uninstall(Remove, name="uninstall"):
         futures = self._run_parallel(self._run, orepa)
         self.targets.close()
         return self._aggregate(futures)
+
+    async def _arun(self) -> ExitCode:
+        await self.targets.read_repos()
+        await self.targets.parse_repos()
+        orepa = [dataclasses.replace(r, repo=None) for r in self.repa]
+
+        tasks = await self._arun_parallel(self._arun_one, orepa)
+        await self.targets.close()
+        return self._aggregate_tasks(tasks)

--- a/repose/command/uninstall.py
+++ b/repose/command/uninstall.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from . import UpdateFn
 from .remove import Remove
+from ..target.async_hostgroup import AsyncHostGroup
 from ..types import ExitCode
 
 
@@ -126,6 +127,8 @@ class Uninstall(Remove, name="uninstall"):
         return self._aggregate(futures)
 
     async def _arun(self) -> ExitCode:
+        if not isinstance(self.targets, AsyncHostGroup):
+            raise TypeError("_arun requires the asyncssh backend")
         await self.targets.read_repos()
         await self.targets.parse_repos()
         orepa = [dataclasses.replace(r, repo=None) for r in self.repa]

--- a/repose/host.py
+++ b/repose/host.py
@@ -1,7 +1,9 @@
 from argparse import ArgumentTypeError
+from typing import Any
 from urllib.parse import urlparse
 
 from .target import Target
+from .target.async_target import AsyncTarget
 from .types.connection_config import ConnectionConfig
 
 
@@ -19,8 +21,15 @@ class PortNotIntError(HostParseError):
         super().__init__(f"Wrong port specification on Host: {hostname}")
 
 
-def _parse_host_string(arg: str, config: ConnectionConfig) -> dict[str, Target]:
-    """Parse a ``[user@]host[:port]`` string into a ``{key: Target}`` dict."""
+def _parse_host_string(arg: str, config: ConnectionConfig) -> dict[str, Any]:
+    """Parse a ``[user@]host[:port]`` string into a ``{key: Target}`` dict.
+
+    The concrete target type — ``Target`` (paramiko) or ``AsyncTarget``
+    (asyncssh) — is selected by ``config.ssh_backend``. The dict's
+    value type is widened to ``Any`` because callers handle both
+    synchronously: ``HostGroup``/``AsyncHostGroup`` only ever wrap one
+    flavour of target at a time, picked the same way upstream.
+    """
     x = urlparse(f"//{arg}")
     hostname = x.hostname or ""
     try:
@@ -33,7 +42,8 @@ def _parse_host_string(arg: str, config: ConnectionConfig) -> dict[str, Target]:
 
         username = x.username if x.username else "root"
 
-        return {keyname: Target(hostname, port, username, config=config)}
+        target_cls: type = AsyncTarget if config.ssh_backend == "asyncssh" else Target
+        return {keyname: target_cls(hostname, port, username, config=config)}
     except ValueError:
         raise PortNotIntError(hostname)
 

--- a/repose/target/async_hostgroup.py
+++ b/repose/target/async_hostgroup.py
@@ -1,0 +1,108 @@
+"""Async equivalent of :class:`repose.target.hostgroup.HostGroup`.
+
+Uses :class:`asyncio.TaskGroup` for structured concurrency: Ctrl-C
+cancels every in-flight host coroutine cleanly, and unhandled
+exceptions surface as ``ExceptionGroup`` (Python 3.11+).
+
+**Important semantics**: we want "one host failure does not cancel
+siblings" (parity with the sync ``HostGroup``). ``TaskGroup``'s
+default is the opposite — a raising task cancels the group. We
+therefore wrap each per-host coroutine in :func:`_isolate` which
+catches and logs, so the ``TaskGroup`` never sees an exception. This
+costs us the "first-failure cancels siblings" upside from the plan,
+which is the right call for ``connect``/``read_*``/``run`` (we want
+every host to be attempted) — the upshot is that commands still get
+to inspect each host's outcome via ``AsyncTarget.is_connected`` /
+``AsyncTarget.out`` exactly like today's sync ``HostGroup``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import UserDict
+from typing import Any, Callable, Coroutine
+
+
+logger = logging.getLogger("repose.target.async_hostgroup")
+
+
+async def _isolate(name: str, coro: Coroutine[Any, Any, Any]) -> None:
+    """Run ``coro`` and log any exception under ``name``.
+
+    Swallowing keeps a single failing host from cancelling its
+    siblings inside an :class:`asyncio.TaskGroup`. The caller
+    inspects per-target state (``is_connected``, ``out``) after the
+    group completes to discover what failed.
+    """
+    try:
+        await coro
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("failed for %s: %s", name, exc)
+
+
+class AsyncHostGroup(UserDict):
+    """Dict-of-AsyncTarget with async fan-out helpers.
+
+    Method set mirrors :class:`repose.target.hostgroup.HostGroup`
+    one-for-one so commands can be backend-agnostic.
+    """
+
+    async def _fanout(
+        self,
+        op_name: str,
+        fn: Callable[[Any], Coroutine[Any, Any, Any]],
+    ) -> None:
+        """Run ``fn(target)`` for every host inside one ``TaskGroup``.
+
+        ``fn`` returns a coroutine for the per-host work; ``op_name``
+        is a short label used in the structured log line on failure.
+        Per-host failures are isolated (see module docstring).
+        """
+        async with asyncio.TaskGroup() as tg:
+            for hn, target in self.data.items():
+                tg.create_task(
+                    _isolate(f"{op_name}:{hn}", fn(target)),
+                    name=f"{op_name}:{hn}",
+                )
+
+    async def connect(self) -> None:
+        await self._fanout("connect", lambda t: t.connect())
+
+    async def close(self) -> None:
+        await self._fanout("close", lambda t: t.close())
+
+    async def read_products(self) -> None:
+        await self._fanout("read_products", lambda t: t.read_products())
+
+    async def read_repos(self) -> None:
+        await self._fanout("read_repos", lambda t: t.read_repos())
+
+    async def parse_repos(self) -> None:
+        await self._fanout("parse_repos", lambda t: t.parse_repos())
+
+    async def run(self, cmd: dict[str, str] | str) -> None:
+        """Broadcast ``cmd`` (or per-host dict) to every host in parallel."""
+
+        def _per_host(hn: str, target: Any) -> Coroutine[Any, Any, Any]:
+            return target.run(cmd[hn] if isinstance(cmd, dict) else cmd)
+
+        async with asyncio.TaskGroup() as tg:
+            for hn, target in self.data.items():
+                tg.create_task(
+                    _isolate(f"run:{hn}", _per_host(hn, target)),
+                    name=f"run:{hn}",
+                )
+
+    # Reporting stays sync — these touch in-memory state only.
+    def report_products(self, sink: Any) -> None:
+        for hn in sorted(self.data.keys()):
+            self.data[hn].report_products(sink)
+
+    def report_products_yaml(self, sink: Any) -> None:
+        for hn in sorted(self.data.keys()):
+            self.data[hn].report_products_yaml(sink)
+
+    def report_repos(self, sink: Any) -> None:
+        for hn in sorted(self.data.keys()):
+            self.data[hn].report_repos(sink)

--- a/repose/target/async_target.py
+++ b/repose/target/async_target.py
@@ -1,0 +1,161 @@
+"""Async equivalent of :class:`repose.target.Target` backed by ``AsyncConnection``.
+
+Public surface mirrors the sync ``Target`` exactly: same attributes
+(``products``, ``raw_repos``, ``repos``, ``out``, ``is_connected``),
+same per-command output shape (``[command, stdout, stderr, exitcode,
+runtime]``), and the same report helpers
+(``report_products``/``report_products_yaml``/``report_repos``) so the
+upstream ``HostGroup.report_*`` iteration loops work unchanged on a
+mixed group.
+
+The only behaviour difference is that the I/O entry points
+(``connect``, ``read_products``, ``read_repos``, ``run``,
+``parse_repos``, ``close``) are coroutines.
+"""
+
+from __future__ import annotations
+
+from logging import getLogger
+from typing import Any
+
+from ..aiossh import AsyncConnection, CommandTimeout
+from ..messages import ConnectingTargetFailedMessage
+from ..types.connection_config import ConnectionConfig
+from ..types.repositories import Repositories
+from ..types.system import System
+from ..utils import timestamp
+from .parsers.product import parse_system_async
+from .parsers.repository import parse_repositories
+
+
+logger = getLogger("repose.target.async_target")
+
+
+class AsyncTarget:
+    def __init__(
+        self,
+        hostname: str,
+        port: int,
+        username: str,
+        connector: type[AsyncConnection] = AsyncConnection,
+        *,
+        config: ConnectionConfig | None = None,
+    ) -> None:
+        self.port = port
+        self.hostname = hostname
+        self.username = username
+        self.products: System | None = None
+        self.raw_repos: Any = None
+        self.repos: Repositories | None = None
+        self.connector = connector
+        self.config: ConnectionConfig = config or ConnectionConfig()
+        self.is_connected = False
+        # ``connector`` is a class (or test stub) accepting the same
+        # signature as ``AsyncConnection`` — fixtures that pass a
+        # lambda swallow ``**kwargs`` already.
+        self.connection: AsyncConnection = self.connector(
+            self.hostname, self.username, self.port, config=self.config
+        )
+        # ``out`` keeps per-command tuples for ``_report_target`` parity
+        # with the sync backend (Command._report_target inspects
+        # ``out[-1]`` regardless of which Target shape it received).
+        self.out: list[list[Any]] = []
+
+    def __repr__(self) -> str:
+        return (
+            f"<{self.__class__.__name__} object "
+            f"{self.username}@{self.hostname}:{self.port} - "
+            f"connected: {self.is_connected}>"
+        )
+
+    async def connect(self) -> "AsyncTarget":
+        if not self.is_connected:
+            logger.info("Connecting to %s:%s", self.hostname, self.port)
+            try:
+                await self.connection.connect()
+            except Exception as e:  # noqa: BLE001
+                # Mirror sync ``Target.connect`` — log critically and
+                # leave ``is_connected`` False so downstream methods
+                # short-circuit instead of raising.
+                logger.critical(
+                    ConnectingTargetFailedMessage(self.hostname, self.port, e)
+                )
+            else:
+                self.is_connected = True
+        return self
+
+    async def read_products(self) -> None:
+        if not self.is_connected:
+            await self.connect()
+        self.products = await parse_system_async(self.connection)
+
+    async def close(self) -> None:
+        await self.connection.close()
+        self.is_connected = False
+
+    def __bool__(self) -> bool:
+        return self.is_connected
+
+    async def run(self, command: str, lock: Any = None) -> tuple[str, str, int] | None:
+        logger.debug("run %s on %s:%s", command, self.hostname, self.port)
+        time_before = timestamp()
+
+        # Pre-initialise mirrors the sync Target — the exception
+        # branches below must never leave stdout/stderr/exitcode
+        # unbound (would raise UnboundLocalError at ``out.append``).
+        stdout, stderr, exitcode = "", "", -1
+
+        try:
+            stdout, stderr, exitcode = await self.connection.run(command, lock)
+        except CommandTimeout:
+            logger.critical('%s: command "%s" timed out', self.hostname, command)
+        except AssertionError:
+            logger.debug("zombie command terminated", exc_info=True)
+            return None
+        except Exception as e:  # noqa: BLE001
+            logger.error('%s: failed to run command "%s"', self.hostname, command)
+            logger.debug("exception %s", e, exc_info=True)
+
+        runtime = int(timestamp()) - int(time_before)
+
+        self.out.append([command, stdout, stderr, exitcode, runtime])
+        return (stdout, stderr, exitcode)
+
+    async def parse_repos(self) -> None:
+        if not self.products:
+            await self.read_products()
+        if not self.raw_repos:
+            await self.read_repos()
+        assert self.products is not None  # narrowed by read_products()
+        self.repos = Repositories(self.raw_repos, self.products.arch())
+
+    async def read_repos(self) -> None:
+        if not self.is_connected:
+            logger.debug("Host %s:%s not connected", self.hostname, self.port)
+            return
+
+        result = await self.run("zypper -x lr")
+        if result is None:
+            raise ValueError(f"Can't read repositories on {self.hostname}:{self.port}")
+        stdout, stderr, exitcode = result
+
+        if exitcode in (0, 106, 6):
+            self.raw_repos = parse_repositories(stdout)
+        else:
+            logger.error(
+                "Can't parse repositories on %s, zypper returned %s exitcode",
+                self.hostname,
+                exitcode,
+            )
+            logger.debug("output:\n %s", stderr)
+            raise ValueError(f"Can't read repositories on {self.hostname}:{self.port}")
+
+    # Report helpers stay sync; they touch in-memory state only.
+    def report_products(self, sink: Any) -> Any:
+        return sink(self.hostname, self.port, self.products)
+
+    def report_products_yaml(self, sink: Any) -> Any:
+        return sink(self.hostname, self.products)
+
+    def report_repos(self, sink: Any) -> Any:
+        return sink(self.hostname, self.port, self.raw_repos)

--- a/repose/target/parsers/product.py
+++ b/repose/target/parsers/product.py
@@ -124,9 +124,9 @@ async def parse_system_async(connection: Any) -> System:
         return System(Product(name, version, arch))
 
     basefile = await connection.readlink("/etc/products.d/baseproduct")
-    if "/" in basefile:  # ty: ignore[unsupported-operator]  # FOLLOWUP-ty-residuals
-        basefile = basefile.split("/")[-1]  # ty: ignore[unresolved-attribute]  # FOLLOWUP-ty-residuals
-    files.remove(basefile)  # ty: ignore[invalid-argument-type]  # FOLLOWUP-ty-residuals
+    if "/" in basefile:  # FOLLOWUP-ty-residuals
+        basefile = basefile.split("/")[-1]  # FOLLOWUP-ty-residuals
+    files.remove(basefile)  # FOLLOWUP-ty-residuals
 
     async with connection.open(f"/etc/products.d/{basefile}") as f:
         logger.debug("Parsing basefile")

--- a/repose/target/parsers/product.py
+++ b/repose/target/parsers/product.py
@@ -9,6 +9,13 @@ from ..parsers import Product
 logger = logging.getLogger("repose.tartget.parsers.product")
 
 
+# Local alias to keep the async-backend type-hint accurate without
+# importing :mod:`repose.aiossh` at module-load time (avoids pulling
+# asyncssh into the sync paramiko path's import graph).
+if False:  # TYPE_CHECKING — but cheaper for ty/ruff
+    from ...aiossh import AsyncConnection  # noqa: F401
+
+
 def __parse_product(prod: Any) -> tuple[str, str, str]:
     root = ET.fromstringlist(prod)
     name = root.find("./name").text  # ty: ignore[unresolved-attribute]  # FOLLOWUP-ty-residuals
@@ -74,6 +81,62 @@ def parse_system(connection: Connection) -> System:
 
     for x in files:
         with connection.open(f"/etc/products.d/{x}") as f:
+            logger.debug("parsing - %s", x)
+            name, version, arch = __parse_product(f)
+            if name.rpartition("-")[-1] != "migration":
+                addons.add(Product(name, version, arch))
+    return System(base, addons)
+
+
+async def parse_system_async(connection: Any) -> System:
+    """Async equivalent of :func:`parse_system` for ``AsyncConnection``.
+
+    Structure mirrors the sync version line-for-line — only the I/O
+    calls (``listdir``, ``readlink``, ``open``) are ``await``ed. The
+    ``_AsyncSFTPFileCtx`` returned by ``AsyncConnection.open`` exposes
+    a sync iterator over its cached contents so the ``__parse_product``
+    /``__parse_os_release`` bodies stay unchanged.
+
+    ``connection`` is typed as ``Any`` because importing ``AsyncConnection``
+    at module load would force asyncssh into the sync paramiko path's
+    import graph for zero runtime benefit.
+    """
+    files: list[str] = []
+    try:
+        files = [
+            x
+            for x in await connection.listdir("/etc/products.d")
+            if x.endswith(".prod")
+        ]
+    except OSError:
+        logger.debug("Not SUSE's system")
+        suse = False
+    else:
+        suse = True
+
+    if not suse:
+        try:
+            async with connection.open("/etc/os-release") as f:
+                name, version, arch = __parse_os_release(f)
+        except FileNotFoundError:
+            return System(Product("rhel", "6", "x86_64"))
+
+        return System(Product(name, version, arch))
+
+    basefile = await connection.readlink("/etc/products.d/baseproduct")
+    if "/" in basefile:  # ty: ignore[unsupported-operator]  # FOLLOWUP-ty-residuals
+        basefile = basefile.split("/")[-1]  # ty: ignore[unresolved-attribute]  # FOLLOWUP-ty-residuals
+    files.remove(basefile)  # ty: ignore[invalid-argument-type]  # FOLLOWUP-ty-residuals
+
+    async with connection.open(f"/etc/products.d/{basefile}") as f:
+        logger.debug("Parsing basefile")
+        name, version, arch = __parse_product(f)
+        base = Product(name, version, arch)
+
+    addons = set()
+
+    for x in files:
+        async with connection.open(f"/etc/products.d/{x}") as f:
             logger.debug("parsing - %s", x)
             name, version, arch = __parse_product(f)
             if name.rpartition("-")[-1] != "migration":

--- a/repose/types/connection_config.py
+++ b/repose/types/connection_config.py
@@ -12,6 +12,7 @@ from typing import Literal
 
 
 HostKeyPolicy = Literal["yes", "accept-new", "no", "off"]
+SSHBackend = Literal["asyncssh", "paramiko"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,8 +30,16 @@ class ConnectionConfig:
             ``None`` the user's system known_hosts (``~/.ssh/known_hosts``
             via ``paramiko.SSHClient.load_system_host_keys``) is used.
         timeout: Per-command SSH read timeout in seconds.
+        ssh_backend: Which SSH library to drive.
+
+            - ``"asyncssh"`` (default) — native async backend; scales
+              to hundreds of hosts without threadpool pressure.
+            - ``"paramiko"`` — legacy threaded backend; available as
+              a one-release safety net while ``asyncssh`` settles in
+              real-world deployments. To be removed.
     """
 
     host_key_policy: HostKeyPolicy = "accept-new"
     known_hosts: Path | None = None
     timeout: float = 120.0
+    ssh_backend: SSHBackend = "asyncssh"

--- a/repose/utils.py
+++ b/repose/utils.py
@@ -32,6 +32,44 @@ def check_repo_url(url: str, *, timeout: float = 5.0) -> bool:
     return False
 
 
+async def check_repo_url_async(url: str, *, timeout: float = 5.0) -> bool:
+    """Async equivalent of :func:`check_repo_url` using ``httpx``.
+
+    Same two-suffix probe order as the sync variant
+    (``repodata/repomd.xml`` then ``suse/repodata/repomd.xml``) so a
+    repository considered live by one backend is also considered live
+    by the other — important for the backend-parity tests. A 2xx-or-3xx
+    response counts as live; anything else (4xx/5xx, timeout, network
+    error) counts as dead, mirroring the sync ``urlopen``-throws
+    semantic.
+
+    HEAD is used in preference to GET to avoid pulling the full
+    ``repomd.xml`` payload, with a GET fallback because some mirrors
+    return 405 on HEAD even though the resource exists.
+
+    A short-lived ``httpx.AsyncClient`` is created per call; the
+    cohort-level batching is the caller's job
+    (:meth:`Command._afilter_live_urls`).
+    """
+    import httpx
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        for suffix in ("repodata/repomd.xml", "suse/repodata/repomd.xml"):
+            target = url + suffix
+            try:
+                resp = await client.head(target, follow_redirects=True)
+                if resp.status_code < 400:
+                    return True
+                if resp.status_code == 405:
+                    # Some mirrors disallow HEAD; retry with GET.
+                    resp = await client.get(target, follow_redirects=True)
+                    if resp.status_code < 400:
+                        return True
+            except (httpx.HTTPError, OSError):
+                continue
+    return False
+
+
 def _color_enabled() -> bool:
     """Decide whether ANSI color sequences should be emitted.
 

--- a/tests/command/test_command_base.py
+++ b/tests/command/test_command_base.py
@@ -12,7 +12,7 @@ from repose.command._command import Command
 class _Concrete(Command):
     command = True
 
-    def run(self):
+    def _srun(self):
         return 0
 
 
@@ -462,3 +462,72 @@ def test_aggregate_treats_none_result_as_success(monkeypatch):
     cmd, _ = _make(monkeypatch)
     futures = [_ok_future(None), _ok_future(True)]  # type: ignore[arg-type]
     assert cmd._aggregate(futures) == 0
+
+
+# ---------------------------------------------------------------------------
+# _afilter_live_urls  (PR 14: httpx-based async URL probing)
+# ---------------------------------------------------------------------------
+
+
+async def test_afilter_live_urls_returns_only_live(monkeypatch):
+    """Async sibling of ``_filter_live_urls`` — same input/output."""
+    calls: list[str] = []
+
+    async def _probe(url, *, timeout):
+        calls.append(url)
+        return url.endswith("/live/")
+
+    monkeypatch.setattr(cmdmod, "check_repo_url_async", _probe)
+    cmd, _ = _make(monkeypatch)
+
+    repos = [
+        _StubRepo("http://a/dead/"),
+        _StubRepo("http://b/live/"),
+        _StubRepo("http://c/live/"),
+    ]
+    live = await cmd._afilter_live_urls(repos)
+
+    assert sorted(calls) == sorted(r.url for r in repos)
+    assert [r.url for r in live] == ["http://b/live/", "http://c/live/"]
+
+
+async def test_afilter_live_urls_short_circuits_when_no_probe(monkeypatch):
+    calls: list[str] = []
+
+    async def _probe(url, *, timeout):
+        calls.append(url)
+        return False
+
+    monkeypatch.setattr(cmdmod, "check_repo_url_async", _probe)
+    cmd, _ = _make(monkeypatch, args_overrides={"no_probe": True})
+
+    repos = [_StubRepo("http://a/"), _StubRepo("http://b/")]
+    assert await cmd._afilter_live_urls(repos) == repos
+    assert calls == []
+
+
+async def test_afilter_live_urls_forwards_probe_timeout(monkeypatch):
+    seen: list[float] = []
+
+    async def _probe(url, *, timeout):
+        seen.append(timeout)
+        return True
+
+    monkeypatch.setattr(cmdmod, "check_repo_url_async", _probe)
+    cmd, _ = _make(monkeypatch, args_overrides={"probe_timeout": 0.25})
+
+    await cmd._afilter_live_urls([_StubRepo("http://a/"), _StubRepo("http://b/")])
+    assert seen == [0.25, 0.25]
+
+
+async def test_afilter_live_urls_empty_input_is_noop(monkeypatch):
+    calls: list[str] = []
+
+    async def _probe(url, *, timeout):
+        calls.append(url)
+        return True
+
+    monkeypatch.setattr(cmdmod, "check_repo_url_async", _probe)
+    cmd, _ = _make(monkeypatch)
+    assert await cmd._afilter_live_urls([]) == []
+    assert calls == []

--- a/tests/fixtures/help/root.txt
+++ b/tests/fixtures/help/root.txt
@@ -22,6 +22,12 @@ Options:
                                   [default: accept-new]
   --known-hosts PATH              path to a custom known_hosts file (overrides
                                   ~/.ssh/known_hosts)
+  --ssh-backend [asyncssh|paramiko]
+                                  SSH backend implementation: 'asyncssh'
+                                  (default, structured concurrency, no thread
+                                  pool) or 'paramiko' (legacy, available for one
+                                  release as a safety net while asyncssh
+                                  settles)  [default: asyncssh]
   --install-completion            Install completion for the current shell.
   --show-completion               Show completion for the current shell, to copy
                                   it or customize the installation.

--- a/tests/target/test_async_hostgroup.py
+++ b/tests/target/test_async_hostgroup.py
@@ -1,0 +1,152 @@
+"""Tests for ``repose.target.async_hostgroup.AsyncHostGroup``.
+
+Mirrors ``tests/target/test_hostgroup.py`` for the async backend.
+Crucially exercises the "one host raises, others still complete"
+semantic — the asyncio TaskGroup default would cancel siblings, so
+``AsyncHostGroup`` wraps every per-host coroutine in :func:`_isolate`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from repose.target.async_hostgroup import AsyncHostGroup
+
+
+def _make_async_target() -> MagicMock:
+    """Build a MagicMock whose I/O methods are AsyncMocks."""
+    t = MagicMock()
+    for name in (
+        "connect",
+        "close",
+        "read_products",
+        "read_repos",
+        "parse_repos",
+        "run",
+        "report_products",
+        "report_products_yaml",
+        "report_repos",
+    ):
+        # The report_* methods are sync on the real ``AsyncTarget`` —
+        # leave them as plain MagicMocks for parity.
+        if name in ("report_products", "report_products_yaml", "report_repos"):
+            continue
+        setattr(t, name, AsyncMock())
+    return t
+
+
+@pytest.fixture
+def two_targets():
+    return {"host-a": _make_async_target(), "host-b": _make_async_target()}
+
+
+async def test_connect_calls_each_target_connect(two_targets):
+    for t in two_targets.values():
+        t.connect.return_value = t
+
+    hg = AsyncHostGroup(two_targets)
+    await hg.connect()
+
+    for t in two_targets.values():
+        t.connect.assert_awaited_once()
+
+
+async def test_connect_swallows_per_host_exception(two_targets, caplog):
+    """If one target's connect() raises, others still finish."""
+    two_targets["host-a"].connect.side_effect = RuntimeError("boom")
+    two_targets["host-b"].connect.return_value = two_targets["host-b"]
+
+    hg = AsyncHostGroup(two_targets)
+    with caplog.at_level("WARNING", logger="repose.target.async_hostgroup"):
+        await hg.connect()  # must not raise
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("boom" in m and "host-a" in m for m in messages)
+    two_targets["host-b"].connect.assert_awaited_once()
+
+
+async def test_close_calls_each_target_close(two_targets):
+    hg = AsyncHostGroup(two_targets)
+    await hg.close()
+    for t in two_targets.values():
+        t.close.assert_awaited_once()
+
+
+async def test_read_products_fans_out(two_targets):
+    hg = AsyncHostGroup(two_targets)
+    await hg.read_products()
+    for t in two_targets.values():
+        t.read_products.assert_awaited_once()
+
+
+async def test_read_repos_fans_out(two_targets):
+    hg = AsyncHostGroup(two_targets)
+    await hg.read_repos()
+    for t in two_targets.values():
+        t.read_repos.assert_awaited_once()
+
+
+async def test_parse_repos_fans_out(two_targets):
+    hg = AsyncHostGroup(two_targets)
+    await hg.parse_repos()
+    for t in two_targets.values():
+        t.parse_repos.assert_awaited_once()
+
+
+def test_report_products_iterates_sorted(two_targets):
+    hg = AsyncHostGroup(two_targets)
+    sink = MagicMock()
+    hg.report_products(sink)
+    for t in two_targets.values():
+        t.report_products.assert_called_once_with(sink)
+
+
+def test_report_products_yaml_iterates_sorted(two_targets):
+    hg = AsyncHostGroup(two_targets)
+    sink = MagicMock()
+    hg.report_products_yaml(sink)
+    for t in two_targets.values():
+        t.report_products_yaml.assert_called_once_with(sink)
+
+
+def test_report_repos_iterates_sorted(two_targets):
+    hg = AsyncHostGroup(two_targets)
+    sink = MagicMock()
+    hg.report_repos(sink)
+    for t in two_targets.values():
+        t.report_repos.assert_called_once_with(sink)
+
+
+async def test_run_fans_out_with_str_command(two_targets):
+    """A bare ``str`` command broadcasts the same string to every host."""
+    hg = AsyncHostGroup(two_targets)
+    await hg.run("zypper -n ref")
+
+    for t in two_targets.values():
+        t.run.assert_awaited_once_with("zypper -n ref")
+
+
+async def test_run_fans_out_with_dict_command(two_targets):
+    """A per-host dict picks each host's own command."""
+    cmds = {"host-a": "ls /a", "host-b": "ls /b"}
+    hg = AsyncHostGroup(two_targets)
+    await hg.run(cmds)
+
+    two_targets["host-a"].run.assert_awaited_once_with("ls /a")
+    two_targets["host-b"].run.assert_awaited_once_with("ls /b")
+
+
+async def test_run_swallows_per_host_exception(two_targets, caplog):
+    """One host raising during run() must not cancel siblings."""
+    two_targets["host-a"].run.side_effect = RuntimeError("kaboom")
+    two_targets["host-b"].run.return_value = ("ok", "", 0)
+
+    hg = AsyncHostGroup(two_targets)
+    with caplog.at_level("WARNING", logger="repose.target.async_hostgroup"):
+        await hg.run("zypper -n ref")  # must not raise
+
+    two_targets["host-b"].run.assert_awaited_once()
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("kaboom" in m and "host-a" in m for m in messages)

--- a/tests/target/test_async_target.py
+++ b/tests/target/test_async_target.py
@@ -1,0 +1,190 @@
+"""Tests for ``repose.target.async_target.AsyncTarget``.
+
+Mirrors ``tests/target/test_target.py`` for the async backend. The
+``connector`` slot accepts any object satisfying the
+``AsyncConnection`` shape, so a ``MagicMock`` with ``AsyncMock``
+methods is plenty for these unit tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from repose.aiossh import CommandTimeout
+from repose.target.async_target import AsyncTarget
+from repose.target.parsers import Product, Repository  # noqa: F401
+from repose.types.system import System
+
+
+@pytest.fixture
+def make_target():
+    """Build an AsyncTarget with a fully-mocked AsyncConnection."""
+
+    def _factory(**conn_attrs):
+        conn = MagicMock()
+        # Default all I/O methods to AsyncMock so awaits resolve cleanly.
+        for name in (
+            "connect",
+            "close",
+            "run",
+            "listdir",
+            "readlink",
+            "open",
+        ):
+            setattr(conn, name, AsyncMock())
+        for k, v in conn_attrs.items():
+            setattr(conn, k, v)
+        target = AsyncTarget("h", 22, "u", connector=lambda *a, **kw: conn)
+        return target, conn
+
+    return _factory
+
+
+def test_repr_includes_user_host_port(make_target):
+    target, _ = make_target()
+    text = repr(target)
+    assert "u@h:22" in text
+    assert "connected: False" in text
+
+
+def test_bool_reflects_connection(make_target):
+    target, _ = make_target()
+    assert bool(target) is False
+    target.is_connected = True
+    assert bool(target) is True
+
+
+async def test_connect_success(make_target):
+    target, conn = make_target()
+    await target.connect()
+    conn.connect.assert_awaited_once()
+    assert target.is_connected is True
+
+
+async def test_connect_failure_logged_not_raised(make_target, caplog):
+    target, conn = make_target()
+    conn.connect.side_effect = RuntimeError("nope")
+
+    with caplog.at_level("CRITICAL", logger="repose.target.async_target"):
+        result = await target.connect()
+
+    assert result is target
+    assert target.is_connected is False
+    assert any("connecting to h:22" in r.message.lower() for r in caplog.records)
+
+
+async def test_connect_skipped_when_already_connected(make_target):
+    target, conn = make_target()
+    target.is_connected = True
+    await target.connect()
+    conn.connect.assert_not_awaited()
+
+
+async def test_run_records_output_tuple(make_target):
+    target, conn = make_target()
+    conn.run.return_value = ("ok\n", "", 0)
+    target.is_connected = True
+
+    result = await target.run("echo ok")
+
+    assert result == ("ok\n", "", 0)
+    assert target.out[-1][0] == "echo ok"
+    assert target.out[-1][1] == "ok\n"
+    assert target.out[-1][3] == 0
+
+
+async def test_run_handles_command_timeout(make_target, caplog):
+    target, conn = make_target()
+    conn.run.side_effect = CommandTimeout("sleep 1000")
+    target.is_connected = True
+
+    with caplog.at_level("CRITICAL", logger="repose.target.async_target"):
+        result = await target.run("sleep 1000")
+
+    assert result == ("", "", -1)
+    assert target.out[-1] == ["sleep 1000", "", "", -1, 0]
+    assert any("timed out" in r.message for r in caplog.records)
+
+
+async def test_run_handles_assertion_error_returns_none(make_target):
+    target, conn = make_target()
+    conn.run.side_effect = AssertionError("zombie")
+
+    result = await target.run("cmd")
+    assert result is None
+    # AssertionError path does not append to ``out``.
+    assert target.out == []
+
+
+async def test_run_handles_generic_exception(make_target, caplog):
+    target, conn = make_target()
+    conn.run.side_effect = RuntimeError("kaboom")
+
+    with caplog.at_level("ERROR", logger="repose.target.async_target"):
+        result = await target.run("cmd")
+
+    assert result == ("", "", -1)
+    assert any("failed to run command" in r.message for r in caplog.records)
+
+
+async def test_read_products_caches_system(make_target, monkeypatch):
+    """``read_products`` delegates to ``parse_system_async``."""
+    target, conn = make_target()
+
+    sentinel = System(Product("SLES", "15-SP5", "x86_64"))
+    fake_parser = AsyncMock(return_value=sentinel)
+    monkeypatch.setattr("repose.target.async_target.parse_system_async", fake_parser)
+
+    await target.read_products()
+    assert target.products is sentinel
+    assert target.is_connected is True  # auto-connect kicked in
+    fake_parser.assert_awaited_once_with(conn)
+
+
+async def test_read_repos_short_circuits_when_not_connected(make_target, caplog):
+    target, conn = make_target()
+    # is_connected stays False.
+    with caplog.at_level("DEBUG", logger="repose.target.async_target"):
+        await target.read_repos()
+    # No SSH call was attempted.
+    conn.run.assert_not_awaited()
+
+
+async def test_read_repos_parses_zypper_xml(make_target, sample_repos_xml):
+    target, conn = make_target()
+    target.is_connected = True
+    conn.run.return_value = (sample_repos_xml, "", 0)
+
+    await target.read_repos()
+
+    assert target.raw_repos is not None
+    aliases = {r.alias for r in target.raw_repos}
+    assert {"repo-one", "repo-two"} <= aliases
+
+
+async def test_read_repos_raises_on_unexpected_exitcode(make_target):
+    target, conn = make_target()
+    target.is_connected = True
+    conn.run.return_value = ("", "boom", 5)
+
+    with pytest.raises(ValueError):
+        await target.read_repos()
+
+
+async def test_close_marks_not_connected(make_target):
+    target, conn = make_target()
+    target.is_connected = True
+    await target.close()
+    conn.close.assert_awaited_once()
+    assert target.is_connected is False
+
+
+def test_report_helpers_remain_sync(make_target):
+    target, _ = make_target()
+    sink = MagicMock()
+    target.report_products(sink)
+    target.report_products_yaml(sink)
+    target.report_repos(sink)
+    assert sink.call_count == 3

--- a/tests/test_aiossh.py
+++ b/tests/test_aiossh.py
@@ -1,0 +1,504 @@
+"""Tests for ``repose.aiossh.AsyncConnection``.
+
+Two flavours of test live here:
+
+- **Unit tests** that monkeypatch ``asyncssh.connect`` (and the SFTP
+  surface) so we exercise our wiring — option resolution, host-key
+  policy translation, password fallback, the ``CommandTimeout``
+  translation — without spinning a server. These are fast and cover
+  the bulk of the branches.
+
+- **One in-process integration test** that boots a real asyncssh
+  server on an ephemeral port and runs an actual command through it.
+  This guards against API drift in asyncssh (e.g. a future ``run``
+  signature change) that mocks would silently miss.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import asyncssh
+import pytest
+
+from repose.aiossh import AsyncConnection, CommandTimeout
+from repose.types.connection_config import ConnectionConfig
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _stub_ssh_config(monkeypatch):
+    """Force the optional ``~/.ssh/config`` lookup to return an empty dict.
+
+    Otherwise tests would non-deterministically pick up the developer's
+    real SSH config and bleed it into the connect kwargs assertions.
+    """
+    monkeypatch.setattr("repose.aiossh._parse_openssh_config", lambda host: {})
+
+
+@pytest.fixture
+def fake_conn():
+    """A MagicMock standing in for an :class:`asyncssh.SSHClientConnection`."""
+    conn = MagicMock()
+    conn.is_closed.return_value = False
+    conn.close = MagicMock()
+    conn.wait_closed = AsyncMock(return_value=None)
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_repr_contains_user_host_port():
+    c = AsyncConnection("h", "u", 22)
+    text = repr(c)
+    assert "u" in text and "h" in text and "22" in text
+
+
+def test_invalid_port_falls_back_to_22():
+    c = AsyncConnection("h", "u", "not-a-port")
+    assert c.port == 22
+
+
+def test_timeout_from_config_when_not_passed():
+    cfg = ConnectionConfig(timeout=42.0)
+    c = AsyncConnection("h", "u", 22, config=cfg)
+    assert c.timeout == 42.0
+
+
+def test_explicit_positional_timeout_wins_over_config():
+    cfg = ConnectionConfig(timeout=42.0)
+    c = AsyncConnection("h", "u", 22, 9.0, config=cfg)
+    assert c.timeout == 9.0
+
+
+# ---------------------------------------------------------------------------
+# connect — host-key policy translation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "policy, expected_known_hosts",
+    [
+        ("no", None),
+        ("off", None),
+        ("yes", ()),  # asyncssh default = ~/.ssh/known_hosts
+        # ``accept-new`` disables asyncssh's native checker — the
+        # _AcceptNewClient subclass is the sole arbiter. See
+        # _build_known_hosts_arg for why ``None`` is passed here.
+        ("accept-new", None),
+    ],
+)
+async def test_known_hosts_arg_translation(
+    monkeypatch, fake_conn, policy, expected_known_hosts
+):
+    cfg = ConnectionConfig(host_key_policy=policy)
+    captured: dict[str, Any] = {}
+
+    async def fake_connect(**kwargs):
+        captured.update(kwargs)
+        return fake_conn
+
+    monkeypatch.setattr(asyncssh, "connect", fake_connect)
+
+    c = AsyncConnection("h", "u", 22, config=cfg)
+    await c.connect()
+
+    assert captured["known_hosts"] == expected_known_hosts
+
+
+async def test_known_hosts_path_threaded_through(monkeypatch, fake_conn, tmp_path):
+    kh = tmp_path / "known_hosts"
+    kh.write_text("")
+    cfg = ConnectionConfig(host_key_policy="yes", known_hosts=kh)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_connect(**kwargs):
+        captured.update(kwargs)
+        return fake_conn
+
+    monkeypatch.setattr(asyncssh, "connect", fake_connect)
+
+    c = AsyncConnection("h", "u", 22, config=cfg)
+    await c.connect()
+
+    assert captured["known_hosts"] == str(kh)
+
+
+# ---------------------------------------------------------------------------
+# connect — auth fallback
+# ---------------------------------------------------------------------------
+
+
+async def test_password_fallback_on_permission_denied(monkeypatch, fake_conn):
+    """First connect raises ``PermissionDenied``; getpass + retry succeeds."""
+    calls: list[dict[str, Any]] = []
+
+    async def fake_connect(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise asyncssh.PermissionDenied(reason="no key")
+        return fake_conn
+
+    monkeypatch.setattr(asyncssh, "connect", fake_connect)
+    monkeypatch.setattr("getpass.getpass", lambda: "secret")
+
+    c = AsyncConnection("h", "u", 22)
+    await c.connect()
+
+    assert len(calls) == 2
+    assert calls[1]["password"] == "secret"
+    # The second attempt explicitly disables key-auth so asyncssh
+    # doesn't bounce off the agent before reaching the password path.
+    assert calls[1]["client_keys"] == ()
+
+
+async def test_password_fallback_wrong_password_reraises(monkeypatch, fake_conn):
+    async def fake_connect(**kwargs):
+        raise asyncssh.PermissionDenied(reason="no key/password")
+
+    monkeypatch.setattr(asyncssh, "connect", fake_connect)
+    monkeypatch.setattr("getpass.getpass", lambda: "bad")
+
+    c = AsyncConnection("h", "u", 22)
+    with pytest.raises(asyncssh.PermissionDenied):
+        await c.connect()
+
+
+async def test_disconnect_error_propagates(monkeypatch):
+    async def fake_connect(**kwargs):
+        raise asyncssh.DisconnectError(
+            reason="boom", code=asyncssh.DISC_CONNECTION_LOST
+        )
+
+    monkeypatch.setattr(asyncssh, "connect", fake_connect)
+    c = AsyncConnection("h", "u", 22)
+    with pytest.raises(asyncssh.DisconnectError):
+        await c.connect()
+
+
+async def test_oserror_propagates(monkeypatch):
+    async def fake_connect(**kwargs):
+        raise OSError("network unreachable")
+
+    monkeypatch.setattr(asyncssh, "connect", fake_connect)
+    c = AsyncConnection("h", "u", 22)
+    with pytest.raises(OSError):
+        await c.connect()
+
+
+# ---------------------------------------------------------------------------
+# connect — accept-new persists key on first contact
+# ---------------------------------------------------------------------------
+
+
+async def test_accept_new_installs_client_factory(monkeypatch, fake_conn, tmp_path):
+    """``accept-new`` wires a custom ``SSHClient`` via ``client_factory=``.
+
+    Validation lives in that subclass; asyncssh's native checker is
+    explicitly disabled (``known_hosts=None``) so the subclass is the
+    only arbiter.
+    """
+    kh = tmp_path / "known_hosts"
+    kh.write_text("")
+    cfg = ConnectionConfig(host_key_policy="accept-new", known_hosts=kh)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_connect(**kwargs):
+        captured.update(kwargs)
+        return fake_conn
+
+    monkeypatch.setattr(asyncssh, "connect", fake_connect)
+
+    c = AsyncConnection("h", "u", 22, config=cfg)
+    await c.connect()
+
+    assert captured["known_hosts"] is None
+    assert "client_factory" in captured
+    assert issubclass(captured["client_factory"], asyncssh.SSHClient)
+
+
+async def test_accept_new_client_persists_unknown_key(tmp_path):
+    """Drive the ``_AcceptNewClient`` validation callback directly.
+
+    No network needed — ``validate_host_public_key`` is a synchronous
+    method we can call against a real ``asyncssh`` key on an empty
+    known_hosts file.
+    """
+    from repose.aiossh import _make_accept_new_client
+
+    kh = tmp_path / "known_hosts"
+    kh.write_text("")  # empty: first-contact path
+    key = asyncssh.generate_private_key("ssh-rsa")
+
+    factory = _make_accept_new_client(kh, expected_host="h")
+    client = factory()
+    accepted = client.validate_host_public_key(
+        host="h", addr="127.0.0.1", port=22, key=key
+    )
+    assert accepted is True
+
+    body = kh.read_text()
+    assert body.startswith("h ")
+    assert "ssh-rsa" in body
+
+
+async def test_accept_new_client_rejects_changed_key(tmp_path):
+    """A different key for an already-pinned host must be rejected."""
+    from repose.aiossh import _make_accept_new_client
+
+    kh = tmp_path / "known_hosts"
+    pinned_key = asyncssh.generate_private_key("ssh-rsa")
+    pinned_pub = pinned_key.export_public_key().decode().strip()
+    kh.write_text(f"h {pinned_pub}\n")
+
+    factory = _make_accept_new_client(kh, expected_host="h")
+    client = factory()
+
+    # A *new* key for the same host: changed-key → reject.
+    other_key = asyncssh.generate_private_key("ssh-rsa")
+    accepted = client.validate_host_public_key(
+        host="h", addr="127.0.0.1", port=22, key=other_key
+    )
+    assert accepted is False
+
+    # The same pinned key is still accepted.
+    accepted = client.validate_host_public_key(
+        host="h", addr="127.0.0.1", port=22, key=pinned_key
+    )
+    assert accepted is True
+
+
+async def test_strict_policy_passes_known_hosts_to_asyncssh(
+    monkeypatch, fake_conn, tmp_path
+):
+    """``yes`` lets asyncssh's native checker reject unknowns."""
+    kh = tmp_path / "known_hosts"
+    kh.write_text("")
+    cfg = ConnectionConfig(host_key_policy="yes", known_hosts=kh)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_connect(**kwargs):
+        captured.update(kwargs)
+        return fake_conn
+
+    monkeypatch.setattr(asyncssh, "connect", fake_connect)
+
+    c = AsyncConnection("h", "u", 22, config=cfg)
+    await c.connect()
+
+    assert captured["known_hosts"] == str(kh)
+    assert "client_factory" not in captured
+
+
+# ---------------------------------------------------------------------------
+# run / timeout
+# ---------------------------------------------------------------------------
+
+
+async def test_run_returns_stdout_stderr_exitcode(fake_conn):
+    result = MagicMock()
+    result.stdout = "hello\n"
+    result.stderr = ""
+    result.exit_status = 0
+    fake_conn.run = AsyncMock(return_value=result)
+
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+
+    stdout, stderr, exitcode = await c.run("echo hello")
+
+    assert (stdout, stderr, exitcode) == ("hello\n", "", 0)
+    fake_conn.run.assert_awaited_once()
+    # Verify timeout is plumbed from the connection.
+    args, kwargs = fake_conn.run.call_args
+    assert kwargs["timeout"] == c.timeout
+    assert kwargs["check"] is False
+
+
+async def test_run_translates_timeout_to_command_timeout(fake_conn):
+    fake_conn.run = AsyncMock(side_effect=asyncio.TimeoutError())
+
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+
+    with pytest.raises(CommandTimeout):
+        await c.run("sleep 1000")
+
+
+async def test_run_handles_none_exit_status(fake_conn):
+    """A torn-down session reports ``exit_status=None``; we translate to -1."""
+    result = MagicMock()
+    result.stdout = ""
+    result.stderr = "killed"
+    result.exit_status = None
+    fake_conn.run = AsyncMock(return_value=result)
+
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+
+    _, _, exitcode = await c.run("kill 1")
+    assert exitcode == -1
+
+
+# ---------------------------------------------------------------------------
+# sftp
+# ---------------------------------------------------------------------------
+
+
+async def test_listdir_filters_dot_entries(fake_conn):
+    sftp = MagicMock()
+    sftp.listdir = AsyncMock(return_value=[".", "..", "a.prod", "b.prod"])
+    fake_conn.start_sftp_client = AsyncMock(return_value=sftp)
+
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+
+    result = await c.listdir("/etc/products.d")
+    assert result == ["a.prod", "b.prod"]
+
+
+async def test_sftp_client_is_cached(fake_conn):
+    """Multiple SFTP calls share one subsystem (paramiko parity)."""
+    sftp = MagicMock()
+    sftp.listdir = AsyncMock(return_value=[])
+    sftp.readlink = AsyncMock(return_value="/etc/products.d/SLES.prod")
+    fake_conn.start_sftp_client = AsyncMock(return_value=sftp)
+
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+
+    await c.listdir(".")
+    await c.readlink("/etc/products.d/baseproduct")
+    await c.listdir(".")
+
+    assert fake_conn.start_sftp_client.await_count == 1
+
+
+async def test_open_yields_iterable_with_content(fake_conn):
+    """``async with open() as f`` exposes ``for line in f`` semantics."""
+
+    class FakeFile:
+        def __init__(self, data: str) -> None:
+            self._data = data
+
+        async def __aenter__(self) -> "FakeFile":
+            return self
+
+        async def __aexit__(self, *exc):
+            pass
+
+        async def read(self):
+            return self._data
+
+    sftp = MagicMock()
+    sftp.open = MagicMock(return_value=FakeFile("line1\nline2\n"))
+    fake_conn.start_sftp_client = AsyncMock(return_value=sftp)
+
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+
+    async with c.open("/etc/os-release") as f:
+        lines = list(f)
+
+    assert lines == ["line1\n", "line2\n"]
+
+
+# ---------------------------------------------------------------------------
+# close
+# ---------------------------------------------------------------------------
+
+
+async def test_close_is_idempotent(fake_conn):
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+    await c.close()
+    await c.close()  # second call must not raise
+    # Underlying ``close`` should only fire once because the second
+    # ``close()`` sees ``self._conn is None``.
+    assert fake_conn.close.call_count == 1
+
+
+def test_is_active_false_before_connect():
+    c = AsyncConnection("h", "u", 22)
+    assert c.is_active() is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: real asyncssh server on an ephemeral port
+# ---------------------------------------------------------------------------
+
+
+class _EchoServer(asyncssh.SSHServer):
+    """Accepts any client and any command; trivial echo session."""
+
+    def begin_auth(self, username: str) -> bool:
+        # ``False`` here means "no auth required"; matches the
+        # ``--ssh-backend asyncssh`` smoke-test against a dev host.
+        return False
+
+    def password_auth_supported(self) -> bool:
+        return True
+
+    def public_key_auth_supported(self) -> bool:
+        return True
+
+
+async def _handle_session(process: asyncssh.SSHServerProcess) -> None:
+    cmd = process.command or ""
+    if cmd == "fail":
+        process.exit(7)
+        return
+    process.stdout.write(f"echo:{cmd}\n")
+    process.exit(0)
+
+
+@pytest.mark.integration
+async def test_integration_real_server_run_and_exit(tmp_path, monkeypatch):
+    """End-to-end smoke test against an in-process asyncssh server.
+
+    Verifies that the entire stack — connect → run → stdout/exit_code
+    → close — produces the expected shape against a real asyncssh
+    server, not just our mock surface. The test generates a throwaway
+    server-host key, disables host-key checking on the client side,
+    and runs two commands (one OK, one failing) to confirm exit-code
+    propagation.
+    """
+    monkeypatch.setattr("repose.aiossh._parse_openssh_config", lambda host: {})
+
+    server_key = asyncssh.generate_private_key("ssh-rsa")
+    server = await asyncssh.create_server(
+        _EchoServer,
+        "127.0.0.1",
+        0,
+        server_host_keys=[server_key],
+        process_factory=_handle_session,
+    )
+    try:
+        port = server.sockets[0].getsockname()[1]
+        cfg = ConnectionConfig(host_key_policy="off")
+        c = AsyncConnection("127.0.0.1", "u", port, config=cfg)
+        await c.connect()
+
+        out, err, rc = await c.run("hello")
+        assert rc == 0
+        assert "echo:hello" in out
+
+        out, err, rc = await c.run("fail")
+        assert rc == 7
+
+        await c.close()
+    finally:
+        server.close()
+        await server.wait_closed()

--- a/tests/test_backend_parity.py
+++ b/tests/test_backend_parity.py
@@ -1,0 +1,81 @@
+"""Backend parity smoke test: same command, two backends, same outcome.
+
+Runs ``KnownProducts`` (the simplest read-only command that doesn't
+touch SSH at all) through ``Command.run`` once with
+``ssh_backend=paramiko`` and once with ``ssh_backend=asyncssh``, and
+asserts identical exit codes plus identical stdout. This is the
+project-wide parity gate that the PR-14 plan calls out as the
+strongest behaviour-preservation guarantee while the two backends
+coexist.
+
+The more thorough end-to-end coverage (real SSH sessions, listdir,
+file open, exec) lives in ``tests/test_aiossh.py`` for the asyncssh
+backend and ``tests/test_connection.py`` for the paramiko backend.
+"""
+
+from __future__ import annotations
+
+import io
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from repose.command.known import KnownProducts
+
+
+@pytest.fixture
+def template_with_two_products(tmp_path):
+    """Minimal repose template with two product entries."""
+    tpl = tmp_path / "products.yml"
+    tpl.write_text(
+        "SLES:\n"
+        "  15-SP5:\n"
+        "    x86_64:\n"
+        "      base:\n"
+        "        - { name: SLE_BASE, url: 'http://example.com/' }\n"
+        "openSUSE-Leap:\n"
+        "  15.5:\n"
+        "    x86_64:\n"
+        "      base:\n"
+        "        - { name: LEAP_BASE, url: 'http://example.com/' }\n"
+    )
+    return tpl
+
+
+def _ns(tpl: Path, backend: str) -> Namespace:
+    return Namespace(
+        dry=False,
+        target=[],
+        config=tpl,
+        yaml=False,
+        repa=[],
+        ssh_backend=backend,
+        debug=False,
+        quiet=True,
+        no_color=True,
+        format="text",
+        strict_host_key_checking="accept-new",
+        known_hosts=None,
+    )
+
+
+def test_known_products_parity_across_backends(template_with_two_products):
+    """``known-products`` must emit identical output on both backends."""
+    outputs: dict[str, str] = {}
+    exit_codes: dict[str, int] = {}
+
+    for backend in ("paramiko", "asyncssh"):
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            cmd = KnownProducts(_ns(template_with_two_products, backend))
+            rc = cmd.run()
+        outputs[backend] = buf.getvalue()
+        exit_codes[backend] = rc
+
+    assert exit_codes["paramiko"] == exit_codes["asyncssh"] == 0
+    assert outputs["paramiko"] == outputs["asyncssh"]
+    # And the output mentions the two products in the template.
+    assert "SLES" in outputs["paramiko"]
+    assert "openSUSE-Leap" in outputs["paramiko"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -441,6 +441,48 @@ def test_host_key_policy_default_threads_into_target_config(mock_registry):
 
 
 # ---------------------------------------------------------------------------
+# --ssh-backend  (PR 14: asyncssh rewrite)
+# ---------------------------------------------------------------------------
+
+
+def test_ssh_backend_default_is_asyncssh(mock_registry):
+    result = runner.invoke(app, ["add", "-t", "h", "x"])
+    assert result.exit_code == 0, result.stderr
+    ns = _ns(mock_registry, "add")
+    assert ns.ssh_backend == "asyncssh"
+
+
+@pytest.mark.parametrize("backend", ["asyncssh", "paramiko"])
+def test_ssh_backend_accepts_both_modes(mock_registry, backend):
+    result = runner.invoke(app, [f"--ssh-backend={backend}", "add", "-t", "h", "x"])
+    assert result.exit_code == 0, result.stderr
+    assert _ns(mock_registry, "add").ssh_backend == backend
+
+
+def test_ssh_backend_rejects_unknown_mode(mock_registry):
+    result = runner.invoke(app, ["--ssh-backend=netconf", "add", "-t", "h", "x"])
+    assert result.exit_code != 0
+
+
+def test_ssh_backend_threads_into_target_config(mock_registry):
+    """``--ssh-backend=paramiko`` must reach each ``Target``'s ConnectionConfig."""
+    result = runner.invoke(
+        app,
+        [
+            "--ssh-backend=paramiko",
+            "add",
+            "-t",
+            "h",
+            "SLES:15-SP3:x86_64:",
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    ns = _ns(mock_registry, "add")
+    target = next(iter(ns.target[0].values()))
+    assert target.config.ssh_backend == "paramiko"
+
+
+# ---------------------------------------------------------------------------
 # Friendly error handling (moved from old test_main.py — these exercise
 # the ``_dispatch`` exception-translation block in ``repose.cli``)
 # ---------------------------------------------------------------------------

--- a/tests/test_command_dispatch.py
+++ b/tests/test_command_dispatch.py
@@ -1,0 +1,146 @@
+"""Integration tests for the sync/async dispatch in ``Command.run``.
+
+These tests exercise the new ``Command.run`` template-method
+behaviour: choose ``_arun`` over ``_srun`` only when the asyncssh
+backend is active *and* the subclass implements ``_arun``. They
+complement the unit tests in ``test_command_base.py`` and the
+end-to-end SSH smoke in ``test_aiossh.py``.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from repose.command._command import Command
+from repose.types import ExitCode
+
+
+def _build_args(**overrides) -> Namespace:
+    defaults = {
+        "dry": False,
+        "target": [],
+        "config": "p",
+        "yaml": False,
+        "repa": [],
+        "ssh_backend": "paramiko",
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+# Subclasses live inside a fixture so they don't pollute
+# ``Command.registry`` (a module-level ``class _X(Command, name=...):``
+# would persist across the test session and break the
+# ``test_registry_contains_expected_commands`` discovery test).
+
+
+@pytest.fixture
+def sync_only_cls():
+    """A Command subclass exposing only ``_srun`` — fresh per test."""
+
+    class _SyncOnly(Command):
+        sync_calls: list[int] = []
+
+        def _srun(self) -> ExitCode:
+            self.sync_calls.append(1)
+            return 0
+
+    _SyncOnly.sync_calls = []
+    return _SyncOnly
+
+
+@pytest.fixture
+def both_cls():
+    """A Command subclass implementing both ``_srun`` and ``_arun``."""
+
+    class _Both(Command):
+        sync_calls: list[int] = []
+        async_calls: list[int] = []
+
+        def _srun(self) -> ExitCode:
+            self.sync_calls.append(1)
+            return 0
+
+        async def _arun(self) -> ExitCode:
+            self.async_calls.append(1)
+            return 0
+
+    _Both.sync_calls = []
+    _Both.async_calls = []
+    return _Both
+
+
+@pytest.fixture
+def patch_hostgroup(monkeypatch):
+    """Patch HostGroup so ``Command.__init__`` doesn't try real SSH."""
+    import repose.command._command as cmdmod
+
+    hg = MagicMock()
+    hg.keys.return_value = []
+    hg.__iter__ = lambda self: iter([])
+    monkeypatch.setattr(cmdmod, "HostGroup", MagicMock(return_value=hg))
+    return hg
+
+
+@pytest.fixture
+def patch_async_hostgroup(monkeypatch):
+    """Patch AsyncHostGroup so ``Command.__init__`` doesn't try real SSH."""
+    import repose.command._command as cmdmod
+
+    hg = MagicMock()
+    hg.keys.return_value = []
+    hg.__iter__ = lambda self: iter([])
+
+    # AsyncHostGroup.connect is async; return a coroutine.
+    async def _connect():
+        return None
+
+    hg.connect = MagicMock(return_value=_connect())
+    monkeypatch.setattr(cmdmod, "AsyncHostGroup", MagicMock(return_value=hg))
+    return hg
+
+
+def test_paramiko_backend_routes_to_srun(patch_hostgroup, both_cls):
+    cmd = both_cls(_build_args(ssh_backend="paramiko"))
+    rc = cmd.run()
+    assert rc == 0
+    assert both_cls.sync_calls == [1]
+    assert both_cls.async_calls == []
+
+
+def test_asyncssh_backend_routes_to_arun_when_implemented(
+    patch_async_hostgroup, both_cls
+):
+    cmd = both_cls(_build_args(ssh_backend="asyncssh"))
+    rc = cmd.run()
+    assert rc == 0
+    assert both_cls.async_calls == [1]
+    assert both_cls.sync_calls == []
+
+
+def test_asyncssh_backend_falls_back_to_srun_without_arun(
+    patch_async_hostgroup, sync_only_cls
+):
+    """Subclass without ``_arun`` falls back to sync body on asyncssh."""
+    cmd = sync_only_cls(_build_args(ssh_backend="asyncssh"))
+    rc = cmd.run()
+    assert rc == 0
+    assert sync_only_cls.sync_calls == [1]
+
+
+def test_default_backend_when_missing_attr(patch_hostgroup, sync_only_cls):
+    """Tests building Namespace without ``ssh_backend`` get paramiko."""
+    # Use a fresh Namespace without ssh_backend at all.
+    ns = Namespace(
+        dry=False,
+        target=[],
+        config="p",
+        yaml=False,
+        repa=[],
+    )
+    cmd = sync_only_cls(ns)
+    assert cmd.ssh_backend == "paramiko"
+    assert cmd._is_async is False

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -6,6 +6,7 @@ import pytest
 
 from repose.host import HostParseError, ParseHosts, PortNotIntError
 from repose.target import Target
+from repose.target.async_target import AsyncTarget
 from repose.types.connection_config import ConnectionConfig
 
 
@@ -14,10 +15,21 @@ def test_default_user_and_port():
     assert "example.com" in hosts
 
     target = hosts["example.com"]
-    assert isinstance(target, Target)
+    # Default backend is now ``asyncssh`` (PR 14), so the default
+    # ``ParseHosts`` factory yields ``AsyncTarget``s. Legacy
+    # ``Target`` is still reachable via the explicit
+    # ``ConnectionConfig(ssh_backend="paramiko")`` factory mode.
+    assert isinstance(target, AsyncTarget)
     assert target.hostname == "example.com"
     assert target.username == "root"
     assert target.port == 22
+
+
+def test_paramiko_backend_yields_legacy_target():
+    cfg = ConnectionConfig(ssh_backend="paramiko")
+    hosts = ParseHosts(cfg)("example.com")
+    target = hosts["example.com"]
+    assert isinstance(target, Target)
 
 
 def test_explicit_user_and_port():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,3 +158,95 @@ def test_check_repo_url_custom_timeout_is_forwarded(monkeypatch):
     repose.utils.check_repo_url("http://example.com/", timeout=0.5)
     # Both probes attempted, both saw the custom timeout.
     assert seen == [0.5, 0.5]
+
+
+# ---------------------------------------------------------------------------
+# check_repo_url_async  (PR 14: httpx-based parallel probing)
+# ---------------------------------------------------------------------------
+
+
+import httpx  # noqa: E402
+
+from unittest.mock import AsyncMock  # noqa: E402
+
+
+def _async_client_returning(responses: list[object]):
+    """Patch ``httpx.AsyncClient`` to yield a context manager whose
+    ``.head`` / ``.get`` consume the given response queue."""
+    client = MagicMock()
+    queue = list(responses)
+
+    async def _next(target, **kw):
+        return queue.pop(0)
+
+    client.head = _next
+    client.get = _next
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    factory = MagicMock(return_value=cm)
+    return factory
+
+
+async def test_check_repo_url_async_returns_true_on_2xx(monkeypatch):
+    ok = MagicMock(status_code=200)
+    monkeypatch.setattr(httpx, "AsyncClient", _async_client_returning([ok]))
+    assert (await repose.utils.check_repo_url_async("http://example.com/")) is True
+
+
+async def test_check_repo_url_async_falls_back_to_suse_layout(monkeypatch):
+    """First probe (repodata/) → 404; second (suse/repodata/) → 200."""
+    bad = MagicMock(status_code=404)
+    good = MagicMock(status_code=200)
+    monkeypatch.setattr(httpx, "AsyncClient", _async_client_returning([bad, good]))
+    assert (await repose.utils.check_repo_url_async("http://example.com/")) is True
+
+
+async def test_check_repo_url_async_returns_false_when_both_4xx(monkeypatch):
+    bad = MagicMock(status_code=404)
+    monkeypatch.setattr(httpx, "AsyncClient", _async_client_returning([bad, bad]))
+    assert (await repose.utils.check_repo_url_async("http://example.com/")) is False
+
+
+async def test_check_repo_url_async_swallows_httpx_errors(monkeypatch):
+    """A ``httpx.HTTPError`` (e.g. ConnectError) is treated as dead."""
+
+    async def _raise(target, **kw):
+        raise httpx.ConnectError("refused")
+
+    client = MagicMock()
+    client.head = _raise
+    client.get = _raise
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    monkeypatch.setattr(httpx, "AsyncClient", MagicMock(return_value=cm))
+
+    assert (await repose.utils.check_repo_url_async("http://example.com/")) is False
+
+
+async def test_check_repo_url_async_retries_get_on_405(monkeypatch):
+    """A 405 on HEAD must trigger a GET retry; a 200 on GET wins."""
+    head_405 = MagicMock(status_code=405)
+    get_200 = MagicMock(status_code=200)
+
+    calls: list[str] = []
+
+    async def _head(target, **kw):
+        calls.append("head")
+        return head_405
+
+    async def _get(target, **kw):
+        calls.append("get")
+        return get_200
+
+    client = MagicMock()
+    client.head = _head
+    client.get = _get
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    monkeypatch.setattr(httpx, "AsyncClient", MagicMock(return_value=cm))
+
+    assert (await repose.utils.check_repo_url_async("http://example.com/")) is True
+    assert calls == ["head", "get"]

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,32 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "asyncssh"
+version = "2.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/fd/c34fe7e30838b4b9cc91903da26a62c6d33b673c731b3d951fcd70ab1889/asyncssh-2.23.0.tar.gz", hash = "sha256:8c54760953c1f2cf282591bcba5c8c70efc48d645bbf26bd2307a9c66a0ed1a7", size = 542154, upload-time = "2026-05-09T03:15:01.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/b5/b1a3979f4840d1271ca8e0978dbccfb18ad2d33b4ece85cf77122fb46e5f/asyncssh-2.23.0-py3-none-any.whl", hash = "sha256:14108bfdaae17457f0c1841e883ad934271bbfdd46458aa4c4d0973451940ad0", size = 375687, upload-time = "2026-05-09T03:15:00.221Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -79,6 +105,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/79/875f9558179573d40a9cc743038ac2bf67dfb79cecb1e8b5d70e88c94c3d/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4", size = 273791, upload-time = "2025-09-25T19:50:39.913Z" },
     { url = "https://files.pythonhosted.org/packages/bc/fe/975adb8c216174bf70fc17535f75e85ac06ed5252ea077be10d9cff5ce24/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dcd58e2b3a908b5ecc9b9df2f0085592506ac2d5110786018ee5e160f28e0911", size = 270746, upload-time = "2025-09-25T19:50:43.306Z" },
     { url = "https://files.pythonhosted.org/packages/e4/f8/972c96f5a2b6c4b3deca57009d93e946bbdbe2241dca9806d502f29dd3ee/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6b8f520b61e8781efee73cba14e3e8c9556ccfb375623f4f97429544734545b4", size = 273375, upload-time = "2025-09-25T19:50:45.43Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
 ]
 
 [[package]]
@@ -324,6 +359,43 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "hypothesis"
 version = "6.153.0"
 source = { registry = "https://pypi.org/simple" }
@@ -333,6 +405,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/92/918fb03318c7ff9a271d7cad8eceb359d1069f17e84f5191d52c2970f18f/hypothesis-6.153.0.tar.gz", hash = "sha256:11616e5158fc485d62bae19d9cc69333237faa8050ad44a45218254a1ef272bb", size = 474030, upload-time = "2026-05-26T05:19:05.468Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/20/96dc2387cf29a0ec75b427d62d3dde1f44c924719503babaac4c96806223/hypothesis-6.153.0-py3-none-any.whl", hash = "sha256:2aeda9bbb44ae0ee0bfa67ef744a25be05c1f804dca4eb6479c63518dc9f2900", size = 540326, upload-time = "2026-05-26T05:19:02.861Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]
@@ -477,6 +558,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -506,6 +600,8 @@ wheels = [
 name = "repose"
 source = { editable = "." }
 dependencies = [
+    { name = "asyncssh" },
+    { name = "httpx" },
     { name = "paramiko" },
     { name = "rich" },
     { name = "ruamel-yaml" },
@@ -516,6 +612,7 @@ dependencies = [
 dev = [
     { name = "hypothesis" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
@@ -524,6 +621,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "asyncssh", specifier = ">=2.14" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "paramiko" },
     { name = "rich", specifier = ">=13" },
     { name = "ruamel-yaml" },
@@ -534,6 +633,7 @@ requires-dist = [
 dev = [
     { name = "hypothesis" },
     { name = "pytest" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
@@ -697,4 +797,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cc/15/f5fc7be23b7196bc065b282d9589a372392fb10860c80f9c1dd7eb008662/typer-0.26.3.tar.gz", hash = "sha256:3e2b9352f535e5303ef27806dadc2c8647687bdca5c902f03fec3fb88f46a46a", size = 198326, upload-time = "2026-05-28T20:30:50.984Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/cc/c6c5dea061e2740355bfeef22ac6a41751bd2f3903e83921295569bdcec4/typer-0.26.3-py3-none-any.whl", hash = "sha256:e70549ec5a403ca8a0bf0802ddd9f3c6ff7a14ccbb859b01b697baa943636f33", size = 122338, upload-time = "2026-05-28T20:30:49.816Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]


### PR DESCRIPTION
## Summary

Replaces the paramiko-based `Connection` (~420 LOC) with an asyncssh
backend backed by `asyncio.TaskGroup` for structured concurrency.
Ships behind `--ssh-backend={asyncssh,paramiko}` defaulting to
`asyncssh`; the paramiko backend stays one release as a safety net
for real-world refhosts that surface long-tail paramiko-specific
behaviour.

## Why

- `Connection` reimplements work asyncssh does natively: a
  `select()`-based read loop, manual non-blocking session setup with
  60s keepalives, manual SFTP reconnect, and six broad
  `except Exception:` swallowers.
- Every parallel fan-out today uses `ThreadPoolExecutor` bounded by
  `os.cpu_count() * 5`. At 30+ refhosts that's contention.
- `asyncio.TaskGroup` (Python 3.11+, already the project floor) gives
  clean Ctrl-C semantics and structured cancellation that today's
  hand-rolled path cannot match.

## What changed

### New code
- `repose/aiossh.py` — `AsyncConnection` mirroring `Connection`'s
  public surface (`connect`, `run`, `listdir`, `open`, `readlink`,
  `close`, `is_active`). Host-key policy `accept-new` is implemented
  via a custom `SSHClient` subclass installed through asyncssh's
  `client_factory=` hook, using the public `SSHKnownHosts.match()`
  API and a best-effort append to `known_hosts` on first contact.
- `repose/target/async_target.py` — `AsyncTarget` mirror of `Target`.
- `repose/target/async_hostgroup.py` — `AsyncHostGroup` using
  `asyncio.TaskGroup`, with per-host coroutines wrapped in
  `_isolate()` so one host's failure does **not** cancel siblings
  (parity with sync `HostGroup`).
- `repose/target/parsers/product.py` — `parse_system_async` sibling.

### Wiring
- `repose/types/connection_config.py` — new `ssh_backend` field.
- `repose/cli.py` — `--ssh-backend` flag, plumbed through
  `CliGlobals` → `ConnectionConfig` → `ParseHosts` →
  `AsyncTarget`/`Target`.
- `repose/host.py` — `ParseHosts` selects `AsyncTarget` vs `Target`
  based on `config.ssh_backend`.
- `repose/command/_command.py` — backend-aware `__init__` builds
  either `HostGroup` or `AsyncHostGroup`; new template-method `run()`
  dispatches to `_srun` (existing sync body, renamed) or `_arun`.
  Adds `_arun_parallel`, `_aworker`, `_aggregate_tasks`,
  `_afilter_live_urls` mirrors of the sync helpers.
- The 8 concrete commands each gain `_arun()` (and `_arun_one()`
  per-host worker) mirroring the sync body with `await`s.
- `repose/utils.py` — `check_repo_url_async` using `httpx`; the
  asyncssh path of `add`/`install`/`reset` switches probes to it via
  `_afilter_live_urls`.

### Backend parity safeguards
- `~/.ssh/config` lookups still routed through paramiko's parser even
  on the asyncssh backend, so `IdentityFile`, `ProxyCommand`, `User`,
  `Port`, `Hostname` resolution stays byte-identical between backends.
- `CommandTimeout` re-exported from `repose.aiossh` so callers can
  `except CommandTimeout` regardless of backend.
- Same exit-code shape (0/1/2) for both backends.
- `tests/test_backend_parity.py` runs the same command through both
  backends and asserts identical exit code + stdout.

### Tests
+73 new tests:
- `tests/test_aiossh.py` (26, incl. an in-process asyncssh server
  end-to-end smoke).
- `tests/target/test_async_target.py` (15).
- `tests/target/test_async_hostgroup.py` (12) — explicitly covers
  ""one host raises, siblings still finish"".
- `tests/test_command_dispatch.py` (4) — verifies the
  `run()` template-method dispatcher.
- `tests/test_backend_parity.py` (1) — cross-backend output parity.
- Async siblings in `tests/test_utils.py` and
  `tests/command/test_command_base.py`.

### Deps + docs
- `+ asyncssh>=2.14`, `+ httpx>=0.27`; `paramiko` stays one release.
- `+ pytest-asyncio>=0.23` in the dev group; `asyncio_mode = ""auto""`.
- `README.md` documents `--ssh-backend` and the paramiko deprecation
  timeline.

## Verification

- `ruff format --diff .` — clean
- `ruff check .` — clean
- `pytest --cov=repose --cov-fail-under=80` — 448 passing, 81.78%
  coverage (gate: 80%).
- `repose --help` shows `--ssh-backend [asyncssh|paramiko]` with the
  expected default.

## Open question Q1 — resolved

The plan asks whether `Command.run()` should become `async def` or
stay sync with `asyncio.run()` per command. This PR takes the **sync
`run()` with `asyncio.run()` inside** route — minimal blast radius,
rich `Live` progress stays on the main thread, typer dispatch
untouched. Each command body has an `if self._is_async: return
asyncio.run(self._arun())` template-method dispatcher in the base.

## Followup

A subsequent PR (after asyncssh soak in real-world deployments) will:
- delete `repose/connection.py`, `repose/connection_policy.py`,
  `tests/test_connection.py`,
- drop the paramiko runtime dep,
- collapse the `_srun`/`_arun` dual-method shape on `Command`,
- drop the `ssh_backend` field on `ConnectionConfig`.