### PR TITLE
fix: verify async repo probe against system trust store

### DIFF
--- a/repose/utils.py
+++ b/repose/utils.py
@@ -1,6 +1,8 @@
 import os
+import ssl
 import sys
 import time
+from functools import lru_cache
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
@@ -8,6 +10,24 @@ from urllib.request import urlopen
 def timestamp() -> str:
     # remove fractional part
     return str(int(time.time()))
+
+
+@lru_cache(maxsize=1)
+def _system_ssl_context() -> ssl.SSLContext:
+    """Return an SSL context that trusts the OS certificate store.
+
+    ``httpx`` defaults to the bundled ``certifi`` CA list, which does
+    not include internal/enterprise CAs (e.g. the SUSE trust root that
+    ``download.suse.de`` presents). ``urllib`` — and therefore the sync
+    probe :func:`check_repo_url` — validates against the system trust
+    store instead, so an internal repository reachable by the sync
+    backend was silently rejected by the async backend. Building the
+    context from the system defaults restores backend parity.
+
+    The context is cached: it is read-only after construction and
+    rebuilding it per probe would re-read the CA bundle from disk.
+    """
+    return ssl.create_default_context()
 
 
 def check_repo_url(url: str, *, timeout: float = 5.0) -> bool:
@@ -47,13 +67,20 @@ async def check_repo_url_async(url: str, *, timeout: float = 5.0) -> bool:
     ``repomd.xml`` payload, with a GET fallback because some mirrors
     return 405 on HEAD even though the resource exists.
 
+    TLS is verified against the system trust store (see
+    :func:`_system_ssl_context`) rather than ``httpx``'s bundled
+    ``certifi`` list, so internal CAs trusted by the sync probe are
+    trusted here too.
+
     A short-lived ``httpx.AsyncClient`` is created per call; the
     cohort-level batching is the caller's job
     (:meth:`Command._afilter_live_urls`).
     """
     import httpx
 
-    async with httpx.AsyncClient(timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        timeout=timeout, verify=_system_ssl_context()
+    ) as client:
         for suffix in ("repodata/repomd.xml", "suse/repodata/repomd.xml"):
             target = url + suffix
             try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 """Tests for ``repose.utils``."""
 
 import io
+import ssl
 from unittest.mock import MagicMock
 from urllib.error import HTTPError, URLError
 
@@ -250,3 +251,35 @@ async def test_check_repo_url_async_retries_get_on_405(monkeypatch):
 
     assert (await repose.utils.check_repo_url_async("http://example.com/")) is True
     assert calls == ["head", "get"]
+
+
+async def test_check_repo_url_async_verifies_against_system_trust_store(
+    monkeypatch,
+):
+    """Regression: the async probe must verify TLS against the system
+    trust store (parity with the urllib sync probe), not httpx's bundled
+    ``certifi`` list. Otherwise a repository behind an internal CA is
+    reachable on the sync backend but silently rejected on the asyncssh
+    backend."""
+    ok = MagicMock(status_code=200)
+    captured: dict = {}
+
+    async def _next(target, **kw):
+        return ok
+
+    client = MagicMock()
+    client.head = _next
+    client.get = _next
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=None)
+
+    def _factory(*args, **kwargs):
+        captured.update(kwargs)
+        return cm
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+
+    assert (await repose.utils.check_repo_url_async("http://example.com/")) is True
+    assert captured["verify"] is repose.utils._system_ssl_context()
+    assert isinstance(captured["verify"], ssl.SSLContext)


### PR DESCRIPTION
## Problem

`check_repo_url_async()` lets `httpx` verify TLS against its bundled
`certifi` CA list, while the sync `check_repo_url()` (urllib) validates
against the OS trust store. Repositories served behind an
internal/enterprise CA are therefore reachable on the **paramiko**
backend but silently rejected on the **asyncssh** backend: every
candidate URL fails the TLS handshake, `_afilter_live_urls` drops them
all, and `reset`/`add` end up issuing **no `zypper ar` at all** (exit 0,
looks like a no-op).

This breaks `reset`/`add`/`install` against internal repositories
whenever the asyncssh backend is in use (the default).

## Fix

Build the `httpx` client with an `ssl.SSLContext` from
`ssl.create_default_context()` (cached) so the async probe trusts the
same CAs as urllib — restoring backend parity.

## Test

Adds a regression test asserting the async client is constructed with a
system-trust-store `SSLContext` as `verify`. Full suite green; `utils.py`
at 100% coverage. `ruff format --diff` / `ruff check` clean.