### PR TITLE
fix(aiossh): make accept-new host-key verification actually work

### DIFF
--- a/repose/aiossh.py
+++ b/repose/aiossh.py
@@ -98,25 +98,56 @@ def _default_known_hosts_path() -> Path:
 
 
 def _build_known_hosts_arg(policy: str, known_hosts: Path | None) -> Any:
-    """Translate ConnectionConfig host-key knobs into asyncssh ``known_hosts``.
+    """Translate ConnectionConfig host-key knobs to asyncssh's
+    ``known_hosts`` argument.
 
-    - ``yes``        → use the configured file (or default
+    - ``yes``        → the configured file (or asyncssh's default
       ``~/.ssh/known_hosts``); asyncssh refuses unknown hosts and
       mismatches natively.
-    - ``accept-new`` → return ``None`` so asyncssh's native checker
-      stays out of the way; validation runs in a custom ``SSHClient``
-      subclass installed via ``client_factory=`` (see
-      :func:`_make_accept_new_client`). Same end behaviour as OpenSSH's
-      ``StrictHostKeyChecking=accept-new``: unknown hosts are accepted
-      and persisted; changed keys are rejected.
+    - ``accept-new`` → the configured file (or ``~/.ssh/known_hosts``)
+      when it exists, so asyncssh does the native matching, host-key
+      algorithm negotiation, revocation and certificate validation; the
+      custom ``_AcceptNewClient`` (see :func:`_make_accept_new_client`)
+      only decides first-contact vs changed-key. An unparseable line
+      makes asyncssh reject the whole file -- unlike OpenSSH we do not
+      skip bad lines. When the file does not exist an empty *but truthy*
+      trust set keeps the validator engaged with every host as first
+      contact.
     - ``no``/``off`` → ``None``: asyncssh disables host-key validation
-      entirely. Matches the historical pre-PR-12 behaviour.
+      entirely (no ``client_factory`` is installed for these policies).
+      Matches the historical pre-PR-12 behaviour.
     """
-    if policy in ("no", "off", "accept-new"):
+    if policy == "accept-new":
+        resolved = known_hosts or _default_known_hosts_path()
+        return str(resolved) if resolved.exists() else ([], [], [])
+    if policy in ("no", "off"):
         return None
     if known_hosts is None:
         return ()  # asyncssh default: ``~/.ssh/known_hosts``
     return str(known_hosts)
+
+
+_DEFAULT_SSH_PORT = 22
+
+
+def _append_known_host(path: Path, host: str, port: int, key: bytes) -> None:
+    """Append a first-contact host key, keeping ``path`` newline-safe.
+
+    An existing known_hosts file whose final line lacks a trailing
+    newline would otherwise have its last entry merged with the new one,
+    corrupting both. Non-default ports are written in OpenSSH's
+    ``[host]:port`` form so the entry matches on the next connect.
+    """
+    entry_host = host if port == _DEFAULT_SSH_PORT else f"[{host}]:{port}"
+    needs_newline = False
+    if path.exists() and path.stat().st_size > 0:
+        with open(path, "rb") as fh:
+            fh.seek(-1, os.SEEK_END)
+            needs_newline = fh.read(1) != b"\n"
+    with open(path, "a", encoding="utf-8") as fh:
+        if needs_newline:
+            fh.write("\n")
+        fh.write(f"{entry_host} {key.decode().strip()}\n")
 
 
 def _make_accept_new_client(
@@ -124,41 +155,57 @@ def _make_accept_new_client(
 ) -> type[asyncssh.SSHClient]:
     """Return an ``SSHClient`` subclass enforcing ``accept-new`` semantics.
 
-    The returned class is what gets passed to
-    ``asyncssh.connect(client_factory=...)``; asyncssh instantiates it
-    for the new connection and consults
-    :meth:`SSHClient.validate_host_public_key` for every offered host
-    key.
+    asyncssh does the native known_hosts matching (see
+    :func:`_build_known_hosts_arg`) and only calls
+    :meth:`validate_host_public_key` for a key it does not already
+    trust. This client then implements the accept-new decision:
 
-    Read the known_hosts file once at factory time. Subsequent
-    validation:
+    - if the key is revoked for this host, refuse it;
+    - if the host has pins (under its resolved name or the configured
+      alias) but the offered key matches none, refuse it as a changed
+      key;
+    - if the offered key matches a pin stored under the alias -- which
+      asyncssh, matching only the resolved name, would have missed --
+      accept it;
+    - otherwise this is first contact: accept and persist the key.
 
-    - accepts a key whose bytes match a pinned entry for this host,
-    - rejects a key when entries exist for this host but none match
-      (the canonical changed-key scenario),
-    - accepts and persists when no entry exists for this host (first
-      contact).
+    The known_hosts file is read once at factory time (via asyncssh's
+    own parser) for that first-contact-vs-changed decision; asyncssh
+    reads the same file for its native matching.
 
-    The match is done via asyncssh's public ``SSHKnownHosts.match``
-    API, which already handles host-pattern matching, hashed entries,
-    and revoked-key flags correctly.
+    Host *certificates* are accepted on first contact under the same
+    trust-on-first-use rule (see :meth:`validate_host_ca_key`), but
+    asyncssh still enforces the certificate's own validity (principals,
+    expiry): an expired or wrong-principal host cert is refused. Pinning
+    a certificate against a specific CA is out of scope.
     """
-    trusted_pubkeys: list[bytes] = []
-    if known_hosts_path.exists():
-        try:
-            khosts = asyncssh.read_known_hosts(str(known_hosts_path))
-            # ``match(host, addr, port)`` returns a 7-tuple; the first
-            # element is the trusted-keys list for this host. Address
-            # and port are not significant for accept-new (we trust by
-            # host pattern), so feed dummies — asyncssh accepts them.
-            trusted, _ca, _revoked, *_ = khosts.match(expected_host, "0.0.0.0", 22)
-            trusted_pubkeys = [k.export_public_key() for k in trusted]
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "accept-new: could not read %s: %s",
-                known_hosts_path,
-                exc,
-            )
+    known_hosts = (
+        asyncssh.read_known_hosts(str(known_hosts_path))
+        if known_hosts_path.exists()
+        else None
+    )
+    persisted: set[bytes] = set()
+
+    def _pins(host: str, addr: str, port: int) -> tuple[set[bytes], set[bytes]]:
+        """Trusted and revoked key blobs for ``host`` and the alias.
+
+        Known limitation: asyncssh's ``SSHKnownHosts.match`` drops the
+        revoked list when a port-qualified lookup finds no trusted key,
+        so a key revoked via a ``@revoked [host]:port`` entry is not
+        detected (this also defeats asyncssh's own native ``yes``
+        validation, not just accept-new). Plain ``@revoked host``
+        entries are honoured.
+        """
+        trusted: set[bytes] = set()
+        revoked: set[bytes] = set()
+        if known_hosts is not None:
+            # A pin may be stored under the resolved name or the
+            # configured alias; consult both so an alias pin is honoured.
+            for name in {host, expected_host}:
+                matched = known_hosts.match(name, addr, port)
+                trusted |= {k.public_data for k in matched[0]}
+                revoked |= {k.public_data for k in matched[2]}
+        return trusted, revoked
 
     class _AcceptNewClient(asyncssh.SSHClient):
         def validate_host_public_key(
@@ -168,34 +215,69 @@ def _make_accept_new_client(
             port: int,
             key: asyncssh.SSHKey,
         ) -> bool:
-            offered = key.export_public_key()
-            if trusted_pubkeys:
-                # Some key already pinned for this host. accept-new
-                # only accepts a *matching* one; a mismatch is the
-                # canonical changed-key scenario.
-                if offered in trusted_pubkeys:
-                    return True
+            offered = key.public_data
+            trusted, revoked = _pins(host, addr, port)
+            if offered in revoked:
+                # A key explicitly revoked for this host is never
+                # accepted, even when no positive pin remains.
+                logger.error(
+                    "accept-new: host key for %s is revoked; refusing",
+                    expected_host,
+                )
+                return False
+            if offered in trusted:
+                # Matches a pin -- possibly one stored under the
+                # configured alias that asyncssh did not match on.
+                return True
+            if trusted:
+                # Host is known but the offered key is not one of its
+                # pins: the canonical changed-key scenario.
                 logger.error(
                     "accept-new: host key for %s changed; refusing",
                     expected_host,
                 )
                 return False
-            # First contact for this host: accept and persist.
-            try:
-                with open(known_hosts_path, "a") as fh:
-                    fh.write(f"{expected_host} {offered.decode().strip()}\n")
-                logger.info(
-                    "accept-new: persisted host key for %s to %s",
-                    expected_host,
-                    known_hosts_path,
-                )
-            except OSError as werr:
-                logger.warning(
-                    "accept-new: could not persist host key for %s to %s: %s",
-                    expected_host,
-                    known_hosts_path,
-                    werr,
-                )
+            # First contact: accept and persist once. The password-auth
+            # fallback re-runs this validator with the same factory, so
+            # guard against writing a duplicate entry.
+            blob = key.export_public_key()
+            if blob not in persisted:
+                try:
+                    _append_known_host(known_hosts_path, host, port, blob)
+                    persisted.add(blob)
+                    logger.info(
+                        "accept-new: persisted host key for %s to %s",
+                        expected_host,
+                        known_hosts_path,
+                    )
+                except OSError as werr:
+                    logger.warning(
+                        "accept-new: could not persist host key for %s to %s: %s",
+                        expected_host,
+                        known_hosts_path,
+                        werr,
+                    )
+            return True
+
+        def validate_host_ca_key(
+            self,
+            host: str,
+            addr: str,
+            port: int,
+            key: asyncssh.SSHKey,
+        ) -> bool:
+            # accept-new is trust-on-first-use: accept a host certificate
+            # the same way an unknown host key is accepted on first
+            # contact. Passing a non-None (empty) known_hosts engages
+            # asyncssh's CA check, whose default would reject every cert
+            # host outright -- a connectivity regression versus leaving
+            # host-key validation off. Certificate *pinning* / change
+            # detection is out of scope (repose targets plain host-key
+            # refhosts); this only restores reachability.
+            logger.info(
+                "accept-new: trusting host certificate for %s (first-contact)",
+                expected_host,
+            )
             return True
 
     return _AcceptNewClient
@@ -321,11 +403,14 @@ class AsyncConnection:
             )
             return
         except asyncssh.HostKeyNotVerifiable:
-            # accept-new and no/off never reach here (they disable the
-            # native checker). Only ``yes`` produces this; bubble up
-            # like paramiko's ``BadHostKeyException``/``RejectPolicy``.
+            # ``yes`` reaches here for an unknown or mismatched key;
+            # ``accept-new`` reaches here when its validator rejects a
+            # *changed* key (``validate_host_public_key`` returned
+            # False). ``no``/``off`` disable the native checker and never
+            # reach here. Bubble up like paramiko's
+            # ``BadHostKeyException``/``RejectPolicy``.
             logger.error(
-                "host key for %s not in known_hosts (policy=%s)",
+                "host key verification failed for %s (policy=%s)",
                 self.hostname,
                 policy,
             )

--- a/tests/test_aiossh.py
+++ b/tests/test_aiossh.py
@@ -91,10 +91,9 @@ def test_explicit_positional_timeout_wins_over_config():
         ("no", None),
         ("off", None),
         ("yes", ()),  # asyncssh default = ~/.ssh/known_hosts
-        # ``accept-new`` disables asyncssh's native checker — the
-        # _AcceptNewClient subclass is the sole arbiter. See
-        # _build_known_hosts_arg for why ``None`` is passed here.
-        ("accept-new", None),
+        # accept-new is file-dependent (the real path when the file is
+        # present, else the empty trust set), so it is covered by the
+        # dedicated tests below rather than this static table.
     ],
 )
 async def test_known_hosts_arg_translation(
@@ -113,6 +112,61 @@ async def test_known_hosts_arg_translation(
     await c.connect()
 
     assert captured["known_hosts"] == expected_known_hosts
+
+
+async def test_accept_new_engages_validator(monkeypatch, fake_conn, tmp_path):
+    """Regression: with no known_hosts file yet, ``accept-new`` still
+    engages the validator instead of disabling checking.
+
+    asyncssh calls ``SSHClient.validate_host_public_key`` only when
+    ``_trusted_host_keys`` is non-None, and substitutes the system
+    ``~/.ssh/known_hosts`` for any *falsy* value (so ``b""``/``None``
+    would bypass the validator). With the file absent the arg is the
+    truthy empty trust set, so every offered key defers to
+    ``_AcceptNewClient``.
+    """
+    kh = tmp_path / "known_hosts"  # not created: missing-file case
+    cfg = ConnectionConfig(host_key_policy="accept-new", known_hosts=kh)
+    captured: dict[str, Any] = {}
+
+    async def fake_connect(**kwargs):
+        captured.update(kwargs)
+        return fake_conn
+
+    monkeypatch.setattr(asyncssh, "connect", fake_connect)
+
+    c = AsyncConnection("h", "u", 22, config=cfg)
+    await c.connect()
+
+    kh_arg = captured["known_hosts"]
+    assert kh_arg  # truthy: asyncssh will not load system known_hosts
+    trusted, _ca, _revoked, *_ = asyncssh.match_known_hosts(kh_arg, "h", "0.0.0.0", 22)
+    assert list(trusted) == []  # empty trust -> validator sees every key
+    assert issubclass(captured["client_factory"], asyncssh.SSHClient)
+
+
+async def test_accept_new_existing_file_passed_to_asyncssh(
+    monkeypatch, fake_conn, tmp_path
+):
+    """When known_hosts exists, asyncssh receives the file path so it
+    does the native matching / algorithm negotiation."""
+    kh = tmp_path / "known_hosts"
+    key = asyncssh.generate_private_key("ssh-ed25519")
+    kh.write_text(f"h {key.export_public_key().decode().strip()}\n")
+    cfg = ConnectionConfig(host_key_policy="accept-new", known_hosts=kh)
+    captured: dict[str, Any] = {}
+
+    async def fake_connect(**kwargs):
+        captured.update(kwargs)
+        return fake_conn
+
+    monkeypatch.setattr(asyncssh, "connect", fake_connect)
+
+    c = AsyncConnection("h", "u", 22, config=cfg)
+    await c.connect()
+
+    assert captured["known_hosts"] == str(kh)  # asyncssh reads it natively
+    assert issubclass(captured["client_factory"], asyncssh.SSHClient)
 
 
 async def test_known_hosts_path_threaded_through(monkeypatch, fake_conn, tmp_path):
@@ -204,9 +258,9 @@ async def test_oserror_propagates(monkeypatch):
 async def test_accept_new_installs_client_factory(monkeypatch, fake_conn, tmp_path):
     """``accept-new`` wires a custom ``SSHClient`` via ``client_factory=``.
 
-    Validation lives in that subclass; asyncssh's native checker is
-    explicitly disabled (``known_hosts=None``) so the subclass is the
-    only arbiter.
+    Validation lives in that subclass: asyncssh does the native matching
+    and defers any not-already-trusted key to the subclass, which is the
+    effective arbiter for accept-new.
     """
     kh = tmp_path / "known_hosts"
     kh.write_text("")
@@ -223,7 +277,7 @@ async def test_accept_new_installs_client_factory(monkeypatch, fake_conn, tmp_pa
     c = AsyncConnection("h", "u", 22, config=cfg)
     await c.connect()
 
-    assert captured["known_hosts"] is None
+    assert captured["known_hosts"]  # truthy: no system-file substitution
     assert "client_factory" in captured
     assert issubclass(captured["client_factory"], asyncssh.SSHClient)
 
@@ -275,6 +329,188 @@ async def test_accept_new_client_rejects_changed_key(tmp_path):
     # The same pinned key is still accepted.
     accepted = client.validate_host_public_key(
         host="h", addr="127.0.0.1", port=22, key=pinned_key
+    )
+    assert accepted is True
+
+
+async def test_accept_new_persist_preserves_trailing_newline(tmp_path):
+    """A known_hosts file without a trailing newline must not have its
+    last entry merged with the newly persisted one."""
+    from repose.aiossh import _make_accept_new_client
+
+    kh = tmp_path / "known_hosts"
+    # Existing entry for a *different* host, no trailing newline.
+    other = asyncssh.generate_private_key("ssh-ed25519")
+    other_line = f"other {other.export_public_key().decode().strip()}"
+    kh.write_bytes(other_line.encode())
+
+    key = asyncssh.generate_private_key("ssh-rsa")
+    factory = _make_accept_new_client(kh, expected_host="h")
+    accepted = factory().validate_host_public_key(
+        host="h", addr="127.0.0.1", port=22, key=key
+    )
+    assert accepted is True
+
+    lines = kh.read_text().splitlines()
+    assert len(lines) == 2  # not merged into one corrupt line
+    assert lines[0] == other_line
+    assert lines[1].startswith("h ")
+
+
+async def test_accept_new_no_duplicate_on_factory_reuse(tmp_path):
+    """The password-auth fallback re-runs the validator with the same
+    factory; a first-contact key must be persisted only once."""
+    from repose.aiossh import _make_accept_new_client
+
+    kh = tmp_path / "known_hosts"
+    kh.write_text("")
+    key = asyncssh.generate_private_key("ssh-rsa")
+
+    factory = _make_accept_new_client(kh, expected_host="h")
+    # Two instances from the same factory mirror the key-auth attempt
+    # followed by the password fallback (same client_factory reused).
+    for _ in range(2):
+        accepted = factory().validate_host_public_key(
+            host="h", addr="127.0.0.1", port=22, key=key
+        )
+        assert accepted is True
+
+    host_lines = [ln for ln in kh.read_text().splitlines() if ln.startswith("h ")]
+    assert len(host_lines) == 1  # no duplicate entry
+
+
+async def test_accept_new_matches_pin_with_trailing_comment(tmp_path):
+    """A pinned entry carrying a trailing comment still matches the
+    comment-less key the server offers (key equality ignores comments)."""
+    from repose.aiossh import _make_accept_new_client
+
+    kh = tmp_path / "known_hosts"
+    key = asyncssh.generate_private_key("ssh-rsa")
+    pub = key.export_public_key().decode().strip()
+    kh.write_text(f"h {pub} admin@ops\n")
+
+    factory = _make_accept_new_client(kh, expected_host="h")
+    accepted = factory().validate_host_public_key(
+        host="h", addr="127.0.0.1", port=22, key=key
+    )
+    assert accepted is True
+
+
+async def test_accept_new_honours_non_default_port_pin(tmp_path):
+    """A host pinned as ``[host]:port`` is matched on that port, so a
+    changed key is rejected instead of being taken as first contact."""
+    from repose.aiossh import _make_accept_new_client
+
+    kh = tmp_path / "known_hosts"
+    pinned = asyncssh.generate_private_key("ssh-rsa")
+    pinned_pub = pinned.export_public_key().decode().strip()
+    kh.write_text(f"[h]:2222 {pinned_pub}\n")
+
+    factory = _make_accept_new_client(kh, expected_host="h")
+    client = factory()
+
+    other = asyncssh.generate_private_key("ssh-rsa")
+    changed = client.validate_host_public_key(
+        host="h", addr="127.0.0.1", port=2222, key=other
+    )
+    assert changed is False  # changed key on the pinned port → reject
+
+    same = client.validate_host_public_key(
+        host="h", addr="127.0.0.1", port=2222, key=pinned
+    )
+    assert same is True
+
+
+async def test_accept_new_persists_non_default_port_in_bracket_form(tmp_path):
+    """First contact on a non-default port persists an ``[host]:port``
+    entry so it matches on the next connect."""
+    from repose.aiossh import _make_accept_new_client
+
+    kh = tmp_path / "known_hosts"
+    kh.write_text("")
+    key = asyncssh.generate_private_key("ssh-rsa")
+
+    factory = _make_accept_new_client(kh, expected_host="h")
+    accepted = factory().validate_host_public_key(
+        host="h", addr="127.0.0.1", port=2222, key=key
+    )
+    assert accepted is True
+    assert kh.read_text().startswith("[h]:2222 ")
+
+
+async def test_accept_new_rejects_revoked_key(tmp_path):
+    """A key explicitly revoked in known_hosts is refused, not taken as
+    first contact and re-persisted."""
+    from repose.aiossh import _make_accept_new_client
+
+    kh = tmp_path / "known_hosts"
+    revoked = asyncssh.generate_private_key("ssh-rsa")
+    revoked_pub = revoked.export_public_key().decode().strip()
+    kh.write_text(f"@revoked h {revoked_pub}\n")
+    before = kh.read_text()
+
+    factory = _make_accept_new_client(kh, expected_host="h")
+    accepted = factory().validate_host_public_key(
+        host="h", addr="127.0.0.1", port=22, key=revoked
+    )
+    assert accepted is False
+    assert kh.read_text() == before  # revoked key not persisted back
+
+
+async def test_accept_new_matches_pin_under_configured_alias(tmp_path):
+    """A key pinned under the configured alias is accepted even when
+    asyncssh resolves and reports a different HostName; a changed key for
+    that aliased host is still refused rather than taken as first
+    contact."""
+    from repose.aiossh import _make_accept_new_client
+
+    kh = tmp_path / "known_hosts"
+    key = asyncssh.generate_private_key("ssh-rsa")
+    pub = key.export_public_key().decode().strip()
+    kh.write_text(f"rh1 {pub}\n")  # pinned under the alias
+
+    # expected_host is the alias; asyncssh calls back with the resolved
+    # HostName, which is not what the pin is stored under.
+    factory = _make_accept_new_client(kh, expected_host="rh1")
+    client = factory()
+
+    accepted = client.validate_host_public_key(
+        host="10.0.0.5", addr="10.0.0.5", port=22, key=key
+    )
+    assert accepted is True
+
+    other = asyncssh.generate_private_key("ssh-rsa")
+    changed = client.validate_host_public_key(
+        host="10.0.0.5", addr="10.0.0.5", port=22, key=other
+    )
+    assert changed is False
+
+
+async def test_accept_new_malformed_known_hosts_raises(tmp_path):
+    """We use asyncssh's native parser and deliberately do NOT skip bad
+    lines the way OpenSSH does: a malformed known_hosts surfaces as an
+    error instead of being silently ignored."""
+    from repose.aiossh import _make_accept_new_client
+
+    kh = tmp_path / "known_hosts"
+    kh.write_text("@badmarker garbage line\n")
+
+    with pytest.raises(ValueError):
+        _make_accept_new_client(kh, expected_host="h")
+
+
+async def test_accept_new_accepts_host_certificate_first_contact(tmp_path):
+    """accept-new trusts a host certificate on first contact (TOFU), so
+    the CA-key hook accepts rather than hard-rejecting cert hosts."""
+    from repose.aiossh import _make_accept_new_client
+
+    kh = tmp_path / "known_hosts"
+    kh.write_text("")
+    ca = asyncssh.generate_private_key("ssh-rsa")
+
+    factory = _make_accept_new_client(kh, expected_host="h")
+    accepted = factory().validate_host_ca_key(
+        host="h", addr="127.0.0.1", port=22, key=ca
     )
     assert accepted is True
 


### PR DESCRIPTION
## What

The `accept-new` host-key policy passed `known_hosts=None` to asyncssh,
which sets `_trusted_host_keys=None` and makes asyncssh **skip
`validate_host_public_key` entirely**. The custom `_AcceptNewClient`
validator was therefore dead code and **every offered host key was
accepted** — a MITM hole on the default policy.

Hand asyncssh the real known_hosts **file** (when it exists) so its
native parser does the matching, host-key-algorithm negotiation,
revocation and certificate validation. The custom client is consulted
only for a key asyncssh does not already trust, where it:

- refuses a revoked key;
- refuses a changed key when the host is already pinned — checked under
  both the resolved name and the configured `~/.ssh/config` alias, so an
  alias-stored pin is not silently treated as first contact;
- otherwise accepts and persists on first contact (newline-safe,
  `[host]:port` form for non-default ports, dedup'd across the
  password-auth fallback).

When no known_hosts file exists yet, a truthy empty trust set keeps the
validator engaged with every host as first contact.

Host certificates are accepted on first contact (asyncssh still enforces
their principal/expiry validity); certificate pinning is out of scope.

## Deliberate non-goals / known limitation

- A malformed known_hosts line is left to asyncssh's native parser,
  which rejects the whole file rather than skipping the bad line — we do
  **not** replicate OpenSSH's line-skipping tolerance.
- A key revoked via a **non-default-port** entry (`@revoked [host]:port`)
  is not detected: asyncssh's `SSHKnownHosts.match` drops the revoked
  list on a port-qualified lookup that finds no trusted key. This is an
  upstream asyncssh matcher quirk that defeats asyncssh's own native
  `yes` validation too, not just accept-new. Plain `@revoked host`
  entries are honoured. Documented in a code comment.

## Verification

Full local gate: ruff format/check clean, `ty check repose` clean,
**529 passed**, coverage 82%. New aiossh tests cover missing-file vs
existing-file arg, alias matching, revoked, changed-key, comment-in-pin,
non-default-port persistence, malformed-file error, newline and dedup —
all hermetic via `tmp_path`.

_AI-assisted._