### PR TITLE
fix(remove): match specific repo aliases exactly

### DIFF
--- a/repose/command/remove.py
+++ b/repose/command/remove.py
@@ -37,10 +37,21 @@ class Remove(Command, name="remove"):
         return patterns
 
     def _calculate_repolist(self, host: str, patterns: set[str]) -> set[str]:
+        """Map REPA patterns to concrete repo aliases on ``host``.
+
+        A pattern ending in ``::`` carries no repo component, i.e. the
+        operator asked to remove *all* repos for a given
+        ``product:version``; such patterns match by prefix. A pattern
+        naming a specific repo alias must match that alias exactly, so
+        that removing ``repo1`` never also deletes ``repo10`` or
+        ``repo1-debuginfo``.
+        """
         repolist: set[str] = set()
         for pattern in patterns:
+            all_repos = pattern.endswith("::")
             for repo in self.targets[host].repos.keys():
-                if pattern in repo:
+                matched = pattern in repo if all_repos else repo == pattern
+                if matched:
                     repolist.add(repo)
         return repolist
 

--- a/tests/command/test_remove.py
+++ b/tests/command/test_remove.py
@@ -171,6 +171,69 @@ def test_remove_command_empty_repolist_does_not_run_rrcmd(
     assert any("no repos for remove" in r.message for r in caplog.records)
 
 
+def test_remove_command_specific_repo_matches_exact_alias_only(
+    monkeypatch, mock_ssh_client
+):
+    """A specific repo alias must match exactly.
+
+    Removing ``repo1`` must not also delete ``repo10`` or
+    ``repo1-debuginfo`` just because their aliases share a prefix.
+    """
+    args = Namespace(
+        dry=False,
+        target=[{"user@host1": MagicMock()}],
+        repa=[Repa("SLES:15-SP4::repo1")],
+        config="dummy",
+        yaml=False,
+    )
+    target, _ = _build_remove_env(
+        monkeypatch,
+        args,
+        [MockProduct("SLES", "15-SP4")],
+        [
+            "SLES:15-SP4::repo1",
+            "SLES:15-SP4::repo10",
+            "SLES:15-SP4::repo1-debuginfo",
+        ],
+    )
+
+    remove_command = Remove(args)
+    assert remove_command.run() == 0
+
+    expected_cmd = remove_command.rrcmd.format(repos="SLES:15-SP4::repo1")
+    target.run.assert_called_once_with(expected_cmd)
+
+
+def test_remove_command_empty_repo_removes_all_for_product(
+    monkeypatch, mock_ssh_client
+):
+    """An empty repo component removes every repo for the product."""
+    args = Namespace(
+        dry=False,
+        target=[{"user@host1": MagicMock()}],
+        repa=[Repa("SLES:15-SP4")],
+        config="dummy",
+        yaml=False,
+    )
+    target, _ = _build_remove_env(
+        monkeypatch,
+        args,
+        [MockProduct("SLES", "15-SP4")],
+        [
+            "SLES:15-SP4::repo1",
+            "SLES:15-SP4::repo10",
+        ],
+    )
+
+    remove_command = Remove(args)
+    assert remove_command.run() == 0
+
+    target.run.assert_called_once()
+    (called_cmd,), _ = target.run.call_args
+    assert "SLES:15-SP4::repo1" in called_cmd
+    assert "SLES:15-SP4::repo10" in called_cmd
+
+
 def test_remove_command_version_mismatch_skipped(monkeypatch, caplog, mock_ssh_client):
     """If version is specified but doesn't match, the product is skipped."""
     args = Namespace(


### PR DESCRIPTION
## What

`_calculate_repolist` selected repos to delete with **substring
containment** (`if pattern in repo`), where `pattern` is
`{product}:{version}::{repo}`. So removing `SLES:15-SP4::repo1` also
matched `SLES:15-SP4::repo10` and `SLES:15-SP4::repo1-debuginfo` and
passed them to `zypper rr` — **deleting repositories the operator never
named**.

Now: when a specific repo is named, the match requires **exact** alias
equality (`repo == pattern`); the "remove all repos for this
product:version" case (pattern ending in `::`) keeps prefix matching.

## Verification

Full gate green. Regression tests: with `repo1`, `repo10`,
`repo1-debuginfo` all present, removing `repo1` deletes **only** `repo1`
(fails on the pre-fix code); the all-repos case still removes every repo
for the product. `/code-review` clean.

_AI-assisted._