### PR TITLE
feat(transactional): detect transactional hosts and reboot after package operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,35 @@ Three steps are conducted by repose:
 2. product info is provided back to repose
 3. repose executes zypper commands on refhost
 
+## Transactional systems (SL Micro)
+
+Repose auto-detects **transactional / immutable** hosts (SL Micro, SLE
+Micro, MicroOS), where the root filesystem is a read-only snapshot. On
+such hosts:
+
+- **Repository changes** (`add`, `remove`, `reset`, `clear`) use plain
+  `zypper` — `/etc/zypp/repos.d` is on a writable overlay, so nothing
+  special is needed.
+- **Product install/remove** (`install`, `uninstall`) is routed through
+  **`transactional-update`** instead of `zypper`, because it modifies the
+  read-only `/usr`. This is decided by the *host*, not the product — e.g.
+  `repose install -t slmicro qa` installs `qa` transactionally.
+- After a transactional package change, repose **reboots** the host into
+  the new snapshot, **reconnects** (with retries/backoff), and
+  **verifies** the product is actually installed (or gone, for
+  `uninstall`) before reporting success.
+
+Detection and routing are automatic — no flag is needed to enable them.
+Pass `--no-reboot` to `install`/`uninstall` to **stage** the change
+without rebooting (a reminder is logged); the snapshot only becomes
+active after the next reboot. `--no-reboot` is a no-op on
+non-transactional hosts.
+
+```
+repose install -t root@slmicro.example qa        # install + reboot + verify
+repose --no-reboot install -t root@slmicro.example qa   # stage only
+```
+
 ## Getting Help
 
 oFor repose itself as well as for its commands you can use:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -150,20 +150,40 @@ install
 -------
 
 ::
-  
-  install [-h] -t HOST REPA [REPA ...]
+
+  install [-h] -t HOST REPA [REPA ...] [--no-reboot]
 
 Add repositories and install products from  HOST corresponding to REPA
+
+On transactional hosts (SL Micro / SLE Micro / MicroOS) the products are
+installed via ``transactional-update`` and the host is rebooted,
+reconnected and verified by default. ``--no-reboot`` stages the change
+without rebooting (no-op on non-transactional hosts).
 
 
 uninstall
 ---------
 
 ::
-  
-  uninstall [-h] -t HOST REPA [REPA ...]
+
+  uninstall [-h] -t HOST REPA [REPA ...] [--no-reboot]
 
 Remove repositories and uninstall product from HOST corresponding to REPA
+
+On transactional hosts the products are removed via
+``transactional-update`` and the host is rebooted, reconnected and
+verified by default; ``--no-reboot`` stages the change.
+
+
+Transactional systems
+---------------------
+
+Repose auto-detects immutable / transactional hosts (presence of a
+``transactional-update.conf``). Repository operations stay plain
+``zypper`` (the repo config is on a writable overlay); only product
+``install``/``uninstall`` is routed through ``transactional-update`` and
+followed by a reboot + reconnect + verification, unless ``--no-reboot``
+is given.
 
 
 list-products

--- a/repose/aiossh.py
+++ b/repose/aiossh.py
@@ -456,6 +456,61 @@ class AsyncConnection:
     def is_active(self) -> bool:
         return self._conn is not None and not self._conn.is_closed()
 
+    async def fire_and_forget(self, command: str) -> None:
+        """Dispatch a command without waiting (mirror of the sync backend).
+
+        Starts ``command`` on a new channel and closes the connection;
+        a dropped link (e.g. from a reboot) is expected. Follow up with
+        :meth:`wait_reconnect`.
+        """
+        logger.debug("fire-and-forget %r on %s:%s", command, self.hostname, self.port)
+        if self._conn is not None:
+            try:
+                # create_process sends the exec request without waiting
+                # for the command to finish — right for a reboot.
+                await self._conn.create_process(command)
+            except Exception:  # noqa: BLE001 - link teardown is expected
+                logger.debug("fire-and-forget dispatch raised", exc_info=True)
+        await self.close()
+
+    async def boot_id(self) -> str:
+        """Return the host's current boot id, or "" if unreadable."""
+        try:
+            stdout, _, _ = await self.run("cat /proc/sys/kernel/random/boot_id")
+        except Exception:  # noqa: BLE001
+            return ""
+        return stdout.strip()
+
+    async def wait_reconnect(
+        self, retry: int = 10, timeout: int = 10, backoff: bool = True
+    ) -> bool:
+        """Reconnect after a reboot, retrying while the host is down.
+
+        Returns True once the connection is active again, else False
+        after exhausting ``retry``.
+        """
+        self._conn = None
+        self._sftp = None
+        count = 0
+        rtimeout = timeout
+        while not self.is_active() and count <= retry:
+            count += 1
+            await asyncio.sleep(rtimeout)
+            if backoff:
+                rtimeout = 2 * (timeout + 5 * count)
+            try:
+                await self.connect()
+            except Exception:  # noqa: BLE001 - host still rebooting
+                logger.debug(
+                    "reconnect attempt %d/%d to %s:%s failed",
+                    count,
+                    retry,
+                    self.hostname,
+                    self.port,
+                    exc_info=True,
+                )
+        return self.is_active()
+
     async def close(self) -> None:
         """Close SFTP (if open) and the SSH session. Idempotent."""
         logger.debug("closing connection to %s:%s", self.hostname, self.port)

--- a/repose/cli.py
+++ b/repose/cli.py
@@ -459,6 +459,16 @@ NoProbeOpt = Annotated[
         help="skip repository URL liveness probes",
     ),
 ]
+NoRebootOpt = Annotated[
+    bool,
+    typer.Option(
+        "--no-reboot",
+        help=(
+            "on transactional hosts (SL Micro), stage the package change "
+            "but do not reboot/reconnect/verify (default: reboot)"
+        ),
+    ),
+]
 
 
 @app.command("add", help="add specified repository to target")
@@ -515,6 +525,7 @@ def install_cmd(
     repa: RepaArg,
     probe_timeout: ProbeTimeoutOpt = 5.0,
     no_probe: NoProbeOpt = False,
+    no_reboot: NoRebootOpt = False,
 ) -> None:
     ns = _build_ns(
         ctx,
@@ -522,6 +533,7 @@ def install_cmd(
         repa=repa,
         probe_timeout=probe_timeout,
         no_probe=no_probe,
+        no_reboot=no_reboot,
     )
     raise typer.Exit(_dispatch("install", ns))
 
@@ -543,8 +555,9 @@ def uninstall_cmd(
     ctx: typer.Context,
     target: TargetOpt,
     repa: RepaArg,
+    no_reboot: NoRebootOpt = False,
 ) -> None:
-    ns = _build_ns(ctx, target=target, repa=repa)
+    ns = _build_ns(ctx, target=target, repa=repa, no_reboot=no_reboot)
     raise typer.Exit(_dispatch("uninstall", ns))
 
 

--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -52,7 +52,7 @@ class Command(ABC):
     rrpcmd: str = "zypper -n rm -t product {products}"
     ipdtcmd: str = "transactional-update pkg in -t product -l -f {products}"
     rrpdtcmd: str = "transactional-update pkg rm -t product -l -f {products}"
-    reboot: str = "rebootmgrctl reboot now"
+    reboot: str = "systemctl reboot"
 
     # Runtime backend selection produces one of two concrete dict-like
     # host groups. Commands' ``_srun``/``_arun`` bodies pick the
@@ -129,6 +129,12 @@ class Command(ABC):
         # intentionally independent (a quiet user still wants warnings,
         # just not the live table).
         self.quiet: bool = getattr(args, "quiet", False)
+        # Transactional hosts must reboot for a staged package change to
+        # take effect; repose reboots + reconnects + verifies by default.
+        # ``--no-reboot`` stages the change and only prints a reminder.
+        # ``getattr`` keeps direct-``Namespace`` tests (and non-install/
+        # uninstall commands) constructing cleanly.
+        self.no_reboot: bool = getattr(args, "no_reboot", False)
 
     @functools.cached_property
     def repoq(self) -> Repoq:
@@ -169,6 +175,76 @@ class Command(ABC):
         for line in self.targets[target].out[-1][2].splitlines():
             self.console.report(target, line, ok=False, level="error")
         return False
+
+    def _check_products(self, host: str, products: list[str], present: bool) -> bool:
+        """Verify ``products`` are present/absent in the host's re-read state.
+
+        ``present=True`` (install) requires each product to now be
+        installed; ``present=False`` (uninstall) requires each to be
+        gone. Caller must have refreshed ``targets[host].products``.
+        """
+        system = self.targets[host].products
+        installed = {p.name for p in system.flatten()} if system else set()
+        ok = True
+        for product in products:
+            if present and product not in installed:
+                logger.error("%s: product %s not installed after reboot", host, product)
+                ok = False
+            elif not present and product in installed:
+                logger.error("%s: product %s still present after reboot", host, product)
+                ok = False
+        if ok:
+            logger.info(
+                "%s: verified product(s) %s after reboot",
+                host,
+                ", ".join(products),
+            )
+        return ok
+
+    def _reboot_and_verify(
+        self, host: str, products: list[str], present: bool = True
+    ) -> bool:
+        """Reboot a transactional host, then verify the change took (sync).
+
+        With ``--no-reboot`` the change is left staged and only a reminder
+        is logged (returns True). Otherwise the host is rebooted +
+        reconnected and its products are re-read and checked.
+        """
+        if self.no_reboot:
+            logger.info(
+                "Reboot %s to activate the staged snapshot (--no-reboot set)",
+                host,
+            )
+            return True
+        if not self.targets[host].reboot(self.reboot):
+            return False
+        try:
+            self.targets[host].read_products()
+        except Exception:
+            logger.error("%s: could not re-read products after reboot", host)
+            logger.debug("re-read failure", exc_info=True)
+            return False
+        return self._check_products(host, products, present)
+
+    async def _areboot_and_verify(
+        self, host: str, products: list[str], present: bool = True
+    ) -> bool:
+        """Async mirror of :meth:`_reboot_and_verify`."""
+        if self.no_reboot:
+            logger.info(
+                "Reboot %s to activate the staged snapshot (--no-reboot set)",
+                host,
+            )
+            return True
+        if not await self.targets[host].reboot(self.reboot):
+            return False
+        try:
+            await self.targets[host].read_products()
+        except Exception:
+            logger.error("%s: could not re-read products after reboot", host)
+            logger.debug("re-read failure", exc_info=True)
+            return False
+        return self._check_products(host, products, present)
 
     def _make_progress(self) -> Progress:
         """Construct the live-progress overlay for this command run.

--- a/repose/command/install.py
+++ b/repose/command/install.py
@@ -46,23 +46,25 @@ class Install(Command, name="install"):
                 self.targets[target].run(self.refcmd)
 
         if repositories.keys():
-            transactional = False
-            if "SL-Micro" in repositories.keys():
-                transactional = True
+            # Transactional is a property of the *host* (read-only /usr),
+            # not of the product being installed: any product on a
+            # transactional host must go through transactional-update.
+            transactional = self.targets[target].products.is_transactional()
+            if transactional:
                 inscmd = self.ipdtcmd.format(products=" ".join(repositories.keys()))
             else:
                 inscmd = self.ipdcmd.format(products=" ".join(repositories.keys()))
             update(target, "installing products")
             if self.dryrun:
                 self.console.dry(str(target), inscmd)
+                if transactional and not self.no_reboot:
+                    self.console.dry(str(target), self.reboot)
             else:
                 self.targets[target].run(inscmd)
                 if not self._report_target(target):
                     ok = False
-                if transactional:
-                    logger.info(
-                        "Reboot %s to switch into correct snapshot", str(target)
-                    )
+                elif transactional:
+                    ok = self._reboot_and_verify(target, list(repositories.keys()))
         else:
             logger.error("No products to install")
             ok = False
@@ -107,23 +109,24 @@ class Install(Command, name="install"):
                 await self.targets[target].run(self.refcmd)
 
         if repositories.keys():
-            transactional = False
-            if "SL-Micro" in repositories.keys():
-                transactional = True
+            # Host property, not product property (see sync ``_run``).
+            transactional = self.targets[target].products.is_transactional()
+            if transactional:
                 inscmd = self.ipdtcmd.format(products=" ".join(repositories.keys()))
             else:
                 inscmd = self.ipdcmd.format(products=" ".join(repositories.keys()))
             update(target, "installing products")
             if self.dryrun:
                 self.console.dry(str(target), inscmd)
+                if transactional and not self.no_reboot:
+                    self.console.dry(str(target), self.reboot)
             else:
                 await self.targets[target].run(inscmd)
                 if not self._report_target(target):
                     ok = False
-                if transactional:
-                    logger.info(
-                        "Reboot %s to switch into correct snapshot",
-                        str(target),
+                elif transactional:
+                    ok = await self._areboot_and_verify(
+                        target, list(repositories.keys())
                     )
         else:
             logger.error("No products to install")

--- a/repose/command/uninstall.py
+++ b/repose/command/uninstall.py
@@ -49,10 +49,11 @@ class Uninstall(Remove, name="uninstall"):
                 repos=" ".join(chain.from_iterable(rdict.values()))
             )
 
-        # Patterns are formatted as "<product>:<version>::<repo>" — detect
-        # SL-Micro by matching the product component, not the whole pattern.
-        transactional = any(p.split(":", 1)[0] == "SL-Micro" for p in patterns)
-        products_arg = " ".join(x.split(":")[0] for x in patterns)
+        # Transactional is a property of the *host* (read-only /usr), not
+        # of the product being removed.
+        transactional = self.targets[host].products.is_transactional()
+        product_names = [x.split(":")[0] for x in patterns]
+        products_arg = " ".join(product_names)
         if transactional:
             pdcmd = self.rrpdtcmd.format(products=products_arg)
         else:
@@ -62,6 +63,8 @@ class Uninstall(Remove, name="uninstall"):
             if rrcmd:
                 self.console.dry(host, rrcmd)
             self.console.dry(host, pdcmd)
+            if transactional and not self.no_reboot:
+                self.console.dry(host, self.reboot)
             return True
 
         ok = True
@@ -74,8 +77,9 @@ class Uninstall(Remove, name="uninstall"):
         self.targets[host].run(pdcmd)
         if not self._report_target(host):
             ok = False
-        if transactional:
-            logger.info("Reboot %s to switch into updated snapshot", host)
+        elif transactional:
+            if not self._reboot_and_verify(host, product_names, present=False):
+                ok = False
         return ok
 
     async def _arun_one(self, host: str, update: UpdateFn, *args: Any) -> bool:
@@ -95,8 +99,9 @@ class Uninstall(Remove, name="uninstall"):
                 repos=" ".join(chain.from_iterable(rdict.values()))
             )
 
-        transactional = any(p.split(":", 1)[0] == "SL-Micro" for p in patterns)
-        products_arg = " ".join(x.split(":")[0] for x in patterns)
+        transactional = self.targets[host].products.is_transactional()
+        product_names = [x.split(":")[0] for x in patterns]
+        products_arg = " ".join(product_names)
         if transactional:
             pdcmd = self.rrpdtcmd.format(products=products_arg)
         else:
@@ -106,6 +111,8 @@ class Uninstall(Remove, name="uninstall"):
             if rrcmd:
                 self.console.dry(host, rrcmd)
             self.console.dry(host, pdcmd)
+            if transactional and not self.no_reboot:
+                self.console.dry(host, self.reboot)
             return True
 
         ok = True
@@ -118,8 +125,9 @@ class Uninstall(Remove, name="uninstall"):
         await self.targets[host].run(pdcmd)
         if not self._report_target(host):
             ok = False
-        if transactional:
-            logger.info("Reboot %s to switch into updated snapshot", host)
+        elif transactional:
+            if not await self._areboot_and_verify(host, product_names, present=False):
+                ok = False
         return ok
 
     def _srun(self) -> ExitCode:

--- a/repose/connection.py
+++ b/repose/connection.py
@@ -213,6 +213,72 @@ class Connection:
                     f"Reconnection to {self.hostname}:{self.port} failed"
                 )
 
+    def fire_and_forget(self, command: str) -> None:
+        """Dispatch a command without waiting for it to return.
+
+        Intended for a command that deliberately tears down the link
+        (e.g. a reboot): the command is exec'd on a fresh session and the
+        local connection is then closed. No output/exit status is
+        collected and a dropped link is expected — follow up with
+        :meth:`wait_reconnect`. Avoids :meth:`run`'s reconnect recovery,
+        which would otherwise fight the still-rebooting host.
+
+        Args:
+            command: The command to dispatch.
+        """
+        logger.debug("fire-and-forget %r on %s:%s", command, self.hostname, self.port)
+        self.__run_command(command)
+        self.close()
+
+    def boot_id(self) -> str:
+        """Return the host's current boot id, or "" if unreadable.
+
+        ``/proc/sys/kernel/random/boot_id`` changes on every boot; used to
+        confirm a reboot actually happened.
+        """
+        try:
+            stdout, _, _ = self.run("cat /proc/sys/kernel/random/boot_id")
+        except Exception:
+            return ""
+        return stdout.strip()
+
+    def wait_reconnect(
+        self, retry: int = 10, timeout: int = 10, backoff: bool = True
+    ) -> bool:
+        """Reconnect after a reboot, retrying while the host is down.
+
+        Args:
+            retry: Maximum number of reconnect attempts.
+            timeout: Base wait (seconds) between attempts.
+            backoff: Grow the wait exponentially between attempts.
+
+        Returns:
+            True once the connection is active again, else False after
+            exhausting ``retry``.
+        """
+        count = 0
+        rtimeout = timeout
+        while not self.is_active() and count <= retry:
+            count += 1
+            # Wait first: right after a reboot dispatch the host is still
+            # going down, so an immediate connect would only race the
+            # shutdown.
+            select.select([], [], [], rtimeout)
+            if backoff:
+                rtimeout = 2 * (timeout + 5 * count)
+            try:
+                self.connect()
+            except Exception:
+                logger.debug(
+                    "reconnect attempt %d/%d to %s:%s failed",
+                    count,
+                    retry,
+                    self.hostname,
+                    self.port,
+                    exc_info=True,
+                )
+        return self.is_active()
+
     def new_session(self) -> Channel | None:
         logger.debug("Creating new session at %s:%s", self.hostname, self.port)
         session: Channel | None = None

--- a/repose/target/__init__.py
+++ b/repose/target/__init__.py
@@ -64,6 +64,39 @@ class Target:
             self.connect()
         self.products = parse_system(self.connection)
 
+    def reboot(self, command: str, *, retry: int = 10, backoff: bool = True) -> bool:
+        """Reboot the host and wait for it to come back.
+
+        Dispatches ``command`` fire-and-forget (the SSH link drops), then
+        reconnects with retries/backoff and checks the boot id changed.
+        Used after a transactional package operation so the new snapshot
+        becomes active.
+
+        Args:
+            command: The reboot command to dispatch.
+            retry: Maximum reconnect attempts.
+            backoff: Grow the wait between attempts exponentially.
+
+        Returns:
+            True once the host is reachable again, else False.
+        """
+        before = self.connection.boot_id()
+        logger.info("Rebooting %s:%s", self.hostname, self.port)
+        self.connection.fire_and_forget(command)
+        self.is_connected = False
+        if not self.connection.wait_reconnect(retry=retry, backoff=backoff):
+            logger.error(
+                "%s:%s did not come back after reboot", self.hostname, self.port
+            )
+            return False
+        self.is_connected = True
+        after = self.connection.boot_id()
+        if before and after and before == after:
+            logger.warning(
+                "%s:%s boot id unchanged after reboot", self.hostname, self.port
+            )
+        return True
+
     def close(self) -> None:
         self.connection.close()
         self.is_connected = False

--- a/repose/target/async_target.py
+++ b/repose/target/async_target.py
@@ -89,6 +89,27 @@ class AsyncTarget:
             await self.connect()
         self.products = await parse_system_async(self.connection)
 
+    async def reboot(
+        self, command: str, *, retry: int = 10, backoff: bool = True
+    ) -> bool:
+        """Async mirror of :meth:`repose.target.Target.reboot`."""
+        before = await self.connection.boot_id()
+        logger.info("Rebooting %s:%s", self.hostname, self.port)
+        await self.connection.fire_and_forget(command)
+        self.is_connected = False
+        if not await self.connection.wait_reconnect(retry=retry, backoff=backoff):
+            logger.error(
+                "%s:%s did not come back after reboot", self.hostname, self.port
+            )
+            return False
+        self.is_connected = True
+        after = await self.connection.boot_id()
+        if before and after and before == after:
+            logger.warning(
+                "%s:%s boot id unchanged after reboot", self.hostname, self.port
+            )
+        return True
+
     async def close(self) -> None:
         await self.connection.close()
         self.is_connected = False

--- a/repose/target/parsers/product.py
+++ b/repose/target/parsers/product.py
@@ -45,6 +45,38 @@ def __parse_os_release(f: Any) -> tuple[str, str, str]:
     return ("rhel", "7", "x86_64")
 
 
+# transactional-update ships its config here; its presence marks an
+# immutable / transactional host (SL Micro 6.x uses /usr/etc, older SLE
+# Micro 5.x / MicroOS use /etc). Probed over SFTP so detection stays
+# command-free and dry-run-safe; name-agnostic across all such products.
+_TRANSACTIONAL_CONF_PATHS = (
+    "/usr/etc/transactional-update.conf",
+    "/etc/transactional-update.conf",
+)
+
+
+def __detect_transactional(connection: Connection) -> bool:
+    """Return True if the host is transactional (sync connection)."""
+    for path in _TRANSACTIONAL_CONF_PATHS:
+        try:
+            with connection.open(path):
+                return True
+        except (FileNotFoundError, OSError):
+            continue
+    return False
+
+
+async def __detect_transactional_async(connection: Any) -> bool:
+    """Return True if the host is transactional (async connection)."""
+    for path in _TRANSACTIONAL_CONF_PATHS:
+        try:
+            async with connection.open(path):
+                return True
+        except (FileNotFoundError, OSError):
+            continue
+    return False
+
+
 def parse_system(connection: Connection) -> System:
     files = []
     try:
@@ -85,7 +117,7 @@ def parse_system(connection: Connection) -> System:
             name, version, arch = __parse_product(f)
             if name.rpartition("-")[-1] != "migration":
                 addons.add(Product(name, version, arch))
-    return System(base, addons)
+    return System(base, addons, transactional=__detect_transactional(connection))
 
 
 async def parse_system_async(connection: Any) -> System:
@@ -141,4 +173,5 @@ async def parse_system_async(connection: Any) -> System:
             name, version, arch = __parse_product(f)
             if name.rpartition("-")[-1] != "migration":
                 addons.add(Product(name, version, arch))
-    return System(base, addons)
+    transactional = await __detect_transactional_async(connection)
+    return System(base, addons, transactional=transactional)

--- a/repose/types/system.py
+++ b/repose/types/system.py
@@ -17,10 +17,16 @@ class UnknownSystemError(ValueError):
 
 @dataclass(frozen=True, slots=True)
 class SystemData:
-    """Typed internal storage for System — always exactly two fields."""
+    """Typed internal storage for System.
+
+    ``transactional`` marks an immutable / transactional-update host (SL
+    Micro, SLE Micro, MicroOS): package operations must go through
+    ``transactional-update`` and a reboot, rather than direct ``zypper``.
+    """
 
     base: Product
     addons: set[Product]
+    transactional: bool = False
 
 
 @dataclass(eq=False)
@@ -32,14 +38,26 @@ class System:
 
     _data: SystemData = field(init=False)
 
-    def __init__(self, base: Product, addons: set[Product] | None = None) -> None:
+    def __init__(
+        self,
+        base: Product,
+        addons: set[Product] | None = None,
+        transactional: bool = False,
+    ) -> None:
         """Create a System with a base product and optional addon set.
 
         Args:
             base: The base product (a ``Product`` dataclass).
             addons: Optional set of addon ``Product`` instances.
+            transactional: True for an immutable / transactional-update
+                host (package ops go through ``transactional-update`` +
+                reboot instead of direct ``zypper``).
         """
-        self._data = SystemData(base=base, addons=addons if addons else set())
+        self._data = SystemData(
+            base=base,
+            addons=addons if addons else set(),
+            transactional=transactional,
+        )
 
     def __str__(self) -> str:
         suffix = "-modules" if self._data.addons else ""
@@ -75,6 +93,15 @@ class System:
 
     def arch(self) -> str:
         return self._data.base.arch
+
+    def is_transactional(self) -> bool:
+        """Return True for an immutable / transactional-update host.
+
+        On such hosts (SL Micro, SLE Micro, MicroOS) the root is a
+        read-only snapshot, so package install/remove must run through
+        ``transactional-update`` and take effect only after a reboot.
+        """
+        return self._data.transactional
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, System):

--- a/tests/command/test_install.py
+++ b/tests/command/test_install.py
@@ -49,6 +49,7 @@ def test_install_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client):
 
     mock_target = MagicMock()
     mock_target.products.get_base.return_value = "dummy_base"
+    mock_target.products.is_transactional.return_value = False
     mock_target.out = _ok_out()
     mock_host_group_instance = MagicMock()
     mock_host_group_instance.keys.return_value = ["user@host1"]
@@ -97,6 +98,7 @@ def _setup_install(monkeypatch, args, repoq_solution, out=None, probe=True):
 
     mock_target = MagicMock()
     mock_target.products.get_base.return_value = "dummy_base"
+    mock_target.products.is_transactional.return_value = False
     mock_target.out = out if out is not None else _ok_out()
     mock_hg = MagicMock()
     mock_hg.keys.return_value = ["user@host1"]
@@ -137,24 +139,82 @@ def test_install_command_dryrun_skips_run(
     assert "user@host1" in out
 
 
-def test_install_command_sl_micro_uses_transactional(
-    monkeypatch, mock_args_and_repa, caplog, mock_ssh_client
+def _make_transactional(target, *, installed_after):
+    """Configure a mock target as a transactional host.
+
+    ``installed_after`` is the set of product names the post-reboot
+    product re-read should report (so the verify step can pass/fail).
+    """
+    target.products.is_transactional.return_value = True
+    target.reboot.return_value = True
+    after = set()
+    for name in installed_after:
+        p = MagicMock()
+        p.name = name
+        after.add(p)
+    target.products.flatten.return_value = after
+
+
+def test_install_on_transactional_host_uses_transactional_and_reboots(
+    monkeypatch, mock_args_and_repa, mock_ssh_client
 ):
+    """Any product on a transactional host → transactional-update + reboot,
+    regardless of the product name (the host, not the product, decides)."""
     args, _ = mock_args_and_repa
 
     target, _, _ = _setup_install(
         monkeypatch,
         args,
-        {"SL-Micro": [MockRepo("repo1", "http://repo1.url", refresh=True)]},
+        {"qa": [MockRepo("repo1", "http://repo1.url", refresh=True)]},
     )
+    # A non-"SL-Micro" product on a transactional host must still go
+    # through transactional-update — this is the core fix.
+    _make_transactional(target, installed_after={"qa"})
 
-    with caplog.at_level("INFO", logger="repose.command.install"):
-        assert Install(args).run() == 0
+    assert Install(args).run() == 0
 
-    # Find the install command issued
     issued = [c.args[0] for c in target.run.call_args_list]
-    assert any("transactional-update" in cmd for cmd in issued)
-    assert any("Reboot" in r.message for r in caplog.records)
+    assert any("transactional-update pkg in" in cmd for cmd in issued)
+    assert not any(cmd.startswith("zypper -n in") for cmd in issued)
+    target.reboot.assert_called_once()
+
+
+def test_install_transactional_verify_fails_when_product_absent(
+    monkeypatch, mock_args_and_repa, mock_ssh_client
+):
+    """If the product is not present after the reboot, the host fails."""
+    args, _ = mock_args_and_repa
+
+    target, _, _ = _setup_install(
+        monkeypatch,
+        args,
+        {"qa": [MockRepo("repo1", "http://repo1.url", refresh=True)]},
+    )
+    _make_transactional(target, installed_after=set())  # qa missing after reboot
+
+    # Single host, verify fails → all hosts failed → exit 2.
+    assert Install(args).run() == 2
+    target.reboot.assert_called_once()
+
+
+def test_install_transactional_no_reboot_stages_only(
+    monkeypatch, mock_args_and_repa, mock_ssh_client
+):
+    """--no-reboot on a transactional host installs but skips reboot/verify."""
+    args, _ = mock_args_and_repa
+    args.no_reboot = True
+
+    target, _, _ = _setup_install(
+        monkeypatch,
+        args,
+        {"qa": [MockRepo("repo1", "http://repo1.url", refresh=True)]},
+    )
+    _make_transactional(target, installed_after=set())
+
+    assert Install(args).run() == 0
+    issued = [c.args[0] for c in target.run.call_args_list]
+    assert any("transactional-update pkg in" in cmd for cmd in issued)
+    target.reboot.assert_not_called()
 
 
 def test_install_command_no_products_logs_error(
@@ -253,6 +313,7 @@ def _setup_install_multi(monkeypatch, hosts):
     for host, out in hosts.items():
         t = MagicMock()
         t.products.get_base.return_value = "dummy_base"
+        t.products.is_transactional.return_value = False
         t.out = out
         targets[host] = t
 

--- a/tests/command/test_uninstall.py
+++ b/tests/command/test_uninstall.py
@@ -48,6 +48,7 @@ def test_uninstall_command_run(monkeypatch, mock_args_and_repa, mock_ssh_client)
     # Mocks
     mock_target = MagicMock()
     mock_target.products.flatten.return_value = [MockProduct("SLES", "15-SP4")]
+    mock_target.products.is_transactional.return_value = False
     mock_target.repos = {
         "SLES:15-SP4::repo1": MockRepo(name="SLES"),
         "SLES:15-SP4::repo2": MockRepo(name="SLES"),
@@ -95,6 +96,7 @@ def _setup_uninstall(monkeypatch, args, products, repos, out=None, hosts=None):
         hosts = ["user@host1"]
     mock_target = MagicMock()
     mock_target.products.flatten.return_value = products
+    mock_target.products.is_transactional.return_value = False
     mock_target.repos = repos
     mock_target.out = out if out is not None else _ok_out()
     mock_hg = MagicMock()
@@ -225,38 +227,71 @@ def test_uninstall_skips_repo_with_unparseable_name(monkeypatch, mock_ssh_client
     assert "SLES:15-SP4::weird" not in rr
 
 
-def test_uninstall_sl_micro_uses_transactional(monkeypatch, caplog, mock_ssh_client):
-    """SL-Micro uninstalls must dispatch via ``transactional-update``.
-
-    Patterns are formatted ``<product>:<version>::<repo>`` so SL-Micro
-    detection has to match on the product component, not the whole pattern.
-    """
+def test_uninstall_on_transactional_host_uses_transactional_and_reboots(
+    monkeypatch, mock_ssh_client
+):
+    """Uninstall on a transactional host → transactional-update rm + reboot,
+    then verify the product is gone. Decided by the host, not the product."""
     args = Namespace(
         dry=False,
         target=[{"user@host1": MagicMock()}],
-        repa=[Repa("SL-Micro:6.0")],
+        repa=[Repa("qa:6.0")],
         config="dummy",
         yaml=False,
     )
     target, _ = _setup_uninstall(
         monkeypatch,
         args,
-        [MockProduct("SL-Micro", "6.0")],
-        {"SL-Micro:6.0::repo1": MockRepo("SL-Micro")},
+        [MockProduct("qa", "6.0")],
+        {"qa:6.0::repo1": MockRepo("qa")},
     )
+    target.products.is_transactional.return_value = True
+    target.reboot.return_value = True
+    # First flatten() drives pattern calc (product present); the second,
+    # after the reboot, is the verify and must show the product gone.
+    target.products.flatten.side_effect = [
+        [MockProduct("qa", "6.0")],
+        [],
+    ]
 
-    with caplog.at_level("INFO", logger="repose.command.uninstall"):
-        assert Uninstall(args).run() == 0
+    assert Uninstall(args).run() == 0
 
     issued = [c.args[0] for c in target.run.call_args_list]
-    # Both rr (for the matched repo) and the transactional rm should fire.
     assert any(cmd.startswith("zypper -n rr") for cmd in issued)
     assert any(
-        "transactional-update pkg rm -t product" in cmd and "SL-Micro" in cmd
+        "transactional-update pkg rm -t product" in cmd and "qa" in cmd
         for cmd in issued
     )
-    # And the reboot reminder must be emitted.
-    assert any("Reboot" in r.message for r in caplog.records)
+    target.reboot.assert_called_once()
+
+
+def test_uninstall_transactional_verify_fails_when_still_present(
+    monkeypatch, mock_ssh_client
+):
+    """If the product is still present after the reboot, the host fails."""
+    args = Namespace(
+        dry=False,
+        target=[{"user@host1": MagicMock()}],
+        repa=[Repa("qa:6.0")],
+        config="dummy",
+        yaml=False,
+    )
+    target, _ = _setup_uninstall(
+        monkeypatch,
+        args,
+        [MockProduct("qa", "6.0")],
+        {"qa:6.0::repo1": MockRepo("qa")},
+    )
+    target.products.is_transactional.return_value = True
+    target.reboot.return_value = True
+    # Still present after reboot → verify fails.
+    target.products.flatten.side_effect = [
+        [MockProduct("qa", "6.0")],
+        [MockProduct("qa", "6.0")],
+    ]
+
+    assert Uninstall(args).run() == 2
+    target.reboot.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -269,6 +304,7 @@ def _setup_uninstall_multi(monkeypatch, hosts):
     for host, out in hosts.items():
         t = MagicMock()
         t.products.flatten.return_value = [MockProduct("SLES", "15-SP4")]
+        t.products.is_transactional.return_value = False
         t.repos = {"SLES:15-SP4::repo1": MockRepo("SLES")}
         t.out = out
         targets[host] = t

--- a/tests/fixtures/help/install.txt
+++ b/tests/fixtures/help/install.txt
@@ -10,4 +10,7 @@ Options:
   --probe-timeout SECONDS  seconds to wait per repository URL probe (default: 5)
                            [default: 5.0]
   --no-probe               skip repository URL liveness probes
+  --no-reboot              on transactional hosts (SL Micro), stage the package
+                           change but do not reboot/reconnect/verify (default:
+                           reboot)
   -h, --help               Show this message and exit.

--- a/tests/fixtures/help/uninstall.txt
+++ b/tests/fixtures/help/uninstall.txt
@@ -7,4 +7,6 @@ Arguments:
 
 Options:
   -t, --target HOST  target to operate on  [required]
+  --no-reboot        on transactional hosts (SL Micro), stage the package change
+                     but do not reboot/reconnect/verify (default: reboot)
   -h, --help         Show this message and exit.

--- a/tests/target/parsers/test_product.py
+++ b/tests/target/parsers/test_product.py
@@ -143,6 +143,51 @@ def test_baseproduct_symlink_with_path_strips_dir():
     assert system.get_base().name == "SLES"
 
 
+def test_transactional_host_detected_via_conf():
+    """A transactional-update.conf marks the host transactional."""
+    base = _prod_xml("SL-Micro", version="6.1", arch="x86_64")
+    conn = _make_connection(
+        files=["SL-Micro.prod"],
+        basefile="SL-Micro.prod",
+        file_contents={
+            "/etc/products.d/SL-Micro.prod": base,
+            "/usr/etc/transactional-update.conf": b"",
+        },
+    )
+
+    system = parse_system(conn)
+    assert system.is_transactional() is True
+
+
+def test_transactional_conf_in_etc_also_detected():
+    """SLE Micro 5.x keeps the conf in /etc, not /usr/etc."""
+    base = _prod_xml("SLE-Micro", version="5.5", arch="x86_64")
+    conn = _make_connection(
+        files=["SLE-Micro.prod"],
+        basefile="SLE-Micro.prod",
+        file_contents={
+            "/etc/products.d/SLE-Micro.prod": base,
+            "/etc/transactional-update.conf": b"",
+        },
+    )
+
+    system = parse_system(conn)
+    assert system.is_transactional() is True
+
+
+def test_non_transactional_host_not_detected():
+    """A regular SLES host (no transactional-update.conf) is not flagged."""
+    base = _prod_xml("SLES", baseversion="16", patchlevel="0", arch="x86_64")
+    conn = _make_connection(
+        files=["SLES.prod"],
+        basefile="SLES.prod",
+        file_contents={"/etc/products.d/SLES.prod": base},
+    )
+
+    system = parse_system(conn)
+    assert system.is_transactional() is False
+
+
 def test_non_suse_falls_back_to_os_release():
     """When /etc/products.d is absent, parser opens /etc/os-release."""
     conn = MagicMock()
@@ -214,6 +259,33 @@ async def test_async_suse_baseproduct_with_patchlevel():
 
     system = await parse_system_async(conn)
     assert system.get_base() == Product("SLES", "15-SP3", "x86_64")
+
+
+async def test_async_transactional_host_detected_via_conf():
+    base = _prod_xml("SL-Micro", version="6.1", arch="x86_64")
+    conn = _make_async_connection(
+        files=["SL-Micro.prod"],
+        basefile="SL-Micro.prod",
+        file_contents={
+            "/etc/products.d/SL-Micro.prod": base,
+            "/usr/etc/transactional-update.conf": b"",
+        },
+    )
+
+    system = await parse_system_async(conn)
+    assert system.is_transactional() is True
+
+
+async def test_async_non_transactional_not_detected():
+    base = _prod_xml("SLES", baseversion="16", patchlevel="0", arch="x86_64")
+    conn = _make_async_connection(
+        files=["SLES.prod"],
+        basefile="SLES.prod",
+        file_contents={"/etc/products.d/SLES.prod": base},
+    )
+
+    system = await parse_system_async(conn)
+    assert system.is_transactional() is False
 
 
 async def test_async_non_suse_falls_back_to_os_release():

--- a/tests/test_aiossh.py
+++ b/tests/test_aiossh.py
@@ -546,3 +546,58 @@ async def test_integration_real_server_run_and_exit(tmp_path, monkeypatch):
     finally:
         server.close()
         await server.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# Transactional reboot support (async mirror of the paramiko tests)
+# ---------------------------------------------------------------------------
+
+
+async def test_async_fire_and_forget_dispatches_then_closes(fake_conn):
+    fake_conn.create_process = AsyncMock()
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+
+    await c.fire_and_forget("systemctl reboot")
+
+    fake_conn.create_process.assert_awaited_once_with("systemctl reboot")
+    fake_conn.close.assert_called()
+    assert c._conn is None  # closed
+
+
+async def test_async_boot_id_returns_stripped(monkeypatch):
+    c = AsyncConnection("h", "u", 22)
+    monkeypatch.setattr(c, "run", AsyncMock(return_value=("abc-123\n", "", 0)))
+    assert await c.boot_id() == "abc-123"
+
+
+async def test_async_wait_reconnect_succeeds_after_retries(monkeypatch, fake_conn):
+    c = AsyncConnection("h", "u", 22)
+    calls = {"n": 0}
+
+    async def fake_connect():
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            c._conn = fake_conn  # host back up on the 2nd attempt
+
+    monkeypatch.setattr(c, "connect", fake_connect)
+
+    ok = await c.wait_reconnect(retry=5, timeout=0, backoff=False)
+
+    assert ok is True
+    assert calls["n"] == 2
+
+
+async def test_async_wait_reconnect_gives_up(monkeypatch):
+    c = AsyncConnection("h", "u", 22)
+    calls = {"n": 0}
+
+    async def fake_connect():
+        calls["n"] += 1  # never becomes active
+
+    monkeypatch.setattr(c, "connect", fake_connect)
+
+    ok = await c.wait_reconnect(retry=2, timeout=0, backoff=False)
+
+    assert ok is False
+    assert calls["n"] == 3  # retry=N → N+1 attempts

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -247,3 +247,59 @@ def test_accept_new_policy_persists_when_path_given(tmp_path):
     policy.missing_host_key(client, "h.example.com", key)
 
     client.save_host_keys.assert_called_once_with(str(kh))
+
+
+# ---------------------------------------------------------------------------
+# Transactional reboot support: fire_and_forget / boot_id / wait_reconnect
+# ---------------------------------------------------------------------------
+
+
+def test_fire_and_forget_dispatches_then_closes(mock_ssh_client):
+    """The command is exec'd on a fresh session and the link is closed."""
+    conn = Connection("h", "u", 22)
+    conn.connect()
+
+    conn.fire_and_forget("systemctl reboot")
+
+    session = mock_ssh_client.get_transport.return_value.open_session.return_value
+    session.exec_command.assert_called_once_with("systemctl reboot")
+    mock_ssh_client.close.assert_called()
+
+
+def test_boot_id_returns_stripped_output(mock_ssh_client, monkeypatch):
+    conn = Connection("h", "u", 22)
+    monkeypatch.setattr(conn, "run", lambda *a, **k: ("abc-123\n", "", 0))
+    assert conn.boot_id() == "abc-123"
+
+
+def test_boot_id_empty_on_error(mock_ssh_client, monkeypatch):
+    conn = Connection("h", "u", 22)
+
+    def _boom(*a, **k):
+        raise RuntimeError("down")
+
+    monkeypatch.setattr(conn, "run", _boom)
+    assert conn.boot_id() == ""
+
+
+def test_wait_reconnect_succeeds_after_retries(mock_ssh_client):
+    """Reconnect keeps retrying while the host is down, then succeeds."""
+    conn = Connection("h", "u", 22)
+    # is_active(): down, down, then up (with a spare for the final check).
+    mock_ssh_client._transport.is_active.side_effect = [False, False, True, True]
+
+    ok = conn.wait_reconnect(retry=5, timeout=0, backoff=False)
+
+    assert ok is True
+    assert mock_ssh_client.connect.call_count == 2
+
+
+def test_wait_reconnect_gives_up_after_retry_budget(mock_ssh_client):
+    conn = Connection("h", "u", 22)
+    mock_ssh_client._transport.is_active.return_value = False
+
+    ok = conn.wait_reconnect(retry=2, timeout=0, backoff=False)
+
+    assert ok is False
+    # count increments after entering, so retry=N yields N+1 attempts.
+    assert mock_ssh_client.connect.call_count == 3


### PR DESCRIPTION
## What

Make repose work correctly on **transactional / immutable** hosts (SL Micro, SLE Micro, MicroOS), where the root (`/usr`) is a read-only btrfs snapshot so package changes must go through `transactional-update` and take effect only after a reboot.

## Why

Repose already had *partial* support, but it keyed off the **product name**: `install.py` used `if "SL-Micro" in repositories.keys()` and `uninstall.py` matched the product component. So installing **any other** product/module on an SL-Micro host (e.g. `repose install -t slmicro qa`) wrongly ran plain `zypper -n in`, which fails on the read-only `/usr`. Transactionality is a property of the **host**, not of the product being (un)installed. There was also no reboot, so a staged snapshot never became active and the result was never verified.

## What changed

- **Host-level detection** (name-agnostic): a host is transactional if a `transactional-update.conf` exists (`/usr/etc/...` on SL Micro 6.x, `/etc/...` on SLE Micro 5.x), probed over SFTP during product parsing. Stored as `System.transactional` + `System.is_transactional()`.
- **Routing**: `install`/`uninstall` choose `transactional-update` vs `zypper` from the host flag, in both the paramiko and asyncssh paths. Repo operations (`add`/`remove`/`reset`/`clear`) stay plain `zypper` — `/etc/zypp/repos.d` is on a writable overlay, verified on a real SL-Micro host.
- **Reboot → reconnect → verify**: after a transactional package op, repose reboots (`systemctl reboot`, fire-and-forget), reconnects with retries/backoff (confirmed via `boot_id`), then re-reads products and verifies the product is present (install) / gone (uninstall) before reporting success. `--no-reboot` stages the change only (no-op on non-transactional hosts).
- New connection primitives `fire_and_forget` / `boot_id` / `wait_reconnect` on both backends, and `Target.reboot()` / `AsyncTarget.reboot()`. Reboot command switched to `systemctl reboot` (universal; `rebootmgrctl` needs `rebootmgr.service`).
- `--no-reboot` CLI flag on `install`/`uninstall`; README + `docs/cli.rst` docs; help snapshots regenerated.

## Testing

`ruff format --diff . && ruff check . && python3 -m pytest` — **481 passed**, ruff clean. New tests cover detection (conf in `/usr/etc` and `/etc`, non-transactional negative), host-based routing (non-`SL-Micro` product on a transactional host uses `transactional-update`), reboot/reconnect (retry + backoff, give-up), post-reboot verify (pass and fail), `--no-reboot`, and dry-run previews — for both backends.

Verified live on real refhosts:

- SL-Micro (transactional): `install`/`uninstall` dry-run shows `transactional-update pkg in/rm -t product …` **+ `systemctl reboot`**; `--no-reboot` omits the reboot.
- SLES (non-transactional): plain `zypper`, no reboot.