### PR TITLE
fix(connection): close channel when a timed-out command is aborted

### DIFF
--- a/repose/connection.py
+++ b/repose/connection.py
@@ -416,64 +416,69 @@ class Connection:
             self._recover_transport(attempt)
             session = self.__run_command(command)
 
-        while True:
-            buf = b""
+        try:
+            while True:
+                buf = b""
 
-            # wait for data to be transmitted. if the timeout is hit,
-            # ask the user on how to procceed
-            if select.select([session], [], [], self.timeout) == ([], [], []):
-                if session is None:
-                    raise RuntimeError(
-                        "Session is unexpectedly None during timeout handling"
-                    )
+                # wait for data to be transmitted. if the timeout is hit,
+                # ask the user on how to procceed
+                if select.select([session], [], [], self.timeout) == ([], [], []):
+                    if session is None:
+                        raise RuntimeError(
+                            "Session is unexpectedly None during timeout handling"
+                        )
 
-                # writing on stdout needs locking as all run threads could
-                # write at the same time to stdout
-                if lock:
-                    lock.acquire()
+                    # writing on stdout needs locking as all run threads could
+                    # write at the same time to stdout
+                    if lock:
+                        lock.acquire()
+
+                    try:
+                        if input(
+                            'command "%s" timed out on %s. wait? (y/N) '
+                            % (command, self.hostname)
+                        ).lower() in ["y", "yes"]:
+                            continue
+                        else:
+                            # if the user don't want to wait, raise
+                            # CommandTimeout and procceed
+                            raise CommandTimeout
+                    finally:
+                        # release lock to allow other command threads to write
+                        # to stdout
+                        if lock:
+                            lock.release()
 
                 try:
-                    if input(
-                        'command "%s" timed out on %s. wait? (y/N) '
-                        % (command, self.hostname)
-                    ).lower() in ["y", "yes"]:
-                        continue
-                    else:
-                        # if the user don't want to wait, raise CommandTimeout
-                        # and procceed
-                        raise CommandTimeout
-                finally:
-                    # release lock to allow other command threads to write to
-                    # stdout
-                    if lock:
-                        lock.release()
+                    # wait for data on the session's stdout/stderr. if debug is
+                    # enabled, print the received data
+                    if session.recv_ready():
+                        buf = session.recv(1024)
+                        stdout += buf
+                        for line in buf.decode("utf-8", "ignore").split("\n"):
+                            if line:
+                                logger.debug(line)
 
-            try:
-                # wait for data on the session's stdout/stderr. if debug is enabled,
-                # print the received data
-                if session.recv_ready():
-                    buf = session.recv(1024)
-                    stdout += buf
-                    for line in buf.decode("utf-8", "ignore").split("\n"):
-                        if line:
-                            logger.debug(line)
+                    if session.recv_stderr_ready():
+                        buf = session.recv_stderr(1024)
+                        stderr += buf
+                        for line in buf.decode("utf-8", "ignore").split("\n"):
+                            if line:
+                                logger.debug(line)
 
-                if session.recv_stderr_ready():
-                    buf = session.recv_stderr(1024)
-                    stderr += buf
-                    for line in buf.decode("utf-8", "ignore").split("\n"):
-                        if line:
-                            logger.debug(line)
+                    if not buf:
+                        break
 
-                if not buf:
-                    break
+                except socket.timeout:
+                    select.select([], [], [], 1)
 
-            except socket.timeout:
-                select.select([], [], [], 1)
-
-        # save the exitcode of the last command and return it
-        exitcode = session.recv_exit_status()
-        self.close_session(session)
+            # save the exitcode of the last command and return it
+            exitcode = session.recv_exit_status()
+        finally:
+            # always release the channel, including on the timeout-abort path
+            # where CommandTimeout is raised, so the session is not leaked on
+            # the shared transport
+            self.close_session(session)
 
         return (stdout.decode(), stderr.decode(), exitcode)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -445,3 +445,35 @@ def test_run_reconnect_failures_consume_budget_then_raise(mock_ssh_client, _no_b
     # Every attempt from the forced teardown onwards tries to reconnect.
     expected_connects = _RECONNECT_MAX_ATTEMPTS - _RECONNECT_FORCE_AFTER + 1
     assert mock_ssh_client.connect.call_count == expected_connects
+
+
+# ---------------------------------------------------------------------------
+# Command-timeout handling: aborting a timed-out command must not leak the
+# channel on the shared transport.
+# ---------------------------------------------------------------------------
+
+
+def test_run_closes_session_when_timeout_aborted(mock_ssh_client, monkeypatch):
+    """Declining the wait prompt on a command timeout still closes the channel.
+
+    ``run`` raises ``CommandTimeout`` when the user declines to keep waiting.
+    The channel must be torn down on that path, otherwise sessions accumulate
+    on the shared transport until ``MaxSessions`` is hit.
+    """
+    session = mock_ssh_client.get_transport.return_value.open_session.return_value
+
+    # Force select() to report a timeout (no data ready), triggering the
+    # interactive wait prompt.
+    monkeypatch.setattr("repose.connection.select.select", lambda *a, **k: ([], [], []))
+    # The user declines to keep waiting → run() raises CommandTimeout.
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "n")
+
+    conn = Connection("h", "u", 22)
+    conn.connect()
+
+    with pytest.raises(CommandTimeout):
+        conn.run("sleep 999")
+
+    # close_session() shuts down and closes the channel on the abort path.
+    session.shutdown.assert_called_once_with(2)
+    session.close.assert_called_once()


### PR DESCRIPTION
## What

When a command timed out and the operator declined the wait prompt,
`run()` raised `CommandTimeout` from inside a `try/finally` that only
released the print lock — the sole `close_session(session)` call after
the read loop was unreachable on that path, so the paramiko `Channel`
stayed open (and the remote command kept running) on the shared
transport. Repeated aborts accumulated sessions until the server's
`MaxSessions` limit, breaking subsequent commands.

The read loop plus `recv_exit_status` are now wrapped in a
`try/finally` that always runs `close_session`, including on the abort
path. The normal-completion path is unchanged.

Note: this is one of four independent single-concern fixes touching
nearby regions of `repose/connection.py` in this batch (bounded
reconnect loops, channel close on abort, prompt serialization,
accept-new persistence). They can merge in any order; later ones may
need a trivial rebase, which I'll provide.

## Verification

Full gate green (ruff format/check, ty, pytest: 548 passed, coverage
83.08%). Regression test drives a timed-out command through the abort
path and asserts the session is closed — it fails on the pre-fix code.
Reviewed by a fan-out adversarial code review; no in-scope findings
survived verification. (The asyncssh backend has an analogous leak on
its hard-timeout path — pre-existing in an untouched file, tracked
separately.)

_AI-assisted._
