### PR TITLE
fix(install): preserve earlier failure across reboot/verify

### DIFF
--- a/repose/command/install.py
+++ b/repose/command/install.py
@@ -71,7 +71,8 @@ class Install(Command, name="install"):
                 if not self._report_target(target):
                     ok = False
                 elif transactional:
-                    ok = self._reboot_and_verify(target, list(repositories.keys()))
+                    if not self._reboot_and_verify(target, list(repositories.keys())):
+                        ok = False
         else:
             logger.error("No products to install")
             ok = False
@@ -137,9 +138,10 @@ class Install(Command, name="install"):
                 if not self._report_target(target):
                     ok = False
                 elif transactional:
-                    ok = await self._areboot_and_verify(
+                    if not await self._areboot_and_verify(
                         target, list(repositories.keys())
-                    )
+                    ):
+                        ok = False
         else:
             logger.error("No products to install")
             ok = False

--- a/tests/command/test_install.py
+++ b/tests/command/test_install.py
@@ -249,6 +249,38 @@ def test_install_transactional_verify_fails_when_product_absent(
     target.reboot.assert_called_once()
 
 
+def test_install_transactional_preserves_earlier_failure(
+    monkeypatch, mock_args_and_repa, mock_ssh_client
+):
+    """A passing reboot/verify must not mask an earlier failure.
+
+    When one repa fails to resolve (``solve_repa`` raises) but another
+    resolves, the product install and a passing reboot/verify must not
+    clobber the accumulated ``ok=False`` — the host still fails.
+    """
+    args, repa_instance = mock_args_and_repa
+    other_repa = Repa("other-repa")
+    args.repa = [repa_instance, other_repa]
+
+    target, _, repoq = _setup_install(
+        monkeypatch,
+        args,
+        {"qa": [MockRepo("repo1", "http://repo1.url", refresh=True)]},
+    )
+    # First repa fails to resolve, second resolves to a product so the
+    # transactional install branch is still reached.
+    repoq.solve_repa.side_effect = [
+        ValueError("Unknow product: X"),
+        {"qa": [MockRepo("repo1", "http://repo1.url", refresh=True)]},
+    ]
+    _make_transactional(target, installed_after={"qa"})
+    # Reboot/verify passes — it must not reset the earlier failure.
+    monkeypatch.setattr(Install, "_reboot_and_verify", lambda self, *a, **k: True)
+
+    # Single host, earlier failure preserved → all hosts failed → exit 2.
+    assert Install(args).run() == 2
+
+
 def test_install_transactional_no_reboot_stages_only(
     monkeypatch, mock_args_and_repa, mock_ssh_client
 ):


### PR DESCRIPTION
## What

In the transactional install branch, both sync `_run` and async
`_arun_one` did `ok = self._reboot_and_verify(...)`, **overwriting** the
accumulated per-host status. An earlier failure — a REPA that fails to
resolve (`solve_repa` `ValueError`) or a failed repo-add — sets
`ok=False`, but a passing reboot/verify then reset it to `True`, so the
host was reported as a **successful** install (exit 0) while the failure
was silently discarded and CI saw a false green.

Fixed both paths with the same idiom `uninstall.py` already uses:
`if not self._reboot_and_verify(...): ok = False`, so a prior `False` is
never clobbered.

## Verification

Full gate green. Regression test drives two REPAs (first raises
`ValueError`, second resolves) into a transactional host with a passing
`_reboot_and_verify` stub and asserts the host still fails (exit 2) —
fails on the pre-fix code, passes with the fix. `/code-review` clean.

_AI-assisted._