### PR TITLE
fix(target): record failure in out on run() AssertionError branch

### DIFF
--- a/repose/target/__init__.py
+++ b/repose/target/__init__.py
@@ -119,6 +119,19 @@ class Target:
             logger.critical('%s: command "%s" timed out', self.hostname, command)
         except AssertionError:
             logger.debug("zombie command terminated", exc_info=True)
+            # Record a synthetic failure so ``out[-1]`` reflects this
+            # aborted command (exitcode -1) rather than desyncing to the
+            # previous command's tuple; callers reading ``out[-1][3]``
+            # must not see a stale success. ``None`` is still returned so
+            # ``read_repos`` keeps treating this as a transient failure.
+            if not stderr:
+                # The pre-initialized stderr is empty here, and
+                # ``_report_target`` prints only the entry's streams --
+                # without a diagnostic the host shows FAILED with no
+                # reason. Keep any real captured stderr.
+                stderr = "command aborted: no exit status received from channel"
+            runtime = int(timestamp()) - int(time_before)
+            self.out.append([command, stdout, stderr, exitcode, runtime])
             return None
         except Exception as e:
             # failed to run command

--- a/repose/target/async_target.py
+++ b/repose/target/async_target.py
@@ -132,6 +132,19 @@ class AsyncTarget:
             logger.critical('%s: command "%s" timed out', self.hostname, command)
         except AssertionError:
             logger.debug("zombie command terminated", exc_info=True)
+            # Record a synthetic failure so ``out[-1]`` reflects this
+            # aborted command (exitcode -1) rather than desyncing to the
+            # previous command's tuple; callers reading ``out[-1][3]``
+            # must not see a stale success. ``None`` is still returned so
+            # ``read_repos`` keeps treating this as a transient failure.
+            if not stderr:
+                # The pre-initialised stderr is empty here, and
+                # ``_report_target`` prints only the entry's streams --
+                # without a diagnostic the host shows FAILED with no
+                # reason. Keep any real captured stderr.
+                stderr = "command aborted: no exit status received from channel"
+            runtime = int(timestamp()) - int(time_before)
+            self.out.append([command, stdout, stderr, exitcode, runtime])
             return None
         except Exception as e:  # noqa: BLE001
             logger.error('%s: failed to run command "%s"', self.hostname, command)

--- a/tests/target/test_async_target.py
+++ b/tests/target/test_async_target.py
@@ -109,13 +109,40 @@ async def test_run_handles_command_timeout(make_target, caplog):
 
 
 async def test_run_handles_assertion_error_returns_none(make_target):
+    """``AssertionError`` returns ``None`` yet still appends a failure
+    entry (exitcode -1) so ``out[-1]`` reflects this aborted command
+    instead of desyncing to a previous command's tuple. The entry's
+    stderr carries a diagnostic so ``_report_target`` does not report a
+    FAILED host with zero explanatory output."""
     target, conn = make_target()
     conn.run.side_effect = AssertionError("zombie")
 
     result = await target.run("cmd")
     assert result is None
-    # AssertionError path does not append to ``out``.
-    assert target.out == []
+    assert target.out[-1][0] == "cmd"
+    assert target.out[-1][2] == (
+        "command aborted: no exit status received from channel"
+    )
+    assert target.out[-1][3] == -1
+
+
+async def test_run_assertion_error_does_not_mask_prior_success(make_target):
+    """Regression: a first command succeeds (exit 0), then a second
+    command hits the AssertionError branch. ``out[-1]`` must report the
+    second command's failure, not the first command's stale success."""
+    target, conn = make_target()
+    conn.run.return_value = ("out", "err", 0)
+    assert await target.run("first") == ("out", "err", 0)
+
+    conn.run.side_effect = AssertionError("zombie")
+    assert await target.run("second") is None
+
+    assert len(target.out) == 2
+    assert target.out[-1][0] == "second"
+    assert target.out[-1][2] == (
+        "command aborted: no exit status received from channel"
+    )
+    assert target.out[-1][3] == -1
 
 
 async def test_run_handles_generic_exception(make_target, caplog):

--- a/tests/target/test_target.py
+++ b/tests/target/test_target.py
@@ -99,13 +99,42 @@ def test_run_command_timeout_records_minus_one(make_target, caplog):
     assert any("timed out" in r.message for r in caplog.records)
 
 
-def test_run_assertion_error_returns_none(make_target):
+def test_run_assertion_error_returns_none_but_records_failure(make_target):
+    """``AssertionError`` returns ``None`` yet still appends a failure
+    entry (exitcode -1) so ``out[-1]`` reflects this aborted command
+    instead of desyncing to a previous command's tuple. The entry's
+    stderr carries a diagnostic so ``_report_target`` does not report a
+    FAILED host with zero explanatory output."""
     target, conn = make_target()
     conn.run.side_effect = AssertionError()
 
     assert target.run("ls") is None
-    # Early return — nothing appended.
-    assert target.out == []
+    assert target.out[-1][0] == "ls"
+    assert target.out[-1][2] == (
+        "command aborted: no exit status received from channel"
+    )
+    assert target.out[-1][3] == -1
+
+
+def test_run_assertion_error_does_not_mask_prior_success(make_target):
+    """Regression: a first command succeeds (exit 0), then a second
+    command hits the AssertionError branch. ``out[-1]`` must report the
+    second command's failure, not the first command's stale success."""
+    target, conn = make_target()
+    conn.run.return_value = ("out", "err", 0)
+    assert target.run("first") == ("out", "err", 0)
+
+    conn.run.side_effect = AssertionError()
+    assert target.run("second") is None
+
+    # Without the fix ``out[-1]`` would still be the exit-0 "first" tuple,
+    # falsely reporting the host as successful.
+    assert len(target.out) == 2
+    assert target.out[-1][0] == "second"
+    assert target.out[-1][2] == (
+        "command aborted: no exit status received from channel"
+    )
+    assert target.out[-1][3] == -1
 
 
 def test_run_generic_exception_records_minus_one(make_target, caplog):


### PR DESCRIPTION
## What

When `Target.run()` hit the `AssertionError` (zombie command) branch it
returned `None` without appending anything to `self.out`. Command
workers then read `out[-1][3]` via `_report_target`, which pointed at
the *previous* command's tuple — masking the aborted command and
falsely reporting a prior exit-0 as success (or raising `IndexError`
when `out` was empty).

The branch now appends a synthetic failure entry (exitcode `-1`, the
same sentinel used for timeouts) before returning `None`, so `out[-1]`
always reflects the command that just ran. Because the connection
raised before producing output, the entry's stderr would be empty and
the host would be reported FAILED with no explanation; it is populated
with a short diagnostic ("command aborted: no exit status received from
channel") when no real stderr was captured. `None` is still returned so
callers keep treating the condition as transient. Applied to both the
sync and async backends.

## Verification

Full gate green (ruff format/check, ty, pytest: 549 passed, coverage
82.55%). Four regression tests (two per backend) drive the
`AssertionError` branch and assert the synthetic entry lands in `out`
with exitcode `-1` and the diagnostic in the stderr field — they fail
on the pre-fix code. Reviewed by a fan-out adversarial code review; all
confirmed findings addressed.

_AI-assisted._
