### PR TITLE
fix(command): treat every non-zero zypper exit as a failure

### DIFF
--- a/repose/command/_command.py
+++ b/repose/command/_command.py
@@ -22,6 +22,18 @@ from ..utils import check_repo_url, check_repo_url_async
 
 logger = logging.getLogger("repose.command")
 
+# zypper exit codes that still mean the operation completed. Beyond 0,
+# these are the informational codes where zypper did the work and only
+# reports a follow-up condition: patches available (100/101), a reboot
+# (102) or package-manager restart (103) required after a *successful*
+# install, some repositories skipped on refresh (106), or a post-install
+# %post script that failed after the transaction already committed (107).
+# See zypper(8) EXIT CODES. Every other non-zero code -- the 1-8 error
+# range (incl. 4 ERR_ZYPP and 6 NO_REPOS), plus 104 (capability not
+# found) and 105 (interrupted) -- is a genuine failure.
+ZYPPER_EXIT_OK = 0
+ZYPPER_SUCCESS_EXIT_CODES = frozenset({0, 100, 101, 102, 103, 106, 107})
+
 # Per-host progress updater signature. ``_run_parallel`` binds
 # ``Progress.update`` and passes it as the second positional argument
 # to every worker ``_run(host, update, *extra)``. Defined here so the
@@ -172,24 +184,37 @@ class Command(ABC):
     def _report_target(self, target: str) -> bool:
         """Report the last command's output for ``target`` via Console.
 
-        Returns ``True`` for zypper exit 0 (success) and exit 4
-        (no repositories — benign, surfaced at ``level="warning"`` for
-        parity with prior behaviour). Any other exit code is treated as
-        failure and the call returns ``False`` so the caller can
-        propagate the per-host status into ``_aggregate``.
+        Returns ``True`` for zypper exit 0 and the informational success
+        codes in :data:`ZYPPER_SUCCESS_EXIT_CODES` -- e.g. 102 ("reboot
+        needed") / 103 ("restart needed") after a *successful* install,
+        which repose otherwise handles out of band. Every other non-zero
+        exit -- the 1-8 error range (including 4 ``ERR_ZYPP`` and 6
+        ``NO_REPOS``), plus 104 (capability not found) and 105
+        (interrupted) -- is a failure: the call returns ``False`` so the
+        caller propagates the per-host failure into ``_aggregate`` rather
+        than masking it as success.
         """
-        exitcode = self.targets[target].out[-1][3]
-        if exitcode == 0:
-            for line in self.targets[target].out[-1][1].splitlines():
+        out = self.targets[target].out[-1]
+        exitcode = out[3]
+        if exitcode == ZYPPER_EXIT_OK:
+            for line in out[1].splitlines():
                 self.console.report(target, line, ok=True, level="info")
             return True
-        if exitcode == 4:
-            # zypper: "no repositories defined" — benign in our flow.
-            for line in self.targets[target].out[-1][1].splitlines():
-                self.console.report(target, line, ok=True, level="warning")
+        if exitcode in ZYPPER_SUCCESS_EXIT_CODES:
+            # The work completed but a non-zero code carries a follow-up
+            # note (e.g. 106 "repository skipped", 107 "%post failed")
+            # that zypper may write to *either* stream, so surface both
+            # at warning level rather than dropping the explanation.
+            for stream in (out[1], out[2]):
+                for line in stream.splitlines():
+                    self.console.report(target, line, ok=True, level="warning")
             return True
-        for line in self.targets[target].out[-1][2].splitlines():
-            self.console.report(target, line, ok=False, level="error")
+        # Surface whatever zypper emitted, on either stream: some
+        # diagnostics (e.g. "repository already exists") go to stdout, so
+        # reporting stderr alone would leave a non-zero exit unexplained.
+        for stream in (out[1], out[2]):
+            for line in stream.splitlines():
+                self.console.report(target, line, ok=False, level="error")
         return False
 
     def _check_products(self, host: str, products: list[str], present: bool) -> bool:

--- a/tests/command/test_command_base.py
+++ b/tests/command/test_command_base.py
@@ -172,19 +172,28 @@ def test_unconnected_targets_are_dropped(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "exitcode,expected_stream,expected_ok",
+    "exitcode,expected_ok",
     [
-        (0, "stdout", True),  # logger.info on stdout, success
-        (4, "stdout", True),  # logger.warning on stdout, benign success
-        (1, "stderr", False),  # logger.warning on stderr, failure
-        (-1, "stderr", False),
+        (0, True),  # ZYPPER_EXIT_OK
+        (100, True),  # patches available
+        (101, True),  # security patches available
+        (102, True),  # reboot needed after a successful install
+        (103, True),  # package-manager restart needed
+        (106, True),  # some repos skipped on refresh
+        (107, True),  # %post failed but transaction committed
+        (1, False),  # ERR_BUG
+        (4, False),  # ERR_ZYPP
+        (5, False),  # ERR_PRIVILEGES
+        (6, False),  # NO_REPOS
+        (8, False),  # ERR_COMMIT
+        (104, False),  # capability not found
+        (105, False),  # interrupted by signal
+        (-1, False),  # Target.run timeout/exception sentinel
     ],
 )
-def test_report_target_routes_by_exitcode(
-    monkeypatch, exitcode, expected_stream, expected_ok
-):
-    """_report_target picks the right output stream depending on exitcode
-    and returns ``True`` for success/benign exits, ``False`` for failures."""
+def test_report_target_routes_by_exitcode(monkeypatch, exitcode, expected_ok):
+    """_report_target returns ``True`` for exit 0 and the informational
+    success codes, ``False`` for every error code."""
     target = MagicMock()
     # out is list of [cmd, stdout, stderr, exitcode, runtime]
     target.out = [["cmd", "out-line", "err-line", exitcode, 0]]


### PR DESCRIPTION
## What

`_report_target` special-cased a single benign exit code — and the code
it excused was **4** (`ZYPPER_EXIT_ERR_ZYPP`, a real libzypp error), not
a success code — so genuine failures during add/install/remove/reset
were reported as **success**.

Classify against zypper's **documented** exit codes instead
(`zypper(8)` EXIT CODES / upstream `src/main.h`):

| Codes | Meaning | Result |
|-------|---------|--------|
| **0** | clean run | success (info) |
| **100 / 101** | patches / security patches available | success (warning) |
| **102 / 103** | install **succeeded** — reboot / restart needed | success (warning) |
| **106** | some repos skipped on refresh | success (warning) |
| **107** | committed, but a `%post` script failed | success (warning) |
| **1–8** (incl. 4 `ERR_ZYPP`, 6 `NO_REPOS`), **104, 105**, `-1` timeout | error / not satisfied | **failure** → propagates into `_aggregate` |

## Why this classification

`ZYPPER_SUCCESS_EXIT_CODES = {0, 100, 101, 102, 103, 106, 107}`. The key
nuance: `zypper in -t product` returns **102 ("reboot needed")** or
**103 ("restart needed")** *after a successful install* — so treating
every non-zero code as failure (a naïve fix) would wrongly fail a
working maintenance update. Conversely 4 and 6 are genuine errors and
must not be masked. Informational codes are reported at **warning** with
their note (both streams, since e.g. 106's "repository skipped" message
may go to stderr); exit 0 stays at **info**. The failure path prints
both stdout and stderr, since some diagnostics (e.g. "already exists")
go to stdout.

## Verification

Full local gate green (**530 passed**, coverage 82%; ruff + `ty` clean).
Parametrised test asserts `0/100/101/102/103/106/107 → success` and
`1/4/5/6/8/104/105/-1 → failure`. Three `/code-review` rounds; the last
caught (and this fixes) a dropped-stderr-note case for the info codes.

_AI-assisted._
