### PR TITLE
fix(connection): bound session/channel reconnect retry loops

### DIFF
--- a/repose/connection.py
+++ b/repose/connection.py
@@ -21,6 +21,16 @@ if not sys.warnoptions:
 
 logger = logging.getLogger("repose.connection")
 
+# Bound the session/channel-creation retry loops. A transport can stay
+# "active" while persistently refusing to hand out new sessions/channels
+# (server MaxSessions reached, half-broken transport). Without a cap the
+# retry loops spin with no sleep and pin a CPU forever, so limit the
+# attempts, back off between them, and recycle the transport before
+# giving up.
+_RECONNECT_MAX_ATTEMPTS = 10
+_RECONNECT_FORCE_AFTER = 3
+_RECONNECT_BACKOFF = 1.0
+
 
 class CommandTimeout(Exception):
     """remote command timeout exception
@@ -279,6 +289,47 @@ class Connection:
                 )
         return self.is_active()
 
+    def _recover_transport(self, attempt: int) -> None:
+        """Back off and reconnect between failed session/channel opens.
+
+        Mirrors :meth:`wait_reconnect`'s bounded pattern for the
+        session/channel-creation loops: a short backoff avoids pinning a
+        CPU, and once ``attempt`` reaches ``_RECONNECT_FORCE_AFTER`` the
+        transport is torn down even if it still reports active. This
+        recycles a degraded-but-active transport (e.g. one that keeps
+        refusing new sessions) instead of spinning on it, since plain
+        :meth:`reconnect` is a no-op while ``is_active()`` is True.
+
+        A failing reconnect is logged and swallowed — again mirroring
+        :meth:`wait_reconnect` — so a transient connect error consumes
+        one attempt of the caller's budget instead of escaping past the
+        ``_RECONNECT_MAX_ATTEMPTS`` cap.
+
+        Args:
+            attempt: 1-based index of the failed attempt just completed.
+        """
+        select.select([], [], [], _RECONNECT_BACKOFF)
+        if attempt >= _RECONNECT_FORCE_AFTER and self.is_active():
+            logger.debug(
+                "forcing transport teardown on %s:%s after %d failed "
+                "session/channel opens",
+                self.hostname,
+                self.port,
+                attempt,
+            )
+            self.close()
+        try:
+            self.reconnect()
+        except Exception:
+            logger.debug(
+                "reconnect attempt %d/%d to %s:%s failed",
+                attempt,
+                _RECONNECT_MAX_ATTEMPTS,
+                self.hostname,
+                self.port,
+                exc_info=True,
+            )
+
     def new_session(self) -> Channel | None:
         logger.debug("Creating new session at %s:%s", self.hostname, self.port)
         session: Channel | None = None
@@ -334,7 +385,7 @@ class Connection:
         """run command over SSH channel
 
         Blocks until command terminates. returncode of issued command is returned.
-        In case of errors, -1 is returned.
+        In case of command-level errors, -1 is returned.
 
         If the connection hits the timeout limit, the user is asked to wait or
         cancel the current command.
@@ -342,6 +393,11 @@ class Connection:
         Keyword arguments:
         command -- the command to run
         lock    -- lock object for write on stdout
+
+        Raises:
+            paramiko.SSHException: if no session can be opened after
+                ``_RECONNECT_MAX_ATTEMPTS`` attempts (including forced
+                transport teardowns and failed reconnects).
         """
 
         stdout = b""
@@ -349,8 +405,15 @@ class Connection:
 
         session = self.__run_command(command)
 
+        attempt = 0
         while not session:
-            self.reconnect()
+            attempt += 1
+            if attempt > _RECONNECT_MAX_ATTEMPTS:
+                raise paramiko.SSHException(
+                    f"Unable to open a session on {self.hostname}:"
+                    f"{self.port} after {_RECONNECT_MAX_ATTEMPTS} attempts"
+                )
+            self._recover_transport(attempt)
             session = self.__run_command(command)
 
         while True:
@@ -426,8 +489,15 @@ class Connection:
 
     def __sftp_reconnect(self) -> SFTPClient:
         sftp = self.__sftp_open()
+        attempt = 0
         while not sftp:
-            self.reconnect()
+            attempt += 1
+            if attempt > _RECONNECT_MAX_ATTEMPTS:
+                raise paramiko.SSHException(
+                    f"Unable to open an SFTP channel on {self.hostname}:"
+                    f"{self.port} after {_RECONNECT_MAX_ATTEMPTS} attempts"
+                )
+            self._recover_transport(attempt)
             sftp = self.__sftp_open()
         return sftp
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -5,7 +5,13 @@ from unittest.mock import MagicMock
 import paramiko
 import pytest
 
-from repose.connection import CommandTimeout, Connection
+import repose.connection
+from repose.connection import (
+    _RECONNECT_FORCE_AFTER,
+    _RECONNECT_MAX_ATTEMPTS,
+    CommandTimeout,
+    Connection,
+)
 from repose.connection_policy import AcceptNewPolicy
 from repose.types.connection_config import ConnectionConfig
 
@@ -303,3 +309,139 @@ def test_wait_reconnect_gives_up_after_retry_budget(mock_ssh_client):
     assert ok is False
     # count increments after entering, so retry=N yields N+1 attempts.
     assert mock_ssh_client.connect.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Bounded reconnect loops: a transport that stays active but keeps
+# refusing new sessions/channels must fail loudly after a capped number
+# of attempts instead of spinning forever (concurrency hazard).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _no_backoff(monkeypatch):
+    """Neutralise the reconnect backoff so the bounded loops run fast.
+
+    The stub reports the channel as readable so that, when a session does
+    open, ``run``'s read loop skips its interactive timeout prompt.
+    """
+    monkeypatch.setattr(
+        repose.connection.select, "select", lambda *a, **k: (["ready"], [], [])
+    )
+
+
+def _active_transport(mock_ssh_client):
+    """Wire the mock so ``is_active()`` reports a live transport."""
+    transport = MagicMock()
+    transport.is_active.return_value = True
+    mock_ssh_client._transport = transport
+    mock_ssh_client.get_transport.return_value = transport
+    return transport
+
+
+def test_run_raises_after_attempt_cap_on_active_transport(mock_ssh_client, _no_backoff):
+    """``run`` must not spin forever when the transport stays active but
+    ``open_session`` keeps failing; it raises after the attempt cap."""
+    transport = _active_transport(mock_ssh_client)
+
+    calls = {"n": 0}
+
+    def _open_session(*args, **kwargs):
+        calls["n"] += 1
+        # Guard against the pre-fix unbounded loop turning this test
+        # into a hang: surface a distinct failure well past the cap.
+        if calls["n"] > _RECONNECT_MAX_ATTEMPTS + 50:
+            raise AssertionError("run() looped past the attempt cap")
+        raise paramiko.SSHException("no session")
+
+    transport.open_session.side_effect = _open_session
+
+    conn = Connection("h", "u", 22)
+    with pytest.raises(paramiko.SSHException):
+        conn.run("true")
+
+    # One initial attempt plus one per bounded retry, then it raises.
+    assert calls["n"] == _RECONNECT_MAX_ATTEMPTS + 1
+
+
+def test_sftp_reconnect_raises_after_attempt_cap_on_active_transport(
+    mock_ssh_client, _no_backoff
+):
+    """``__sftp_reconnect`` (via ``listdir``) must also bound its retries
+    when the SFTP channel open keeps failing on an active transport."""
+    _active_transport(mock_ssh_client)
+
+    calls = {"n": 0}
+
+    def _open_sftp(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] > _RECONNECT_MAX_ATTEMPTS + 50:
+            raise AssertionError("__sftp_reconnect looped past the cap")
+        raise paramiko.SSHException("no channel")
+
+    mock_ssh_client.open_sftp.side_effect = _open_sftp
+
+    conn = Connection("h", "u", 22)
+    with pytest.raises(paramiko.SSHException):
+        conn.listdir("/etc")
+
+    assert calls["n"] == _RECONNECT_MAX_ATTEMPTS + 1
+
+
+def test_run_recovers_after_forced_transport_teardown(mock_ssh_client, _no_backoff):
+    """A degraded-but-active transport is recycled at the force threshold:
+    ``close()`` tears it down, ``connect()`` brings up a fresh transport,
+    and ``run`` then completes normally."""
+    broken = _active_transport(mock_ssh_client)
+    broken.open_session.side_effect = paramiko.SSHException("no session")
+
+    good_session = MagicMock()
+    good_session.recv_ready.return_value = False
+    good_session.recv_stderr_ready.return_value = False
+    good_session.recv_exit_status.return_value = 0
+
+    def _teardown(*args, **kwargs):
+        # A real close() leaves no live transport behind.
+        mock_ssh_client._transport = None
+
+    def _fresh_transport(*args, **kwargs):
+        # A real connect() installs a new, working transport.
+        fresh = MagicMock()
+        fresh.is_active.return_value = True
+        fresh.open_session.return_value = good_session
+        mock_ssh_client._transport = fresh
+        mock_ssh_client.get_transport.return_value = fresh
+
+    mock_ssh_client.close.side_effect = _teardown
+    mock_ssh_client.connect.side_effect = _fresh_transport
+
+    conn = Connection("h", "u", 22)
+    assert conn.run("true") == ("", "", 0)
+
+    # The broken transport was retried up to the force threshold, then
+    # recycled: close() tore it down and connect() replaced it.
+    assert broken.open_session.call_count == _RECONNECT_FORCE_AFTER
+    assert mock_ssh_client.close.called
+    assert mock_ssh_client.connect.called
+
+
+def test_run_reconnect_failures_consume_budget_then_raise(mock_ssh_client, _no_backoff):
+    """When reconnect() keeps failing after the forced teardown, the loop
+    must consume the remaining attempt budget and raise the cap-exhausted
+    ``SSHException`` — not leak the raw connect error."""
+    broken = _active_transport(mock_ssh_client)
+    broken.open_session.side_effect = paramiko.SSHException("no session")
+
+    def _teardown(*args, **kwargs):
+        mock_ssh_client._transport = None
+
+    mock_ssh_client.close.side_effect = _teardown
+    mock_ssh_client.connect.side_effect = RuntimeError("network down")
+
+    conn = Connection("h", "u", 22)
+    with pytest.raises(paramiko.SSHException, match="Unable to open a session"):
+        conn.run("true")
+
+    # Every attempt from the forced teardown onwards tries to reconnect.
+    expected_connects = _RECONNECT_MAX_ATTEMPTS - _RECONNECT_FORCE_AFTER + 1
+    assert mock_ssh_client.connect.call_count == expected_connects


### PR DESCRIPTION
## What

`run()` and `__sftp_reconnect()` retried session/channel creation in
unbounded `while` loops whose only recovery action, `reconnect()`, is a
no-op while the transport still reports active. A transport that stays
active but keeps refusing new sessions/channels (server `MaxSessions`
reached, half-broken transport) made both loops spin forever with no
sleep and no attempt cap, pinning a CPU.

Both loops are now bounded: `_RECONNECT_MAX_ATTEMPTS` (10) attempts with
a 1s backoff, mirroring `wait_reconnect`; once attempts reach
`_RECONNECT_FORCE_AFTER` (3) the transport is forcibly torn down and
reconnected even while `is_active()` is true, so a degraded-but-active
transport gets recycled. A reconnect that fails on the teardown path is
logged and consumes one attempt of the same budget (wait_reconnect's
idiom) instead of escaping as a raw connect error. When the budget is
exhausted, `paramiko.SSHException` is raised; `run()`'s docstring
documents the new raise.

Note: this is one of four independent single-concern fixes touching
nearby regions of `repose/connection.py` in this batch (bounded
reconnect loops, channel close on abort, prompt serialization,
accept-new persistence). They can merge in any order; later ones may
need a trivial rebase, which I'll provide.

## Verification

Full gate green (ruff format/check, ty, pytest: 551 passed, coverage
83.92%). The recycle mechanism is mutation-verified: deleting the
force-teardown block, or unwrapping the reconnect try/except, fails the
new tests. Tests pin (a) recovery success — teardown at the force
threshold followed by a working reconnect lets `run()` complete and
asserts `connect()` was called, (b) budget consumption when reconnect
keeps failing ends in the cap-exhausted `SSHException`, not a raw
connect error, and (c) cap exhaustion on both the session and SFTP
loops. Reviewed by a fan-out adversarial code review; all confirmed
findings addressed.

_AI-assisted._
