### PR TITLE
ci(codeql): modernize workflow and drop dead Autobuild step

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,72 +1,54 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
-
+---
+name: CodeQL
+# yamllint disable-line rule:truthy
 on:
   push:
-    branches: [ "master" ]
+    branches: [master]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [master]
   schedule:
     - cron: '24 5 * * 1'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
+      # required to upload results to the code-scanning dashboard
+      security-events: write
+      # only needed for private repos; harmless on public ones
       actions: read
       contents: read
-      security-events: write
 
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        # Python is interpreted, so no build step is needed; scan the
+        # source directly with build-mode "none".
+        include:
+          - language: python
+            build-mode: none
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6  # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
 
-        
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6  # v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

- Rewrite `codeql-analysis.yml` against **codeql-action v3** with
  `build-mode: none` (the current recommended path for interpreted
  languages) and drop the Autobuild step Python never needed.
- Bump `actions/checkout` v4 → v6; **SHA-pin** both actions.
- Add top-level least-privilege `permissions: contents: read`, a
  `concurrency` group that cancels superseded PR runs, a per-job
  `timeout-minutes`, and the `security-extended` query pack.
- Triggers (push/PR to `master` + weekly cron) unchanged.

## Why

The workflow was **auto-disabled for inactivity** — its last run was
**June 2025** — and still pinned `github/codeql-action@v2`, which GitHub
has sunset. So the repo has effectively had no static security scanning
for over a year, and even if re-enabled the v2 action would fail. This
brings it back to a supported, hardened baseline.

Companion PR adds a `github-actions` Dependabot ecosystem so the pins
here stay fresh and this can't silently rot again.

## Verification

- `python3 -c 'yaml.safe_load(...)'` parses clean.
- Action SHAs resolved from the live `v6`/`v3` tags at authoring time.

> **Note for maintainer:** merging this file should re-enable the
> inactivity-disabled workflow automatically. If it stays disabled,
> enable it once from the **Actions** tab (I don't have that access on
> this repo).

_AI-assisted._
