### PR TITLE
feat(cli): shell completion + man pages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Generated man pages — produced by `uv run repose-mangen`. Marking
+# them as generated keeps GitHub from counting them in language stats
+# and auto-collapses them in pull-request diffs. CI's `man-drift` job
+# regenerates and ensures they stay in sync with repose/cli.py.
+docs/man/*.1 linguist-generated=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,20 @@ jobs:
         run: uv sync
       - name: Test with pytest
         run: uv run pytest --cov=repose --cov-fail-under=80
+  man-drift:
+    # Regenerates docs/man/*.1 from the Typer CLI and fails if the
+    # committed pages drift from what `uv run repose-mangen` produces.
+    # Catches the case where a contributor edits a subcommand's help
+    # text or flags but forgets to refresh the man pages.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: uv sync
+      - name: Regenerate man pages
+        run: uv run repose-mangen
+      - name: Check for drift
+        run: git diff --exit-code -- docs/man/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include docs/*
+recursive-include docs/man *.1

--- a/README.md
+++ b/README.md
@@ -15,6 +15,35 @@ zypper ar -f http://download.suse.de/ibs/QA:/Maintenance/$DISTRO/ qam-infra
 zypper -n in repose
 ```
 
+After install, `man repose` shows the full command reference.
+
+## Shell completion
+
+Repose ships shell-completion support for bash, zsh, and fish via Typer's
+built-in machinery. Install once into your shell's rc file:
+
+```
+repose --install-completion bash   # or: zsh, fish
+```
+
+Then in a new shell, tab-complete subcommands, flags, and REPA product
+prefixes:
+
+```
+repose <TAB>           # add remove reset install clear uninstall ...
+repose add -t host <TAB>  # SLES sle-sdk sle-module-... (from products.yml)
+```
+
+To preview the completion script without installing it:
+
+```
+repose --show-completion zsh
+```
+
+REPA-prefix completion reads `/etc/repose/products.yml` (or the path passed
+to `-c/--config`). If the file is unreadable, completion silently returns no
+suggestions rather than erroring in your shell.
+
 ## Internal Functionality
 
 Repose reports or modifies the package repositories in one or more refhosts

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,13 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help Makefile man
+
+# Regenerate the click-man-driven man pages in docs/man/ from the
+# Typer CLI. Declared explicitly (and listed in .PHONY) so the
+# catch-all below doesn't shadow it with Sphinx's own "man" builder.
+man:
+	uv run repose-mangen
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/man/repose-add.1
+++ b/docs/man/repose-add.1
@@ -1,0 +1,8 @@
+.TH "REPOSE ADD" "1" "2024-01-01" "1.11.2" "repose add Manual"
+.SH NAME
+repose\-add \- add specified repository to target
+.SH SYNOPSIS
+.B repose add
+[OPTIONS] REPA
+.SH DESCRIPTION
+add specified repository to target

--- a/docs/man/repose-clear.1
+++ b/docs/man/repose-clear.1
@@ -1,0 +1,8 @@
+.TH "REPOSE CLEAR" "1" "2024-01-01" "1.11.2" "repose clear Manual"
+.SH NAME
+repose\-clear \- clear all repositories from target
+.SH SYNOPSIS
+.B repose clear
+[OPTIONS]
+.SH DESCRIPTION
+clear all repositories from target

--- a/docs/man/repose-install.1
+++ b/docs/man/repose-install.1
@@ -1,0 +1,8 @@
+.TH "REPOSE INSTALL" "1" "2024-01-01" "1.11.2" "repose install Manual"
+.SH NAME
+repose\-install \- add specified repository to target and...
+.SH SYNOPSIS
+.B repose install
+[OPTIONS] REPA
+.SH DESCRIPTION
+add specified repository to target and install product

--- a/docs/man/repose-known-products.1
+++ b/docs/man/repose-known-products.1
@@ -1,0 +1,8 @@
+.TH "REPOSE KNOWN-PRODUCTS" "1" "2024-01-01" "1.11.2" "repose known-products Manual"
+.SH NAME
+repose\-known-products \- list known products by 'repose'
+.SH SYNOPSIS
+.B repose known-products
+[OPTIONS]
+.SH DESCRIPTION
+list known products by 'repose'

--- a/docs/man/repose-list-products.1
+++ b/docs/man/repose-list-products.1
@@ -1,0 +1,8 @@
+.TH "REPOSE LIST-PRODUCTS" "1" "2024-01-01" "1.11.2" "repose list-products Manual"
+.SH NAME
+repose\-list-products \- list products on target
+.SH SYNOPSIS
+.B repose list-products
+[OPTIONS]
+.SH DESCRIPTION
+list products on target

--- a/docs/man/repose-list-repos.1
+++ b/docs/man/repose-list-repos.1
@@ -1,0 +1,8 @@
+.TH "REPOSE LIST-REPOS" "1" "2024-01-01" "1.11.2" "repose list-repos Manual"
+.SH NAME
+repose\-list-repos \- list repositories on target
+.SH SYNOPSIS
+.B repose list-repos
+[OPTIONS]
+.SH DESCRIPTION
+list repositories on target

--- a/docs/man/repose-remove.1
+++ b/docs/man/repose-remove.1
@@ -1,0 +1,8 @@
+.TH "REPOSE REMOVE" "1" "2024-01-01" "1.11.2" "repose remove Manual"
+.SH NAME
+repose\-remove \- remove repository from target
+.SH SYNOPSIS
+.B repose remove
+[OPTIONS] REPA
+.SH DESCRIPTION
+remove repository from target

--- a/docs/man/repose-reset.1
+++ b/docs/man/repose-reset.1
@@ -1,0 +1,8 @@
+.TH "REPOSE RESET" "1" "2024-01-01" "1.11.2" "repose reset Manual"
+.SH NAME
+repose\-reset \- reset target repositories to only...
+.SH SYNOPSIS
+.B repose reset
+[OPTIONS]
+.SH DESCRIPTION
+reset target repositories to only installed products repositories

--- a/docs/man/repose-uninstall.1
+++ b/docs/man/repose-uninstall.1
@@ -1,0 +1,8 @@
+.TH "REPOSE UNINSTALL" "1" "2024-01-01" "1.11.2" "repose uninstall Manual"
+.SH NAME
+repose\-uninstall \- remove specified repository from target...
+.SH SYNOPSIS
+.B repose uninstall
+[OPTIONS] REPA
+.SH DESCRIPTION
+remove specified repository from target and uninstall product

--- a/docs/man/repose.1
+++ b/docs/man/repose.1
@@ -1,0 +1,45 @@
+.TH "REPOSE" "1" "2024-01-01" "1.11.2" "repose Manual"
+.SH NAME
+repose \- Repository manipulation tool for QAM
+.SH SYNOPSIS
+.B repose
+[OPTIONS] COMMAND [ARGS]...
+.SH DESCRIPTION
+Repository manipulation tool for QAM
+.SH COMMANDS
+.PP
+\fBadd\fP
+  add specified repository to target
+  See \fBrepose-add(1)\fP for full documentation on the \fBadd\fP command.
+.PP
+\fBremove\fP
+  remove repository from target
+  See \fBrepose-remove(1)\fP for full documentation on the \fBremove\fP command.
+.PP
+\fBreset\fP
+  reset target repositories to only...
+  See \fBrepose-reset(1)\fP for full documentation on the \fBreset\fP command.
+.PP
+\fBinstall\fP
+  add specified repository to target and...
+  See \fBrepose-install(1)\fP for full documentation on the \fBinstall\fP command.
+.PP
+\fBclear\fP
+  clear all repositories from target
+  See \fBrepose-clear(1)\fP for full documentation on the \fBclear\fP command.
+.PP
+\fBuninstall\fP
+  remove specified repository from target...
+  See \fBrepose-uninstall(1)\fP for full documentation on the \fBuninstall\fP command.
+.PP
+\fBlist-products\fP
+  list products on target
+  See \fBrepose-list-products(1)\fP for full documentation on the \fBlist-products\fP command.
+.PP
+\fBlist-repos\fP
+  list repositories on target
+  See \fBrepose-list-repos(1)\fP for full documentation on the \fBlist-repos\fP command.
+.PP
+\fBknown-products\fP
+  list known products by 'repose'
+  See \fBrepose-known-products(1)\fP for full documentation on the \fBknown-products\fP command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.13",
 ]
-scripts = { repose = "repose.cli:app" }
+scripts = { repose = "repose.cli:app", repose-mangen = "repose.mangen:main" }
 dependencies = [
   "asyncssh>=2.14",
   "httpx>=0.27",
@@ -29,6 +29,7 @@ Repository = "https://github.com/openSUSE/repose"
 
 [dependency-groups]
 dev = [
+  "click-man>=0.5",
   "hypothesis",
   "pytest",
   "pytest-asyncio>=0.23",

--- a/repose/cli.py
+++ b/repose/cli.py
@@ -27,6 +27,7 @@ from repose import __version__
 from repose.colorlog import create_logger
 from repose.command import Command
 from repose.host import ParseHosts
+from repose.template import load_template
 from repose.types.connection_config import ConnectionConfig
 from repose.types.repa import Repa
 
@@ -136,6 +137,39 @@ def _target_parser(value: str) -> ParseHosts:
 def _repa_parser(value: str) -> Repa:
     """Parser shim for each ``REPA`` positional token."""
     return Repa(value)
+
+
+def _complete_repa(ctx: typer.Context, incomplete: str) -> list[str]:
+    """Shell-completion callback for ``REPA`` positional arguments.
+
+    Reads the products YAML pointed at by ``-c/--config`` (or the
+    default ``/etc/repose/products.yml``) and returns product-name
+    prefixes that match ``incomplete``. Completes only the first
+    colon-separated segment (the product); subsequent segments
+    (``:VERSION:ARCH:REPO``) are left to free-form user input.
+
+    Any failure to read or parse the YAML — missing file, permission
+    error, malformed YAML — collapses to an empty completion list so
+    the user's shell never raises mid-keystroke.
+    """
+    # The root callback populates ``ctx.obj``; during completion it
+    # has typically already run. Fall back gracefully if not.
+    config_path: Path | None = None
+    obj = getattr(ctx, "obj", None)
+    if isinstance(obj, CliGlobals):
+        config_path = obj.config
+    if config_path is None:
+        config_path = Path("/etc/repose/products.yml")
+    try:
+        template = load_template(config_path)
+    except (OSError, YAMLError):
+        return []
+    # Only complete the first ``:``-separated segment (product name).
+    # If the user has already typed past a colon, return nothing so we
+    # don't clobber the version/arch/repo they're filling in by hand.
+    if ":" in incomplete:
+        return []
+    return sorted(name for name in template.keys() if name.startswith(incomplete))
 
 
 # ---------------------------------------------------------------------------
@@ -407,6 +441,7 @@ RepaArg = Annotated[
         metavar="REPA",
         parser=_repa_parser,
         help="REPA pattern specification for needed repository",
+        autocompletion=_complete_repa,
     ),
 ]
 ProbeTimeoutOpt = Annotated[

--- a/repose/mangen.py
+++ b/repose/mangen.py
@@ -52,8 +52,12 @@ def _pinned_source_date() -> Iterator[None]:
         yield
     finally:
         if had_value:
-            # mypy: ``prior`` is ``str`` because ``had_value`` is True.
-            os.environ["SOURCE_DATE_EPOCH"] = prior  # type: ignore[assignment]
+            # ``had_value`` is True iff the key was present at entry,
+            # which means ``prior`` was bound to ``os.environ[...]``
+            # and is therefore ``str`` (never ``None``). The assert
+            # narrows the type for the static checker.
+            assert prior is not None
+            os.environ["SOURCE_DATE_EPOCH"] = prior
         else:
             os.environ.pop("SOURCE_DATE_EPOCH", None)
 

--- a/repose/mangen.py
+++ b/repose/mangen.py
@@ -1,0 +1,76 @@
+"""Generate man pages for ``repose`` and its subcommands.
+
+Walks the Typer/Click app object and emits one ``.1`` man page per
+command into ``docs/man/``. The output is committed to the repo so
+downstream packagers don't need ``click-man`` at build time; a CI job
+regenerates and ``git diff --exit-code``s to catch drift.
+
+Reproducibility: ``click-man`` stamps the current date into each
+page's ``.TH`` header by default, which would cause spurious diffs
+on every run. We pin the date via ``SOURCE_DATE_EPOCH``
+(reproducible-builds standard) — ``click_man.man.ManPage`` honours
+that env var natively. The ``write_man_pages`` ``date=`` keyword
+argument is broken in click-man 0.5.1 (only forwarded to recursive
+children, never applied to the page being generated), so we
+manipulate the env instead and restore it on exit.
+
+If callers already export ``SOURCE_DATE_EPOCH`` (e.g. distro builds),
+their value wins.
+"""
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import typer
+from click_man.core import write_man_pages
+
+from repose import __version__
+from repose.cli import app
+
+# Fallback epoch (UTC ``2024-01-01 00:00:00``) used when callers
+# haven't already exported ``SOURCE_DATE_EPOCH``. Pinning a constant
+# keeps ``uv run repose-mangen`` byte-stable across machines and dates;
+# CI uses this to catch drift via ``git diff --exit-code``.
+_FALLBACK_SOURCE_DATE_EPOCH = "1704067200"  # 2024-01-01T00:00:00Z
+
+
+@contextmanager
+def _pinned_source_date() -> Iterator[None]:
+    """Temporarily set ``SOURCE_DATE_EPOCH`` if unset, restore on exit.
+
+    Caller-provided values take precedence — distro builds frequently
+    export this from a changelog timestamp and we don't want to clobber
+    that.
+    """
+    had_value = "SOURCE_DATE_EPOCH" in os.environ
+    prior = os.environ.get("SOURCE_DATE_EPOCH")
+    if not had_value:
+        os.environ["SOURCE_DATE_EPOCH"] = _FALLBACK_SOURCE_DATE_EPOCH
+    try:
+        yield
+    finally:
+        if had_value:
+            # mypy: ``prior`` is ``str`` because ``had_value`` is True.
+            os.environ["SOURCE_DATE_EPOCH"] = prior  # type: ignore[assignment]
+        else:
+            os.environ.pop("SOURCE_DATE_EPOCH", None)
+
+
+def main() -> None:
+    """Regenerate ``docs/man/repose*.1`` from the Typer app."""
+    out = Path(__file__).resolve().parent.parent / "docs" / "man"
+    out.mkdir(parents=True, exist_ok=True)
+    click_group = typer.main.get_command(app)
+    with _pinned_source_date():
+        write_man_pages(
+            name="repose",
+            cli=click_group,
+            version=__version__,
+            target_dir=str(out),
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -1,0 +1,143 @@
+"""Tests for ``repose.cli._complete_repa`` shell-completion callback.
+
+The callback is invoked by Typer/Click outside of a real shell during
+unit tests; we drive it directly with a stub ``typer.Context``-like
+object carrying a ``CliGlobals`` payload (the shape the root callback
+attaches at runtime).
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from repose.cli import CliGlobals, _complete_repa
+from repose.types.connection_config import ConnectionConfig
+
+
+@dataclass
+class _StubCtx:
+    """Minimal ``typer.Context`` stand-in.
+
+    ``_complete_repa`` only reads ``ctx.obj``; supplying the live
+    Typer/Click context isn't necessary and would couple the test to
+    the Click invocation machinery.
+    """
+
+    obj: Any
+
+
+def _make_globals(config: Path) -> CliGlobals:
+    """Construct a ``CliGlobals`` with the given config path.
+
+    Other ``CliGlobals`` fields use the same defaults the root callback
+    would supply; only ``config`` matters for completion.
+    """
+    return CliGlobals(
+        dry=False,
+        config=config,
+        debug=False,
+        quiet=False,
+        no_color=False,
+        format="text",
+        strict_host_key_checking="accept-new",
+        known_hosts=Path("~/.ssh/known_hosts"),
+        ssh_backend="asyncssh",
+        conn_config=ConnectionConfig(),
+    )
+
+
+@pytest.fixture
+def products_yml(tmp_path: Path) -> Path:
+    """A products.yml with a handful of recognizable product names."""
+    p = tmp_path / "products.yml"
+    p.write_text(
+        "SLES:\n"
+        "  15-SP5:\n"
+        "    x86_64:\n"
+        "      base:\n"
+        "        - { name: SLE_BASE, url: 'http://example.com/' }\n"
+        "sle-sdk:\n"
+        "  15-SP5:\n"
+        "    x86_64:\n"
+        "      base:\n"
+        "        - { name: SDK_BASE, url: 'http://example.com/' }\n"
+        "sle-module-toolchain:\n"
+        "  15-SP5:\n"
+        "    x86_64:\n"
+        "      base:\n"
+        "        - { name: TOOLCHAIN_BASE, url: 'http://example.com/' }\n"
+        "openSUSE-Leap:\n"
+        "  15.5:\n"
+        "    x86_64:\n"
+        "      base:\n"
+        "        - { name: LEAP_BASE, url: 'http://example.com/' }\n"
+    )
+    return p
+
+
+def test_repa_complete_filters_prefix(products_yml: Path) -> None:
+    """Empty prefix returns all products sorted; prefix narrows them."""
+    ctx = _StubCtx(obj=_make_globals(products_yml))
+
+    all_products = _complete_repa(ctx, "")
+    assert all_products == sorted(
+        ["SLES", "sle-sdk", "sle-module-toolchain", "openSUSE-Leap"]
+    )
+
+    sle_matches = _complete_repa(ctx, "sle-")
+    assert sle_matches == ["sle-module-toolchain", "sle-sdk"]
+
+    one_match = _complete_repa(ctx, "openSUSE")
+    assert one_match == ["openSUSE-Leap"]
+
+
+def test_repa_complete_no_matches_returns_empty(products_yml: Path) -> None:
+    """Prefix that matches nothing returns an empty list (not an error)."""
+    ctx = _StubCtx(obj=_make_globals(products_yml))
+    assert _complete_repa(ctx, "nonexistent-product") == []
+
+
+def test_repa_complete_after_colon_returns_empty(products_yml: Path) -> None:
+    """Once the user has typed ``:``, completion bows out.
+
+    We only complete the first segment (the product). The
+    ``:VERSION:ARCH:REPO`` tail is free-form.
+    """
+    ctx = _StubCtx(obj=_make_globals(products_yml))
+    assert _complete_repa(ctx, "SLES:") == []
+    assert _complete_repa(ctx, "SLES:15-SP5:") == []
+
+
+def test_repa_complete_missing_config_returns_empty(tmp_path: Path) -> None:
+    """A nonexistent config file collapses to an empty list.
+
+    Completion must never raise inside the user's shell.
+    """
+    missing = tmp_path / "does-not-exist.yml"
+    ctx = _StubCtx(obj=_make_globals(missing))
+    assert _complete_repa(ctx, "") == []
+
+
+def test_repa_complete_malformed_yaml_returns_empty(tmp_path: Path) -> None:
+    """Malformed YAML collapses to an empty list (YAMLError swallowed)."""
+    bad = tmp_path / "broken.yml"
+    bad.write_text("this is: : not: valid: yaml:\n  -\n  -\n  - [\n")
+    ctx = _StubCtx(obj=_make_globals(bad))
+    assert _complete_repa(ctx, "") == []
+
+
+def test_repa_complete_no_ctx_obj_uses_default_path() -> None:
+    """When ``ctx.obj`` is missing, the helper falls back to the default
+    ``/etc/repose/products.yml``; if that file is unreadable, return [].
+
+    This exercises the defensive branch — the default path is unlikely
+    to exist in CI, so we just assert the call doesn't raise and that
+    it returns an empty list when the file is missing.
+    """
+    ctx = _StubCtx(obj=None)
+    result = _complete_repa(ctx, "")
+    # On a dev box where /etc/repose/products.yml happens to exist the
+    # call would return real products; either way, it must not raise.
+    assert isinstance(result, list)

--- a/uv.lock
+++ b/uv.lock
@@ -187,6 +187,30 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "click-man"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/1c/686c42d3a07d25d1cde107d0b92a2cf6234b92e569e61f8a294ffe6c9357/click_man-0.5.1.tar.gz", hash = "sha256:2db2163ef51a1b746d6d7781f78856430a2bcf0f10df428fe5986ecc0ef9809c", size = 21345, upload-time = "2025-04-08T14:41:11.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/37/34e03579eb583a587edba458599af6d82715a617e685dbe2ff30e4238930/click_man-0.5.1-py3-none-any.whl", hash = "sha256:ed63caf6d6bf04f2b1fb198a1a764daea9785ad29f303b2962418a417541a6ce", size = 8825, upload-time = "2025-04-08T14:41:09.345Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -610,6 +634,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "click-man" },
     { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -631,6 +656,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "click-man", specifier = ">=0.5" },
     { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=0.23" },


### PR DESCRIPTION
## Summary

Adds shell completion (bash, zsh, fish) and 10 generated man pages —
one for `repose` and one per subcommand. Both ride on the typer
migration that landed earlier; this PR is the user-facing polish.

## What's included

- **Shell completion**: `repose --install-completion {bash,zsh,fish}`
  now writes a working completion script. `add_completion=True` was
  already set on the Typer app, so this side is mostly README docs +
  one new feature on top.
- **REPA-value completion**: tab-completing a `REPA` positional reads
  the configured `products.yml` and suggests product-name prefixes
  (e.g. `SLES`, `sle-sdk`, `sle-module-toolchain`). The callback
  silently returns `[]` on any read/parse error so the user's shell
  never raises mid-keystroke.
- **Man pages**: `man repose` and `man repose-<subcmd>` render after
  install. 10 pages committed under `docs/man/` so packagers don't
  need `click-man` at build time; shipped via `MANIFEST.in`.
- **CI drift guard**: new `man-drift` job regenerates and runs
  `git diff --exit-code docs/man/`, catching the case where a
  contributor edits `cli.py` help text but forgets to refresh the
  pages.

## Reproducibility

`click-man` 0.5.1's `write_man_pages(date=...)` kwarg is broken (only
forwarded to recursive children, never applied to the page being
generated). `repose/mangen.py` pins `SOURCE_DATE_EPOCH` instead — the
reproducible-builds standard, honoured natively by
`click_man.man.ManPage`. Caller-provided values take precedence so
distro builds can stamp their changelog timestamp. Two consecutive
local runs produce byte-identical output (verified with `md5sum`).

## Files

| File | Change |
| --- | --- |
| `repose/cli.py` | `_complete_repa` autocompletion callback wired into `RepaArg` |
| `repose/mangen.py` | new — wrapper around `click_man.write_man_pages` with pinned `SOURCE_DATE_EPOCH` |
| `pyproject.toml` | `click-man>=0.5` dev dep + `repose-mangen` entry point |
| `docs/man/*.1` | new — 10 generated pages |
| `docs/Makefile` | explicit `man` target before the Sphinx catch-all |
| `MANIFEST.in` | `recursive-include docs/man *.1` |
| `.gitattributes` | mark `docs/man/*.1` as `linguist-generated` |
| `.github/workflows/ci.yml` | new `man-drift` job |
| `tests/test_cli_completion.py` | 6 tests covering happy path, no-match, post-colon, missing-config, malformed-yaml, no-ctx-obj |
| `README.md` | Shell completion section + post-install `man repose` note |

## Downstream packaging note

The `qam-infra` `.spec` will need `%{_mandir}/man1/repose.1*` in its
file list to pick up the man pages. That change lives out-of-repo.

## Verification

- `uv run ruff format --diff .` — 80 files already formatted
- `uv run ruff check .` — All checks passed
- `uv run pytest -q --no-cov` — **454 passed** (6 new in `test_cli_completion.py`)
- `uv build --sdist` — tarball contains all 10 `docs/man/*.1` files
- `uv run repose-mangen && git diff --exit-code -- docs/man/` — clean
- Two consecutive `repose-mangen` runs → bit-identical (`md5sum` proof)
- `man docs/man/repose.1` + `man docs/man/repose-add.1` render correctly