### PR TITLE
chore(test): drop unused unit and slow pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,7 @@ addopts = [
   "--cov-report=term-missing",
 ]
 markers = [
-  "unit: pure-logic unit tests (default, fast)",
   "integration: tests exercising multiple modules together",
-  "slow: tests that take noticeable time",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## What

Remove the `unit` and `slow` markers from `[tool.pytest.ini_options]`.
Keep `integration`.

## Why

Both were declared under `--strict-markers` but **never applied to any
test** (grep confirms: only `integration` is used, once, in
`tests/test_aiossh.py`). They were dead config implying a fast/slow
split the suite doesn't actually have.

## Verification

- `pytest -m integration` → 1 passed, 518 deselected (marker still
  resolves).
- Full run: 519 passed under `--strict-markers`.

_AI-assisted._
