### PR TITLE
fix(connection): persist accept-new host keys to known_hosts

### DIFF
--- a/repose/connection.py
+++ b/repose/connection.py
@@ -120,20 +120,24 @@ class Connection:
         # paramiko already raises ``BadHostKeyException`` for keys that
         # exist in the host-key store but mismatch on connect, *before*
         # the missing-key policy is consulted. So both ``accept-new``
-        # (custom: persist on first contact) and ``yes`` (reject
-        # missing) get changed-key rejection automatically. ``no``/
-        # ``off`` use ``AutoAddPolicy`` which tolerates *changed* keys
-        # too — the historical pre-PR-12 behaviour.
+        # (persist on first contact) and ``yes`` (reject missing) get
+        # changed-key rejection automatically. ``no``/``off`` use
+        # ``AutoAddPolicy`` which tolerates *changed* keys too — the
+        # historical pre-PR-12 behaviour.
         policy: paramiko.MissingHostKeyPolicy
         if policy_name == "yes":
             policy = paramiko.RejectPolicy()
         elif policy_name == "accept-new":
-            kh = (
+            # A concrete path is always resolved (config override, else
+            # ~/.ssh/known_hosts to match the asyncssh backend) so a
+            # first-contact key survives the process and later runs can
+            # reject a changed key.
+            known_hosts = (
                 str(self.config.known_hosts)
                 if self.config.known_hosts is not None
-                else None
+                else os.path.expanduser("~/.ssh/known_hosts")
             )
-            policy = AcceptNewPolicy(known_hosts_path=kh)
+            policy = AcceptNewPolicy(known_hosts_path=known_hosts)
         else:
             # "no" or "off"
             policy = paramiko.AutoAddPolicy()

--- a/repose/connection_policy.py
+++ b/repose/connection_policy.py
@@ -11,26 +11,41 @@ that exist in ``client.get_host_keys()`` but mismatch the server's
 presented key — that check fires *before* the missing-host-key policy
 is consulted. So a true accept-new implementation only needs to handle
 the *missing* (i.e. genuinely unknown) case: add the key in-memory and,
-when a writable ``known_hosts`` path is available, persist it.
+when a ``known_hosts`` path is available, persist it.
+
+Persistence deliberately avoids ``SSHClient.save_host_keys``: it
+truncate-rewrites the whole file, silently dropping comments, blank
+lines and any entries paramiko cannot round-trip — unacceptable for the
+user's real ``~/.ssh/known_hosts``. Instead a single well-formed line is
+*appended*, exactly like OpenSSH itself records first contacts.
 """
 
 import logging
 import os
-from typing import Any
-
+import threading
 
 import paramiko
 
 
 logger = logging.getLogger("repose.connection_policy")
 
+# ``HostGroup`` fans connections out over a thread pool, so several
+# first contacts may try to persist to the same known_hosts file at
+# once. One process-wide lock serializes the appends so concurrent
+# writes cannot interleave or drop lines.
+_known_hosts_lock = threading.Lock()
+
 
 class AcceptNewPolicy(paramiko.MissingHostKeyPolicy):
     """Add unknown host keys; rely on paramiko to reject changed ones.
 
-    Matches OpenSSH's ``StrictHostKeyChecking=accept-new``. Optionally
-    persists newly-accepted keys to ``known_hosts_path`` so subsequent
-    runs can detect a changed key.
+    Matches OpenSSH's ``StrictHostKeyChecking=accept-new``. A newly
+    accepted key is recorded in the client's in-memory host-key store
+    (trusting it for the current process) and, when ``known_hosts_path``
+    is set, persisted by appending one ``known_hosts`` line so
+    subsequent runs can detect a changed key. Existing file content is
+    never rewritten; the file (and its parent directory) is created on
+    first contact if missing.
     """
 
     def __init__(self, known_hosts_path: str | None = None) -> None:
@@ -43,8 +58,21 @@ class AcceptNewPolicy(paramiko.MissingHostKeyPolicy):
         )
 
     def missing_host_key(
-        self, client: paramiko.SSHClient, hostname: str, key: Any
+        self, client: paramiko.SSHClient, hostname: str, key: paramiko.PKey
     ) -> None:
+        """Trust ``key`` for this run and persist it to known_hosts.
+
+        Args:
+            client: The connecting ``SSHClient`` (its in-memory host-key
+                store receives the new entry).
+            hostname: Hostname as presented by paramiko (already in
+                ``[host]:port`` form for non-standard ports).
+            key: The server's host key.
+
+        A persistence failure must not kill the session: the connection
+        proceeds on the in-memory entry alone and a warning names the
+        path and the error.
+        """
         logger.info(
             "accept-new: recording unknown host key for %s (%s)",
             hostname,
@@ -54,14 +82,37 @@ class AcceptNewPolicy(paramiko.MissingHostKeyPolicy):
         if self.known_hosts_path is None:
             return
         try:
-            client.save_host_keys(self.known_hosts_path)
+            _append_known_hosts_line(self.known_hosts_path, hostname, key)
         except OSError as exc:
             # Read-only known_hosts (e.g. system-wide file, or a path
             # the user can't write to) is a soft failure: the key is
-            # still in-memory for this run, but won't survive a restart.
+            # still trusted in-memory for this run, but won't survive a
+            # restart.
             logger.warning(
                 "accept-new: could not persist host key for %s to %s: %s",
                 hostname,
                 self.known_hosts_path,
                 exc,
             )
+
+
+def _append_known_hosts_line(path: str, hostname: str, key: paramiko.PKey) -> None:
+    """Append one ``known_hosts`` entry for ``hostname`` to ``path``.
+
+    Creates the parent directory (mode ``0o700``) and the file (mode
+    ``0o600``) if missing — matching OpenSSH conventions — and never
+    truncates or rewrites existing content. All appends in the process
+    share one lock, so concurrent first contacts cannot corrupt the
+    file.
+
+    Raises:
+        OSError: If the directory or file cannot be created or written.
+    """
+    line = f"{hostname} {key.get_name()} {key.get_base64()}\n"
+    with _known_hosts_lock:
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, mode=0o700, exist_ok=True)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        with os.fdopen(fd, "w") as fobj:
+            fobj.write(line)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,6 +1,8 @@
 """Tests for ``repose.connection``."""
 
 import threading
+import logging
+import os
 from unittest.mock import MagicMock
 
 import paramiko
@@ -243,17 +245,99 @@ def test_accept_new_policy_adds_unknown_key():
     client.save_host_keys.assert_not_called()
 
 
-def test_accept_new_policy_persists_when_path_given(tmp_path):
-    """When ``known_hosts_path`` is set, ``save_host_keys`` is called."""
+def test_accept_new_defaults_known_hosts_to_user_file(mock_ssh_client, monkeypatch):
+    """Without a config override, accept-new persists to ~/.ssh/known_hosts."""
+    monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", "/home/fake"))
+    cfg = ConnectionConfig(host_key_policy="accept-new")  # known_hosts=None
+    conn = Connection("h", "u", 22, config=cfg)
+    conn.connect()
+
+    # The default path still goes through the system loader (missing
+    # file tolerated); only the *persist* target is resolved eagerly.
+    mock_ssh_client.load_system_host_keys.assert_called_once_with()
+    policy = mock_ssh_client.set_missing_host_key_policy.call_args.args[0]
+    assert isinstance(policy, AcceptNewPolicy)
+    assert policy.known_hosts_path == "/home/fake/.ssh/known_hosts"
+
+
+def test_accept_new_uses_configured_known_hosts(mock_ssh_client, tmp_path):
+    """A ``known_hosts`` config override is also the persist target."""
     kh = tmp_path / "kh"
-    client = MagicMock()
-    key = MagicMock()
-    key.get_name.return_value = "ssh-rsa"
+    kh.write_text("")
+    cfg = ConnectionConfig(host_key_policy="accept-new", known_hosts=kh)
+    conn = Connection("h", "u", 22, config=cfg)
+    conn.connect()
 
-    policy = AcceptNewPolicy(known_hosts_path=str(kh))
-    policy.missing_host_key(client, "h.example.com", key)
+    mock_ssh_client.load_host_keys.assert_called_once_with(str(kh))
+    policy = mock_ssh_client.set_missing_host_key_policy.call_args.args[0]
+    assert isinstance(policy, AcceptNewPolicy)
+    assert policy.known_hosts_path == str(kh)
 
-    client.save_host_keys.assert_called_once_with(str(kh))
+
+def test_accept_new_first_contact_creates_known_hosts(tmp_path):
+    """First contact ever: no known_hosts file (nor parent directory).
+
+    The policy must create both with safe permissions and write exactly
+    one well-formed line, while also trusting the key in-memory.
+    """
+    known_hosts = tmp_path / ".ssh" / "known_hosts"  # parent missing too
+    client = paramiko.SSHClient()
+    key = paramiko.ECDSAKey.generate()
+
+    policy = AcceptNewPolicy(known_hosts_path=str(known_hosts))
+    policy.missing_host_key(client, "newhost.example.com", key)
+
+    assert client.get_host_keys().lookup("newhost.example.com") is not None
+    expected = f"newhost.example.com {key.get_name()} {key.get_base64()}\n"
+    assert known_hosts.read_text() == expected
+    # 0o600/0o700 modulo umask: never group/other accessible.
+    assert known_hosts.stat().st_mode & 0o077 == 0
+    assert known_hosts.parent.stat().st_mode & 0o077 == 0
+
+
+def test_accept_new_appends_without_rewriting_existing_content(tmp_path):
+    """Persisting must append, byte-preserving prior file content.
+
+    ``SSHClient.save_host_keys`` would truncate-rewrite the file and
+    drop the comment and blank line below; the append path keeps them.
+    """
+    known_hosts = tmp_path / "known_hosts"
+    existing = (
+        "# trusted fleet hosts — hand-maintained comment\n"
+        "\n"
+        "old.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeFakeFake\n"
+    )
+    known_hosts.write_text(existing)
+    client = paramiko.SSHClient()
+    key = paramiko.ECDSAKey.generate()
+
+    policy = AcceptNewPolicy(known_hosts_path=str(known_hosts))
+    policy.missing_host_key(client, "new.example.com", key)
+
+    new_line = f"new.example.com {key.get_name()} {key.get_base64()}\n"
+    assert known_hosts.read_text() == existing + new_line
+
+
+def test_accept_new_persist_failure_warns_and_still_accepts(tmp_path, caplog):
+    """An OSError during persist is a visible soft failure.
+
+    The warning names the path and the error, and the key stays trusted
+    in-memory so the connection is not aborted.
+    """
+    blocker = tmp_path / "blocker"
+    blocker.write_text("")  # regular file where a directory is needed
+    known_hosts = blocker / ".ssh" / "known_hosts"
+    client = paramiko.SSHClient()
+    key = paramiko.ECDSAKey.generate()
+
+    policy = AcceptNewPolicy(known_hosts_path=str(known_hosts))
+    with caplog.at_level(logging.WARNING, logger="repose.connection_policy"):
+        # Must not raise: persist failure must not kill the session.
+        policy.missing_host_key(client, "h.example.com", key)
+
+    assert client.get_host_keys().lookup("h.example.com") is not None
+    assert "could not persist host key" in caplog.text
+    assert str(known_hosts) in caplog.text
 
 
 def test_run_timeout_non_tty_raises_without_prompt(mock_ssh_client, monkeypatch):


### PR DESCRIPTION
## What

The paramiko backend's default `accept-new` host-key policy only added
first-contact keys to the in-memory store — nothing was ever written to
disk. Every run was therefore a fresh first contact: a host whose key
changed (the canonical MITM signal) was silently accepted again instead
of raising `BadHostKeyException`, and the policy diverged from the
asyncssh backend, which persists to `~/.ssh/known_hosts`.

`accept-new` now always resolves a concrete persist path (the
configured `known_hosts`, else `~/.ssh/known_hosts` to match asyncssh)
and records a newly accepted key by appending a single `known_hosts`
line, the way OpenSSH itself does:

- append-only — never truncates or rewrites existing content, so
  comments, blank lines, and entries paramiko cannot round-trip survive
  (`SSHClient.save_host_keys` would rewrite the whole file and drop
  them);
- one process-wide lock serializes appends across `HostGroup`'s
  thread-pool fan-out, so concurrent first contacts cannot corrupt the
  file;
- on true first contact the parent directory (0700) and file (0600) are
  created;
- a persist failure (e.g. read-only file) logs a warning naming the
  path and error but does not abort the connection — the key stays
  trusted in-memory for the run.

Note: this is one of four independent single-concern fixes touching
nearby regions of `repose/connection.py` in this batch (bounded
reconnect loops, channel close on abort, prompt serialization,
accept-new persistence). They can merge in any order; later ones may
need a trivial rebase, which I'll provide.

## Verification

Full gate green (ruff format/check, ty, pytest: 551 passed, coverage
82.72%). Regression tests cover: first contact with no known_hosts file
(file created with exactly the new key line, correct modes, in-memory
entry present); appending to an existing file with comments and
unrelated entries (prior content byte-identical); persist `OSError`
(warning logged, connection proceeds); and persist-path wiring for both
the default and a config override. Reviewed by a fan-out adversarial
code review; all confirmed findings addressed (the review drove this
redesign from an earlier `save_host_keys`-based version).

_AI-assisted._
