### PR TITLE
ci(dependabot): add uv and github-actions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+---
+# Dependabot configuration.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  # Python dependencies. The "uv" ecosystem updates both pyproject.toml
+  # and uv.lock, which is the resolved set the project actually installs
+  # from (uv is the documented dev/CI path); the "pip" ecosystem would
+  # leave uv.lock to drift stale.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by the workflows. Keeps the SHA-pinned actions in
+  # ci.yml / codeql-analysis.yml current so they cannot silently rot the
+  # way codeql-action@v2 did.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## What

Add `.github/dependabot.yml` with two ecosystems:

- **`uv`** — updates `pyproject.toml` **and** `uv.lock`. `uv` is the
  documented dev/CI path, so the lockfile is the set actually installed;
  the `pip` ecosystem tracks only the manifest and leaves `uv.lock`
  drifting stale.
- **`github-actions`** — keeps the SHA-pinned actions in the workflows
  current.

Both weekly, minor+patch grouped into a single PR, 5-PR cap.

## Why

The repo had **no `dependabot.yml` at all** — only ad-hoc security
alerts, no routine version updates. The `github-actions` entry directly
prevents a recurrence of the stale-and-disabled CodeQL situation (see
companion CodeQL PR): a `github-actions` update would have flagged the
sunset `codeql-action@v2` long ago.

## Verification

`yaml.safe_load` parses clean; schema follows the current Dependabot v2
docs (grouped `update-types`).

_AI-assisted._
