### PR TITLE
fix: run transactional-update non-interactively for product ops

### DIFF
--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -50,8 +50,14 @@ class Command(ABC):
     refcmd: str = "zypper -n --gpg-auto-import-keys ref -f"
     ipdcmd: str = "zypper -n in -t product -l -f {products}"
     rrpcmd: str = "zypper -n rm -t product {products}"
-    ipdtcmd: str = "transactional-update pkg in -t product -l -f {products}"
-    rrpdtcmd: str = "transactional-update pkg rm -t product -l -f {products}"
+    # ``-n`` makes transactional-update non-interactive, which in turn runs
+    # the inner ``zypper`` with ``--non-interactive``. Without it the inner
+    # zypper prompts ``Continue? [y/n]`` and, having no terminal under an SSH
+    # exec, dies with ``Cannot read input: bad stream or EOF`` (exit 4) — the
+    # snapshot is then discarded and the product never installs. The
+    # non-transactional twins above already use ``zypper -n``.
+    ipdtcmd: str = "transactional-update -n pkg in -t product -l -f {products}"
+    rrpdtcmd: str = "transactional-update -n pkg rm -t product -l -f {products}"
     reboot: str = "systemctl reboot"
 
     # Runtime backend selection produces one of two concrete dict-like

--- a/tests/command/test_install.py
+++ b/tests/command/test_install.py
@@ -174,7 +174,12 @@ def test_install_on_transactional_host_uses_transactional_and_reboots(
     assert Install(args).run() == 0
 
     issued = [c.args[0] for c in target.run.call_args_list]
-    assert any("transactional-update pkg in" in cmd for cmd in issued)
+    assert any("transactional-update -n pkg in" in cmd for cmd in issued)
+    # -n is mandatory: it makes the inner zypper non-interactive, otherwise
+    # it hits "Continue? [y/n]" -> EOF -> exit 4 under a non-tty SSH exec.
+    assert not any("transactional-update pkg in" in cmd for cmd in issued), (
+        "transactional-update must be invoked with -n (non-interactive)"
+    )
     assert not any(cmd.startswith("zypper -n in") for cmd in issued)
     target.reboot.assert_called_once()
 
@@ -213,7 +218,7 @@ def test_install_transactional_no_reboot_stages_only(
 
     assert Install(args).run() == 0
     issued = [c.args[0] for c in target.run.call_args_list]
-    assert any("transactional-update pkg in" in cmd for cmd in issued)
+    assert any("transactional-update -n pkg in" in cmd for cmd in issued)
     target.reboot.assert_not_called()
 
 

--- a/tests/command/test_uninstall.py
+++ b/tests/command/test_uninstall.py
@@ -259,8 +259,12 @@ def test_uninstall_on_transactional_host_uses_transactional_and_reboots(
     issued = [c.args[0] for c in target.run.call_args_list]
     assert any(cmd.startswith("zypper -n rr") for cmd in issued)
     assert any(
-        "transactional-update pkg rm -t product" in cmd and "qa" in cmd
+        "transactional-update -n pkg rm -t product" in cmd and "qa" in cmd
         for cmd in issued
+    )
+    # -n is mandatory (non-interactive inner zypper); see the install tests.
+    assert not any("transactional-update pkg rm" in cmd for cmd in issued), (
+        "transactional-update must be invoked with -n (non-interactive)"
     )
     target.reboot.assert_called_once()
 


### PR DESCRIPTION
## Problem

The transactional product-install / -remove templates invoked
`transactional-update pkg in|rm ...` **without `-n`**:

```
ipdtcmd  = "transactional-update pkg in -t product -l -f {products}"
rrpdtcmd = "transactional-update pkg rm -t product -l -f {products}"
```

Without `-n`, transactional-update runs the inner `zypper` interactively.
Under an SSH exec (no tty) that dies at the confirmation prompt:

```
Continue? [y/n/v/...? shows all options] (y): Cannot read input: bad stream or EOF.
...
ERROR: zypper install on /.snapshots/NNN/snapshot failed with exit code 4!
Removing snapshot #NNN...
```

So `repose install`/`uninstall` of a product on a transactional host
(SL Micro / SLE Micro / MicroOS) always fails with exit 4 and the
snapshot is discarded — the product is never installed/removed. The
non-transactional twins already pass `zypper -n`.

## Fix

Add `-n` to both transactional templates so transactional-update
propagates `--non-interactive` to the inner zypper:

```
ipdtcmd  = "transactional-update -n pkg in -t product -l -f {products}"
rrpdtcmd = "transactional-update -n pkg rm -t product -l -f {products}"
```

Verified on a live SL-Micro host: `repose install qa:16.0` now installs
the product in a new snapshot, reboots, and verifies — where it
previously aborted with exit 4.

## Test

Updated the transactional install/uninstall tests to assert the `-n`
form is issued and the bare interactive form never is. Full suite green;
`ruff format`/`ruff check` clean.