### PR TITLE
Fix three latent bugs in the asyncssh/command layers

### DIFF
--- a/repose/aiossh.py
+++ b/repose/aiossh.py
@@ -38,6 +38,25 @@ __all__ = ["AsyncConnection", "CommandTimeout"]
 logger = logging.getLogger("repose.aiossh")
 
 
+def _translate_sftp_error(exc: asyncssh.SFTPError) -> OSError:
+    """Map an asyncssh ``SFTPError`` onto the matching ``OSError`` subclass.
+
+    asyncssh's SFTP exceptions derive from ``asyncssh.Error`` — *not*
+    from ``OSError`` — so backend-neutral callers that ``except
+    OSError``/``except FileNotFoundError`` (e.g. the shared
+    :func:`repose.target.parsers.product.parse_system_async`) would
+    otherwise never catch a missing ``/etc/products.d`` or
+    ``/etc/os-release``. paramiko's SFTP client raises ``OSError``
+    subclasses for the same conditions, so translating here keeps the
+    two backends behaviourally identical.
+    """
+    if isinstance(exc, asyncssh.SFTPNoSuchFile):
+        return FileNotFoundError(str(exc))
+    if isinstance(exc, asyncssh.SFTPPermissionDenied):
+        return PermissionError(str(exc))
+    return OSError(str(exc))
+
+
 def _parse_openssh_config(hostname: str) -> dict[str, Any]:
     """Look up ``hostname`` in the user's ``~/.ssh/config``.
 
@@ -403,13 +422,19 @@ class AsyncConnection:
         # input encoding; we always pass str, so we always get str.
         # Filter out ``.`` and ``..`` for paramiko parity (paramiko's
         # SFTPClient.listdir does so by default).
-        entries = await sftp.listdir(path)
+        try:
+            entries = await sftp.listdir(path)
+        except asyncssh.SFTPError as exc:
+            raise _translate_sftp_error(exc) from exc
         return [e for e in entries if e not in (".", "..")]
 
     async def readlink(self, path: str) -> str | None:
         logger.debug("read link %s:%s:%s", self.hostname, self.port, path)
         sftp = await self._sftp_open()
-        link = await sftp.readlink(path)
+        try:
+            link = await sftp.readlink(path)
+        except asyncssh.SFTPError as exc:
+            raise _translate_sftp_error(exc) from exc
         return link if isinstance(link, str) or link is None else link.decode()
 
     def open(self, filename: str, mode: str = "r") -> "_AsyncSFTPFileCtx":
@@ -470,8 +495,11 @@ class _AsyncSFTPFileCtx:
 
     async def __aenter__(self) -> "_AsyncSFTPFileCtx":
         sftp = await self._conn._sftp_open()
-        async with sftp.open(self._filename, self._mode) as f:
-            data = await f.read()
+        try:
+            async with sftp.open(self._filename, self._mode) as f:
+                data = await f.read()
+        except asyncssh.SFTPError as exc:
+            raise _translate_sftp_error(exc) from exc
         self._content = data
         return self
 

--- a/repose/command/uninstall.py
+++ b/repose/command/uninstall.py
@@ -18,12 +18,17 @@ class Uninstall(Remove, name="uninstall"):
     ) -> dict[str, list[str]]:
         rdict: dict[str, list[str]] = {}
         for pattern in patterns:
-            for repo in self.targets[host].repos.items():
-                if pattern in repo[0]:
-                    if repo[1].name in rdict:
-                        rdict[repo[1].name].append(repo[0])
-                    else:
-                        rdict[repo[1].name] = [repo[0]]
+            for alias, product in self.targets[host].repos.items():
+                if pattern not in alias:
+                    continue
+                # ``Repositories`` stores a ``(None, None)`` sentinel for
+                # any repo whose name isn't a 4-part product string. Such
+                # a repo can't be mapped to a product to uninstall, so
+                # skip it instead of dereferencing ``.name`` and crashing.
+                name = getattr(product, "name", None)
+                if name is None:
+                    continue
+                rdict.setdefault(name, []).append(alias)
         return rdict
 
     def _run(self, host: str, update: UpdateFn, *args: Any) -> bool:

--- a/repose/types/repositories.py
+++ b/repose/types/repositories.py
@@ -1,9 +1,19 @@
 from collections import UserDict
+from typing import TYPE_CHECKING
 
-from ..target.parsers import Product
+if TYPE_CHECKING:
+    from ..target.parsers import Product
 
 
-def _parse_product(name: str, arch) -> tuple[None, None] | Product:
+def _parse_product(name: str, arch) -> "tuple[None, None] | Product":
+    # Imported lazily: ``repose.target.parsers`` lives under the
+    # ``repose.target`` package, whose ``__init__`` imports this module.
+    # A module-level import here makes the two modules a hard import
+    # cycle that breaks whenever ``repose.types.repositories`` is the
+    # first of the pair to be imported. Deferring to call time keeps the
+    # cycle from forming at import time.
+    from ..target.parsers import Product
+
     parts = name.split(":")
     # TODO: more check for possible products
     if len(parts) != 4:

--- a/tests/command/test_uninstall.py
+++ b/tests/command/test_uninstall.py
@@ -177,6 +177,54 @@ def test_uninstall_no_matching_repos_runs_only_pdcmd(monkeypatch, mock_ssh_clien
     assert "rm -t product" in target.run.call_args[0][0]
 
 
+def test_uninstall_skips_repo_with_unparseable_name(monkeypatch, mock_ssh_client):
+    """A repo whose name isn't a 4-part product must not crash uninstall.
+
+    ``Repositories`` stores a ``(None, None)`` sentinel for such repos.
+    When its alias still matches a removal pattern, ``_calculate_repodict``
+    used to dereference ``.name`` on the sentinel and raise
+    ``AttributeError``. It must instead skip the unmappable repo and
+    remove only the genuine product repos.
+    """
+    from collections import namedtuple
+
+    from repose.types.repositories import Repositories
+
+    RawRepo = namedtuple("RawRepo", "alias name")
+    repos = Repositories(
+        [
+            # 4-part name -> parsed into a Product
+            RawRepo("SLES:15-SP4::repo1", "SLES:15-SP4:x86_64:pool"),
+            # alias matches the pattern, but the name isn't a product
+            # -> stored as the (None, None) sentinel
+            RawRepo("SLES:15-SP4::weird", "SLES-15-SP4-weird"),
+        ],
+        "x86_64",
+    )
+
+    args = Namespace(
+        dry=False,
+        target=[{"user@host1": MagicMock()}],
+        repa=[Repa("SLES:15-SP4")],
+        config="dummy",
+        yaml=False,
+    )
+    target, _ = _setup_uninstall(
+        monkeypatch,
+        args,
+        [MockProduct("SLES", "15-SP4")],
+        repos,
+    )
+
+    assert Uninstall(args).run() == 0
+
+    issued = [c.args[0] for c in target.run.call_args_list]
+    rr = next(cmd for cmd in issued if cmd.startswith("zypper -n rr"))
+    # Only the product-mapped repo is removed; the sentinel one is skipped.
+    assert "SLES:15-SP4::repo1" in rr
+    assert "SLES:15-SP4::weird" not in rr
+
+
 def test_uninstall_sl_micro_uses_transactional(monkeypatch, caplog, mock_ssh_client):
     """SL-Micro uninstalls must dispatch via ``transactional-update``.
 

--- a/tests/target/parsers/test_product.py
+++ b/tests/target/parsers/test_product.py
@@ -1,10 +1,10 @@
 """Tests for ``repose.target.parsers.product.parse_system``."""
 
-from contextlib import contextmanager
-from unittest.mock import MagicMock
+from contextlib import asynccontextmanager, contextmanager
+from unittest.mock import AsyncMock, MagicMock
 
 from repose.target.parsers import Product
-from repose.target.parsers.product import parse_system
+from repose.target.parsers.product import parse_system, parse_system_async
 from repose.types.system import System
 
 
@@ -166,4 +166,81 @@ def test_non_suse_without_osrelease_returns_rhel6_default():
     conn.open.side_effect = FileNotFoundError("/etc/os-release")
 
     system = parse_system(conn)
+    assert system.get_base() == Product("rhel", "6", "x86_64")
+
+
+# ---------------------------------------------------------------------------
+# parse_system_async — mirrors the sync cases for the async backend.
+# These guard the backend-parity contract: the async parser keys off the
+# same OSError/FileNotFoundError surface, which only holds because
+# AsyncConnection translates asyncssh's SFTP errors (see test_aiossh.py).
+# ---------------------------------------------------------------------------
+
+
+def _async_open_returning(content: bytes):
+    @asynccontextmanager
+    async def _cm(*args, **kwargs):
+        mock_file = MagicMock()
+        mock_file.__iter__.return_value = iter([content])
+        yield mock_file
+
+    return _cm()
+
+
+def _make_async_connection(files, basefile, file_contents, listdir_error=None):
+    conn = MagicMock()
+    if listdir_error is not None:
+        conn.listdir = AsyncMock(side_effect=listdir_error)
+    else:
+        conn.listdir = AsyncMock(return_value=files)
+    conn.readlink = AsyncMock(return_value=basefile)
+
+    def _open(path, *args, **kwargs):
+        if path in file_contents:
+            return _async_open_returning(file_contents[path])
+        raise FileNotFoundError(path)
+
+    conn.open.side_effect = _open
+    return conn
+
+
+async def test_async_suse_baseproduct_with_patchlevel():
+    base = _prod_xml("SLES", baseversion="15", patchlevel="3", arch="x86_64")
+    conn = _make_async_connection(
+        files=["SLES.prod"],
+        basefile="SLES.prod",
+        file_contents={"/etc/products.d/SLES.prod": base},
+    )
+
+    system = await parse_system_async(conn)
+    assert system.get_base() == Product("SLES", "15-SP3", "x86_64")
+
+
+async def test_async_non_suse_falls_back_to_os_release():
+    """A missing /etc/products.d (FileNotFoundError) must not crash.
+
+    Before the SFTP-error translation, asyncssh raised ``SFTPNoSuchFile``
+    (not an ``OSError``) here, so the ``except OSError`` never fired and
+    every non-SUSE host blew up on the default backend.
+    """
+    conn = MagicMock()
+    conn.listdir = AsyncMock(side_effect=FileNotFoundError("No such directory"))
+
+    def _open(path, *args, **kwargs):
+        if path == "/etc/os-release":
+            return _async_open_returning(b"")
+        raise FileNotFoundError(path)
+
+    conn.open.side_effect = _open
+
+    system = await parse_system_async(conn)
+    assert system.get_base() == Product("rhel", "7", "x86_64")
+
+
+async def test_async_non_suse_without_osrelease_returns_rhel6_default():
+    conn = MagicMock()
+    conn.listdir = AsyncMock(side_effect=FileNotFoundError("No such directory"))
+    conn.open.side_effect = FileNotFoundError("/etc/os-release")
+
+    system = await parse_system_async(conn)
     assert system.get_base() == Product("rhel", "6", "x86_64")

--- a/tests/test_aiossh.py
+++ b/tests/test_aiossh.py
@@ -415,6 +415,50 @@ async def test_open_yields_iterable_with_content(fake_conn):
     assert lines == ["line1\n", "line2\n"]
 
 
+async def test_listdir_translates_missing_dir_to_filenotfound(fake_conn):
+    """A missing remote directory surfaces as ``FileNotFoundError``.
+
+    asyncssh's ``SFTPNoSuchFile`` does not derive from ``OSError``;
+    backend-neutral callers (``parse_system_async``) ``except OSError``,
+    so the translation is what lets non-SUSE hosts be detected.
+    """
+    sftp = MagicMock()
+    sftp.listdir = AsyncMock(side_effect=asyncssh.SFTPNoSuchFile("no dir"))
+    fake_conn.start_sftp_client = AsyncMock(return_value=sftp)
+
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+
+    with pytest.raises(FileNotFoundError):
+        await c.listdir("/etc/products.d")
+
+
+async def test_open_translates_missing_file_to_filenotfound(fake_conn):
+    """A missing remote file surfaces as ``FileNotFoundError`` on open."""
+    sftp = MagicMock()
+    sftp.open = MagicMock(side_effect=asyncssh.SFTPNoSuchFile("no file"))
+    fake_conn.start_sftp_client = AsyncMock(return_value=sftp)
+
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+
+    with pytest.raises(FileNotFoundError):
+        async with c.open("/etc/os-release"):
+            pass
+
+
+async def test_sftp_permission_denied_translates_to_permissionerror(fake_conn):
+    sftp = MagicMock()
+    sftp.listdir = AsyncMock(side_effect=asyncssh.SFTPPermissionDenied("nope"))
+    fake_conn.start_sftp_client = AsyncMock(return_value=sftp)
+
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+
+    with pytest.raises(PermissionError):
+        await c.listdir("/etc/products.d")
+
+
 # ---------------------------------------------------------------------------
 # close
 # ---------------------------------------------------------------------------

--- a/tests/test_import_cycle.py
+++ b/tests/test_import_cycle.py
@@ -1,0 +1,33 @@
+"""Guard against import cycles between ``repose.types`` and ``repose.target``.
+
+``repose.types.repositories`` needs ``repose.target.parsers.Product`` and
+``repose.target.__init__`` needs ``repose.types.repositories.Repositories``.
+If either is imported at module scope on both sides, importing whichever
+module first triggers an ``ImportError`` on a partially-initialised module.
+
+These tests import each module *first* in a clean interpreter (a
+subprocess, so the test session's already-populated ``sys.modules``
+doesn't mask the cycle).
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "repose.types.repositories",
+        "repose.types.system",
+        "repose.target",
+    ],
+)
+def test_module_imports_in_isolation(module):
+    proc = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
Three independent bug fixes, one commit each. All found by inspection/probing of the post-rewrite code; the existing suite was green, so each fix ships with a regression test that fails before and passes after.

## 1. `fix(aiossh)`: translate SFTP errors to `OSError` for backend parity
asyncssh's SFTP exceptions (`SFTPNoSuchFile`, `SFTPPermissionDenied`, …) derive from `asyncssh.Error`, **not** `OSError`. The backend-neutral `parse_system_async()` catches `OSError`/`FileNotFoundError` to detect a non-SUSE host (missing `/etc/products.d`) and a missing `/etc/os-release`, mirroring the paramiko path. Because the asyncssh errors slipped past those handlers, **every non-SUSE host crashed on the default `asyncssh` backend** instead of falling back to the os-release probe.

`AsyncConnection.listdir`/`readlink`/`open` now map `SFTPNoSuchFile → FileNotFoundError`, `SFTPPermissionDenied → PermissionError`, and any other `SFTPError → OSError`, so the two backends raise the same exception types. Also adds the previously-missing `parse_system_async` coverage.

## 2. `fix(uninstall)`: skip repos whose name isn't a product
`Repositories` stores a `(None, None)` sentinel for any repo whose name isn't a 4-part `product:version:arch:repo` string. When such a repo's alias still matched a removal pattern, `_calculate_repodict` dereferenced `.name` on the sentinel tuple and raised `AttributeError`, failing the host. Such repos are now skipped (they can't be mapped to a product to uninstall) and only genuine product repos are removed.

## 3. `fix(types)`: break `repositories` ↔ `target` import cycle
`repose.types.repositories` imported `repose.target.parsers.Product` at module scope, while `repose.target.__init__` imports `repose.types.repositories.Repositories`. Importing `repose.types.repositories` (or `repose.types.system`, which pulls it in) before `repose.target` raised `ImportError` on the partially-initialised module. The Product import is now deferred into `_parse_product` (TYPE_CHECKING-only at module scope), so the cycle never forms at import time.

---
Validation: `ruff`, `ty`, and the full pytest suite all pass (464 tests, +10 new).