### PR TITLE
ci(release): publish GitHub releases from version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+---
+name: release
+# yamllint disable-line rule:truthy
+on:
+  push:
+    tags:
+      # Version tags: 2.0.2, 2.1.0, optionally with a pre-release suffix
+      # (2.1.0rc1). The project tags without a "v" prefix.
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # required for `gh release create`
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          python-version: '3.11'
+          cache-suffix: release
+
+      - name: Verify tag matches package version
+        run: |
+          pkg="$(sed -n 's/^__version__ = "\(.*\)"/\1/p' repose/__init__.py)"
+          if [ "$pkg" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::tag '$GITHUB_REF_NAME' != repose.__version__ '$pkg'"
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "$GITHUB_REF_NAME"
+          --title "$GITHUB_REF_NAME"
+          --generate-notes
+          dist/*


### PR DESCRIPTION
## What

Add `.github/workflows/release.yml`, triggered on version tags
(`[0-9]+.[0-9]+.[0-9]+`, no `v` prefix, optional pre-release suffix):

1. **Guard** the tag against `repose.__version__` and fail on mismatch
   (catches a mistagged push before anything is published).
2. **Build** the sdist and wheel with `uv build`.
3. **Publish** a GitHub release with `--generate-notes` and the
   artifacts attached.

Least privilege: top-level `contents: read`, `contents: write` only on
the release job.

## Why

The latest **GitHub release is 1.11.2**, but tags run up to **2.0.2** —
the 2.0.x versions were tagged and never published, so the Releases page
shows a stale "latest". This closes that gap going forward.

Not wired to PyPI: the project ships via the openSUSE rpm, isn't on
PyPI, and has no trusted-publisher configured — that can be added later
if desired.

## Verification

- `release.yml` parses clean.
- Version guard locally: `sed` extracts `2.0.2` from `repose/__init__.py`.
- `uv build` produces `repose-2.0.2.tar.gz` and
  `repose-2.0.2-py3-none-any.whl`.

_AI-assisted._
