### PR TITLE
fix(hostgroup): surface worker errors in read/parse fan-out

### DIFF
--- a/repose/target/hostgroup.py
+++ b/repose/target/hostgroup.py
@@ -1,11 +1,38 @@
 from collections import UserDict
 import concurrent.futures
 import logging
+from typing import Any, Callable
 
 logger = logging.getLogger("repose.target.hostgroup")
 
 
 class HostGroup(UserDict):
+    def _fanout(self, op_name: str, fn: Callable[[Any], Any]) -> None:
+        """Run ``fn(target)`` for every host and surface per-host failures.
+
+        Each host's work is submitted to a thread pool; results are
+        collected via :func:`concurrent.futures.as_completed` and
+        ``future.result()`` is called so that a worker exception (e.g.
+        an ``OSError`` on a dropped SSH link or a ``ValueError`` while
+        parsing repositories) is logged against the offending host
+        instead of being silently swallowed. Sibling hosts still run to
+        completion.
+
+        Args:
+            op_name: Short label for the operation, used in log lines.
+            fn: Callable invoked with each host's target object.
+        """
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = {
+                executor.submit(fn, self.data[hn]): hn for hn in self.data.keys()
+            }
+            for future in concurrent.futures.as_completed(futures):
+                hostname = futures[future]
+                try:
+                    future.result()
+                except Exception as exc:
+                    logger.warning("%s failed for %s: %s", op_name, hostname, exc)
+
     def run(self, cmd: dict[str, str] | str) -> None:
         with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = [
@@ -37,25 +64,13 @@ class HostGroup(UserDict):
             concurrent.futures.wait(connections)
 
     def read_products(self) -> None:
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            connections = [
-                executor.submit(self.data[hn].read_products) for hn in self.data.keys()
-            ]
-            concurrent.futures.wait(connections)
+        self._fanout("read_products", lambda t: t.read_products())
 
     def read_repos(self) -> None:
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            connections = [
-                executor.submit(self.data[hn].read_repos) for hn in self.data.keys()
-            ]
-            concurrent.futures.wait(connections)
+        self._fanout("read_repos", lambda t: t.read_repos())
 
     def parse_repos(self) -> None:
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            connections = [
-                executor.submit(self.data[hn].parse_repos) for hn in self.data.keys()
-            ]
-            concurrent.futures.wait(connections)
+        self._fanout("parse_repos", lambda t: t.parse_repos())
 
     def report_products(self, sink) -> None:
         for hn in sorted(self.data.keys()):

--- a/tests/target/test_hostgroup.py
+++ b/tests/target/test_hostgroup.py
@@ -68,6 +68,58 @@ def test_parse_repos_fans_out(two_targets):
         t.parse_repos.assert_called_once()
 
 
+def test_read_products_logs_worker_exception(monkeypatch, two_targets, caplog):
+    """A worker exception in read_products is logged, not swallowed."""
+    monkeypatch.setattr(
+        "repose.target.hostgroup.concurrent.futures.ThreadPoolExecutor",
+        ImmediateExecutor,
+    )
+    two_targets["host-a"].read_products.side_effect = OSError("dropped link")
+
+    hg = HostGroup(two_targets)
+    with caplog.at_level("WARNING", logger="repose.target.hostgroup"):
+        hg.read_products()  # should not raise
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("dropped link" in m and "host-a" in m for m in messages)
+    # Sibling host still ran to completion.
+    two_targets["host-b"].read_products.assert_called_once()
+
+
+def test_read_repos_logs_worker_exception(monkeypatch, two_targets, caplog):
+    """A worker exception in read_repos is logged, not swallowed."""
+    monkeypatch.setattr(
+        "repose.target.hostgroup.concurrent.futures.ThreadPoolExecutor",
+        ImmediateExecutor,
+    )
+    two_targets["host-a"].read_repos.side_effect = ValueError("bad repo")
+
+    hg = HostGroup(two_targets)
+    with caplog.at_level("WARNING", logger="repose.target.hostgroup"):
+        hg.read_repos()  # should not raise
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("bad repo" in m and "host-a" in m for m in messages)
+    two_targets["host-b"].read_repos.assert_called_once()
+
+
+def test_parse_repos_logs_worker_exception(monkeypatch, two_targets, caplog):
+    """A worker exception in parse_repos is logged, not swallowed."""
+    monkeypatch.setattr(
+        "repose.target.hostgroup.concurrent.futures.ThreadPoolExecutor",
+        ImmediateExecutor,
+    )
+    two_targets["host-a"].parse_repos.side_effect = AttributeError("no attr")
+
+    hg = HostGroup(two_targets)
+    with caplog.at_level("WARNING", logger="repose.target.hostgroup"):
+        hg.parse_repos()  # should not raise
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("no attr" in m and "host-a" in m for m in messages)
+    two_targets["host-b"].parse_repos.assert_called_once()
+
+
 def test_report_products_iterates_sorted(two_targets):
     hg = HostGroup(two_targets)
     sink = MagicMock()


### PR DESCRIPTION
## What

`HostGroup.read_products` / `read_repos` / `parse_repos` submitted
per-host work to a `ThreadPoolExecutor` and only called
`concurrent.futures.wait()`, never inspecting the futures. Any worker
exception (`OSError`/`AttributeError` on a dropped link, `ValueError`
while parsing repos) was silently swallowed — no log line at all — and
the host's `products`/`repos` stayed `None`; downstream code then
dereferenced `None` and raised an obscure `AttributeError` far from the
real cause.

These fan-outs now route through a `_fanout` helper that collects
results via `as_completed` and calls `future.result()` inside
`try/except`, logging per-host failures the same way `connect()` and
the async `_isolate` pattern already do. Sibling hosts still run to
completion.

## Verification

Full gate green (ruff format/check, ty, pytest: 550 passed, coverage
82.53%). Regression tests drive worker exceptions through the
read/parse fan-outs and assert the failure is logged per host while the
remaining hosts complete normally — they fail on the pre-fix code.
Reviewed by a fan-out adversarial code review; all confirmed findings
addressed.

_AI-assisted._
