### PR TITLE
fix(reset): abort on partial live-URL probe drop to avoid data loss

### DIFF
--- a/repose/command/reset.py
+++ b/repose/command/reset.py
@@ -11,22 +11,38 @@ logger = logging.getLogger("repose.command.reset")
 
 
 class Reset(Clear, name="reset"):
-    def _add(self, target):
+    def _add(self, target) -> tuple[set[str], list[str]]:
+        """Resolve replacement repos for ``target`` into ``zypper ar`` cmds.
+
+        Returns ``(cmds, dropped)`` where ``dropped`` is the list of
+        resolved-candidate repo names whose live-URL probe failed. A
+        non-empty ``dropped`` means the probe removed a proper subset of
+        the candidates; the caller must treat that as a failure rather
+        than silently re-adding only the survivors, which would
+        permanently lose the dropped repos on the destructive ``rr``.
+        """
         cmds = set()
-        repolist = chain.from_iterable(
-            x for x in self.repoq.solve_product(self.targets[target].products).values()
+        repolist = list(
+            chain.from_iterable(
+                x
+                for x in self.repoq.solve_product(
+                    self.targets[target].products
+                ).values()
+            )
         )
         # Probe all candidate URLs in parallel before issuing any
         # ``zypper ar``; otherwise each per-host worker would serialise
         # 1-2 probes per repository.
         live = self._filter_live_urls(repolist)
+        live_ids = {id(r) for r in live}
+        dropped = [r.name for r in repolist if id(r) not in live_ids]
         cmds.update(
             self.addcmd.format(
                 name=x.name, url=x.url, params="-cfkn" if x.refresh else "-ckn"
             )
             for x in live
         )
-        return cmds
+        return cmds, dropped
 
     def _run(self, host: str, update: UpdateFn) -> bool:
         update(host, "clearing repos")
@@ -34,14 +50,11 @@ class Reset(Clear, name="reset"):
         ok = True
         try:
             update(host, "resolving new repos")
-            cmds = self._add(host)
+            cmds, dropped = self._add(host)
 
-            if self.dryrun:
-                self.console.dry(host, self.rrcmd.format(repos=" ".join(repoaliases)))
-                for cmd in cmds:
-                    self.console.dry(host, cmd)
-                return True
-
+            # Guards run BEFORE the dry-run preview so ``--dry`` predicts
+            # the real abort instead of showing a destructive plan that
+            # never executes.
             if not cmds:
                 logger.error(
                     "Refhost %s - no live replacement repositories "
@@ -50,6 +63,24 @@ class Reset(Clear, name="reset"):
                     host,
                 )
                 return False
+
+            if dropped:
+                logger.error(
+                    "Refhost %s - live-URL probe dropped %d of the "
+                    "resolved replacement repositories (%s); aborting "
+                    "reset to avoid permanently losing repositories over "
+                    "a transient mirror failure",
+                    host,
+                    len(dropped),
+                    ", ".join(sorted(dropped)),
+                )
+                return False
+
+            if self.dryrun:
+                self.console.dry(host, self.rrcmd.format(repos=" ".join(repoaliases)))
+                for cmd in cmds:
+                    self.console.dry(host, cmd)
+                return True
 
             update(host, f"re-adding {len(cmds)} repo(s)")
             self.targets[host].run(self.rrcmd.format(repos=" ".join(repoaliases)))
@@ -64,13 +95,25 @@ class Reset(Clear, name="reset"):
             ok = False
         return ok
 
-    async def _aadd(self, target) -> set[str]:
-        """Async sibling of ``_add`` — uses async URL probing."""
+    async def _aadd(self, target) -> tuple[set[str], list[str]]:
+        """Async sibling of ``_add`` — uses async URL probing.
+
+        Returns ``(cmds, dropped)`` with the same contract as ``_add``:
+        ``dropped`` names the resolved candidates whose live-URL probe
+        failed so the caller can refuse a partial reset.
+        """
         cmds: set[str] = set()
-        repolist = chain.from_iterable(
-            x for x in self.repoq.solve_product(self.targets[target].products).values()
+        repolist = list(
+            chain.from_iterable(
+                x
+                for x in self.repoq.solve_product(
+                    self.targets[target].products
+                ).values()
+            )
         )
         live = await self._afilter_live_urls(repolist)
+        live_ids = {id(r) for r in live}
+        dropped = [r.name for r in repolist if id(r) not in live_ids]
         cmds.update(
             self.addcmd.format(
                 name=x.name,
@@ -79,7 +122,7 @@ class Reset(Clear, name="reset"):
             )
             for x in live
         )
-        return cmds
+        return cmds, dropped
 
     async def _arun_one(self, host: str, update: UpdateFn) -> bool:
         update(host, "clearing repos")
@@ -87,14 +130,11 @@ class Reset(Clear, name="reset"):
         ok = True
         try:
             update(host, "resolving new repos")
-            cmds = await self._aadd(host)
+            cmds, dropped = await self._aadd(host)
 
-            if self.dryrun:
-                self.console.dry(host, self.rrcmd.format(repos=" ".join(repoaliases)))
-                for cmd in cmds:
-                    self.console.dry(host, cmd)
-                return True
-
+            # Guards run BEFORE the dry-run preview so ``--dry`` predicts
+            # the real abort instead of showing a destructive plan that
+            # never executes.
             if not cmds:
                 logger.error(
                     "Refhost %s - no live replacement repositories "
@@ -103,6 +143,24 @@ class Reset(Clear, name="reset"):
                     host,
                 )
                 return False
+
+            if dropped:
+                logger.error(
+                    "Refhost %s - live-URL probe dropped %d of the "
+                    "resolved replacement repositories (%s); aborting "
+                    "reset to avoid permanently losing repositories over "
+                    "a transient mirror failure",
+                    host,
+                    len(dropped),
+                    ", ".join(sorted(dropped)),
+                )
+                return False
+
+            if self.dryrun:
+                self.console.dry(host, self.rrcmd.format(repos=" ".join(repoaliases)))
+                for cmd in cmds:
+                    self.console.dry(host, cmd)
+                return True
 
             update(host, f"re-adding {len(cmds)} repo(s)")
             await self.targets[host].run(self.rrcmd.format(repos=" ".join(repoaliases)))

--- a/tests/command/test_reset.py
+++ b/tests/command/test_reset.py
@@ -302,7 +302,7 @@ async def test_arun_one_aborts_when_no_live_replacement(mock_args, caplog):
 
     reset.targets = {"user@host1": target}
     # Empty replacement set == every probe failed.
-    reset._aadd = AsyncMock(return_value=set())
+    reset._aadd = AsyncMock(return_value=(set(), ["r1"]))
 
     with caplog.at_level("ERROR", logger="repose.command.reset"):
         ok = await reset._arun_one("user@host1", lambda host, msg: None)
@@ -310,3 +310,95 @@ async def test_arun_one_aborts_when_no_live_replacement(mock_args, caplog):
     assert ok is False
     target.run.assert_not_awaited()
     assert any("Refhost" in r.message for r in caplog.records)
+
+
+def test_reset_partial_probe_drop_aborts_without_removal(
+    monkeypatch, mock_args, caplog, mock_ssh_client
+):
+    """A partial probe failure must not silently lose repos.
+
+    When the live-URL probe drops a proper subset of the resolved
+    replacement repositories the destructive ``rr`` must NOT run and
+    the host is reported failed — otherwise the dropped repos are
+    permanently gone after a transient mirror blip while the survivors
+    are re-added and the host is still reported as success.
+    """
+    target, _, _ = _setup_reset(
+        monkeypatch,
+        mock_args,
+        repoq_solution={
+            "product": [
+                MockRepo("good", "http://good", refresh=False),
+                MockRepo("bad", "http://bad", refresh=False),
+            ]
+        },
+    )
+    # One mirror is alive, the other fails the probe → partial drop.
+    monkeypatch.setattr(
+        repose.command._command,
+        "check_repo_url",
+        lambda url, *, timeout: url != "http://bad",
+    )
+
+    with caplog.at_level("ERROR", logger="repose.command.reset"):
+        # Single host aborted before removal → all-fail → exit 2.
+        assert Reset(mock_args).run() == 2
+
+    # Neither the destructive rr nor any ar ran.
+    target.run.assert_not_called()
+    assert any("bad" in r.getMessage() for r in caplog.records)
+
+
+def test_reset_dryrun_predicts_partial_drop_abort(
+    monkeypatch, mock_args, caplog, mock_ssh_client
+):
+    """``--dry`` must predict the real abort on a partial drop, not show
+    a destructive plan that never executes."""
+    mock_args.dry = True
+    target, _, _ = _setup_reset(
+        monkeypatch,
+        mock_args,
+        repoq_solution={
+            "product": [
+                MockRepo("good", "http://good", refresh=False),
+                MockRepo("bad", "http://bad", refresh=False),
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        repose.command._command,
+        "check_repo_url",
+        lambda url, *, timeout: url != "http://bad",
+    )
+
+    with caplog.at_level("ERROR", logger="repose.command.reset"):
+        # Dry-run aborts (exit 2), matching the real run.
+        assert Reset(mock_args).run() == 2
+    target.run.assert_not_called()
+    assert any("bad" in r.getMessage() for r in caplog.records)
+
+
+async def test_arun_one_aborts_on_partial_probe_drop(mock_args, caplog):
+    """Async ``_arun_one`` must mirror the sync partial-drop guard.
+
+    With a survivor *and* a dropped candidate it must not run the
+    destructive ``rr`` and must report the host as failed.
+    """
+    mock_args.ssh_backend = "asyncssh"
+    reset = Reset(mock_args)
+
+    target = MagicMock()
+    target.raw_repos = [MockRawRepo("existing-repo1")]
+    target.out = _ok_out()
+    target.run = AsyncMock()
+
+    reset.targets = {"user@host1": target}
+    # One survivor command, one candidate dropped by the probe.
+    reset._aadd = AsyncMock(return_value=({"ar good"}, ["bad"]))
+
+    with caplog.at_level("ERROR", logger="repose.command.reset"):
+        ok = await reset._arun_one("user@host1", lambda host, msg: None)
+
+    assert ok is False
+    target.run.assert_not_awaited()
+    assert any("bad" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## What

The `reset` empty-replacement guard (from the earlier data-loss fix)
only covered the case where the live-URL probe drops **every**
candidate. When it drops a **proper subset** — a transient outage on one
mirror — reset still ran `zypper rr <all old aliases>` and re-added only
the survivors, so the transiently-failed repos were **permanently lost**
while the host was reported as success.

Now `_add`/`_aadd` return `(cmds, dropped)`, and both the sync `_run` and
async `_arun_one` **abort without running `rr`** (report failure, log the
dropped repos) when `dropped` is non-empty. The guards run **before** the
`--dry` preview, so a dry run predicts the real abort rather than showing
a destructive plan that never executes.

Behaviour is unchanged when all candidates survive the probe or under
`--no-probe`.

## Verification

Full gate green (533 passed, ~82%). Regression tests: sync + async
partial-drop abort, plus a `--dry` partial-drop test. Two `/code-review`
rounds; the second caught the dry-run divergence, fixed here.

_AI-assisted._