### PR TITLE
fix: import repo keys into the snapshot before transactional install

### DIFF
--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -48,6 +48,16 @@ class Command(ABC):
     addcmd: str = "zypper -n ar {params} {name} {url} {name}"
     rrcmd: str = "zypper -n rr {repos}"
     refcmd: str = "zypper -n --gpg-auto-import-keys ref -f"
+    # Transactional refresh: import repo signing keys into the *snapshot*
+    # keyring before a transactional product install. On a transactional
+    # host the plain ``refcmd`` runs on the live system, where the rpmdb is
+    # read-only, so a freshly added repo's GPG key never lands where the
+    # ``transactional-update`` inner ``zypper -R <snapshot>`` looks for it —
+    # the inner zypper then rejects the repo's ``repomd.xml`` signature and
+    # the install aborts (exit 4). Running the auto-importing refresh through
+    # ``transactional-update run`` writes the key into a snapshot the
+    # subsequent ``pkg in`` builds upon.
+    reftcmd: str = "transactional-update -n run zypper -n --gpg-auto-import-keys ref -f"
     ipdcmd: str = "zypper -n in -t product -l -f {products}"
     rrpcmd: str = "zypper -n rm -t product {products}"
     ipdtcmd: str = "transactional-update pkg in -t product -l -f {products}"

--- a/repose/command/install.py
+++ b/repose/command/install.py
@@ -56,10 +56,17 @@ class Install(Command, name="install"):
                 inscmd = self.ipdcmd.format(products=" ".join(repositories.keys()))
             update(target, "installing products")
             if self.dryrun:
+                if transactional:
+                    self.console.dry(str(target), self.reftcmd)
                 self.console.dry(str(target), inscmd)
                 if transactional and not self.no_reboot:
                     self.console.dry(str(target), self.reboot)
             else:
+                # Import repo keys into the snapshot keyring first, else the
+                # inner zypper of the transactional install rejects the repo
+                # signature (see reftcmd).
+                if transactional:
+                    self.targets[target].run(self.reftcmd)
                 self.targets[target].run(inscmd)
                 if not self._report_target(target):
                     ok = False
@@ -117,10 +124,15 @@ class Install(Command, name="install"):
                 inscmd = self.ipdcmd.format(products=" ".join(repositories.keys()))
             update(target, "installing products")
             if self.dryrun:
+                if transactional:
+                    self.console.dry(str(target), self.reftcmd)
                 self.console.dry(str(target), inscmd)
                 if transactional and not self.no_reboot:
                     self.console.dry(str(target), self.reboot)
             else:
+                # Import repo keys into the snapshot keyring first (see reftcmd).
+                if transactional:
+                    await self.targets[target].run(self.reftcmd)
                 await self.targets[target].run(inscmd)
                 if not self._report_target(target):
                     ok = False

--- a/tests/command/test_install.py
+++ b/tests/command/test_install.py
@@ -179,6 +179,53 @@ def test_install_on_transactional_host_uses_transactional_and_reboots(
     target.reboot.assert_called_once()
 
 
+def test_install_transactional_imports_keys_before_install(
+    monkeypatch, mock_args_and_repa, mock_ssh_client
+):
+    """On a transactional host the repo signing keys must be imported into
+    the snapshot keyring (reftcmd) *before* the product install, otherwise
+    the inner zypper rejects the repo signature (exit 4)."""
+    args, _ = mock_args_and_repa
+
+    target, _, _ = _setup_install(
+        monkeypatch,
+        args,
+        {"qa": [MockRepo("repo1", "http://repo1.url", refresh=True)]},
+    )
+    _make_transactional(target, installed_after={"qa"})
+
+    assert Install(args).run() == 0
+
+    issued = [c.args[0] for c in target.run.call_args_list]
+    reftcmd = "transactional-update -n run zypper -n --gpg-auto-import-keys ref -f"
+    assert reftcmd in issued, "transactional key-import refresh must be issued"
+    install_idx = next(
+        i for i, c in enumerate(issued) if "transactional-update pkg in" in c
+    )
+    assert issued.index(reftcmd) < install_idx, (
+        "key-import refresh must run before the transactional install"
+    )
+
+
+def test_install_non_transactional_skips_key_import_refresh(
+    monkeypatch, mock_args_and_repa, mock_ssh_client
+):
+    """The transactional key-import refresh is only for transactional hosts."""
+    args, _ = mock_args_and_repa
+
+    target, _, _ = _setup_install(
+        monkeypatch,
+        args,
+        {"qa": [MockRepo("repo1", "http://repo1.url", refresh=True)]},
+    )
+    # default _setup_install leaves is_transactional() -> False
+
+    assert Install(args).run() == 0
+
+    issued = [c.args[0] for c in target.run.call_args_list]
+    assert not any("transactional-update run" in cmd for cmd in issued)
+
+
 def test_install_transactional_verify_fails_when_product_absent(
     monkeypatch, mock_args_and_repa, mock_ssh_client
 ):


### PR DESCRIPTION
## Problem

On a **transactional** host (SL Micro / MicroOS), `repose install <product>`
fails with `zypper` exit 4:

```
Retrieving repository 'qa:...' metadata [...
... Signature verification failed for repomd.xml
ERROR: zypper install on /.snapshots/NNN/snapshot failed with exit code 4!
```

`install` adds the repo and runs the live `zypper -n --gpg-auto-import-keys
ref -f` (`refcmd`). But on a transactional host the live **rpmdb is
read-only**, so a freshly added repo's signing key never lands in the
keyring that `transactional-update`'s inner `zypper -R <snapshot>` consults.
The inner zypper then rejects the repo's `repomd.xml` signature and the
product install aborts (snapshot discarded, nothing installed). A
non-transactional host is fine because the live refresh and the install
share one writable rpmdb.

## Fix

Before the transactional product install, import the repo keys through
`transactional-update run` so they land in a snapshot the subsequent
`pkg in` builds on:

```
reftcmd = "transactional-update -n run zypper -n --gpg-auto-import-keys ref -f"
```

It runs only on transactional hosts, immediately before `ipdtcmd`
(reflected in `--dry` output too). Verified on a live SL-Micro host: this
is exactly the step that unblocks `transactional-update pkg in`.

## Test

Regression tests assert the key-import refresh is issued **before** the
transactional install, and is **not** issued on non-transactional hosts.
Full suite green; `ruff` clean.

## Note

Complements the transactional product-install fixes (the `-n`
non-interactive fix); both are needed for `repose install <product>` to
fully work on a transactional host.