### PR TITLE
fix(product): parse real identity from os-release instead of stub

### DIFF
--- a/repose/target/parsers/product.py
+++ b/repose/target/parsers/product.py
@@ -39,10 +39,54 @@ def __parse_product(prod: Any) -> tuple[str, str, str]:
     return (name, version, arch)  # ty: ignore[invalid-return-type]  # FOLLOWUP-ty-residuals
 
 
-def __parse_os_release(f: Any) -> tuple[str, str, str]:
-    # TODO : ...
-    logger.debug("TODO parse OSRELEASE file")
-    return ("rhel", "7", "x86_64")
+def __parse_os_release(f: Any, hostname: str) -> tuple[str, str, str]:
+    """Parse ``/etc/os-release`` into a ``(name, version, arch)`` tuple.
+
+    Reads the ``KEY=VALUE`` lines from the opened os-release file object,
+    stripping optional surrounding quotes, and derives the distribution
+    identity from ``ID`` and ``VERSION_ID`` (per ``os-release(5)``).
+
+    When the file carries no usable ``ID``, the spec default ``"linux"``
+    is used (``os-release(5)``: "If not set, a default value of 'linux'
+    may be used") and a warning names the host and the fallback, so the
+    host stays scannable without silently fabricating distro data.
+
+    ``/etc/os-release`` carries no architecture field, so ``arch`` is taken
+    from an optional, non-standard ``ARCHITECTURE`` key when present and
+    otherwise falls back to the documented placeholder ``"unknown"``.
+
+    Args:
+        f: An opened, iterable os-release file object yielding ``str`` or
+            ``bytes`` chunks, as returned by ``Connection.open``.
+        hostname: Host the file was read from, used in the fallback warning.
+
+    Returns:
+        A ``(name, version, arch)`` tuple built from the parsed ``ID``,
+        ``VERSION_ID`` and derived architecture.
+    """
+    values: dict[str, str] = {}
+    for chunk in f:
+        text = chunk.decode() if isinstance(chunk, bytes) else chunk
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            values[key.strip()] = value.strip().strip("\"'")
+
+    name = values.get("ID")
+    if not name:
+        name = "linux"
+        logger.warning(
+            "%s: /etc/os-release has no usable ID field; "
+            "falling back to the os-release(5) default ID %r",
+            hostname,
+            name,
+        )
+    version = values.get("VERSION_ID", "")
+    arch = values.get("ARCHITECTURE", "unknown")
+    logger.debug("Parsed os-release: %s %s %s", name, version, arch)
+    return (name, version, arch)
 
 
 # transactional-update ships its config here; its presence marks an
@@ -92,7 +136,7 @@ def parse_system(connection: Connection) -> System:
     if not suse:
         try:
             with connection.open("/etc/os-release") as f:
-                name, version, arch = __parse_os_release(f)
+                name, version, arch = __parse_os_release(f, connection.hostname)
         except FileNotFoundError:
             # TODO: old RH systems have only /etc/redhat-release
             return System(Product("rhel", "6", "x86_64"))
@@ -149,7 +193,7 @@ async def parse_system_async(connection: Any) -> System:
     if not suse:
         try:
             async with connection.open("/etc/os-release") as f:
-                name, version, arch = __parse_os_release(f)
+                name, version, arch = __parse_os_release(f, connection.hostname)
         except FileNotFoundError:
             return System(Product("rhel", "6", "x86_64"))
 

--- a/repose/types/refhost/transformations.py
+++ b/repose/types/refhost/transformations.py
@@ -1,4 +1,4 @@
-def transform_version_partialy(version: str) -> dict[str, int | str]:
+def transform_version_partialy(version: str) -> dict[str, int | str] | str:
     """Normalise a version string into a dict with 'major' and optional 'minor' keys.
 
     Args:
@@ -7,22 +7,31 @@ def transform_version_partialy(version: str) -> dict[str, int | str]:
 
     Returns:
         Dictionary with at least a ``"major"`` key, and a ``"minor"`` key when
-        the version contains a service-pack or minor component.
+        the version contains a service-pack or minor component. Versions that
+        do not fit those SUSE shapes — an empty string, a non-numeric value
+        such as ``"tumbleweed"``, or a multi-part one such as Alpine's
+        ``"3.19.1"`` (all legitimate os-release ``VERSION_ID`` shapes) — are
+        returned unchanged instead of raising.
     """
     minor: int | str | None = None
     major: int | str
-    if "-" in version:
-        major_str, minor_str = version.split("-", 1)
-        major = int(major_str)
-        minor = minor_str
-    elif "." in version:
-        major_str, minor_str = version.split(".", 1)
-        major = int(major_str)
-        minor = int(minor_str)
-    elif version == "ALL":
-        major = "ALL"
-    else:
-        major = int(version)
+    try:
+        if "-" in version:
+            major_str, minor_str = version.split("-", 1)
+            major = int(major_str)
+            minor = minor_str
+        elif "." in version:
+            major_str, minor_str = version.split(".", 1)
+            major = int(major_str)
+            minor = int(minor_str)
+        elif version == "ALL":
+            major = "ALL"
+        else:
+            major = int(version)
+    except ValueError:
+        # Best effort: pass unnormalisable versions through unchanged
+        # rather than aborting whole-report rendering.
+        return version
 
     ret: dict[str, int | str] = {"major": major}
 

--- a/repose/types/system.py
+++ b/repose/types/system.py
@@ -11,10 +11,6 @@ if TYPE_CHECKING:
     from ..target.parsers import Product
 
 
-class UnknownSystemError(ValueError):
-    pass
-
-
 @dataclass(frozen=True, slots=True)
 class SystemData:
     """Typed internal storage for System.

--- a/tests/target/parsers/test_product.py
+++ b/tests/target/parsers/test_product.py
@@ -1,5 +1,6 @@
 """Tests for ``repose.target.parsers.product.parse_system``."""
 
+import logging
 from contextlib import asynccontextmanager, contextmanager
 from unittest.mock import AsyncMock, MagicMock
 
@@ -188,21 +189,82 @@ def test_non_transactional_host_not_detected():
     assert system.is_transactional() is False
 
 
-def test_non_suse_falls_back_to_os_release():
-    """When /etc/products.d is absent, parser opens /etc/os-release."""
+_UBUNTU_OS_RELEASE = (
+    b'NAME="Ubuntu"\n'
+    b'VERSION_ID="22.04"\n'
+    b'VERSION="22.04.3 LTS (Jammy Jellyfish)"\n'
+    b"ID=ubuntu\n"
+    b"ID_LIKE=debian\n"
+)
+
+
+def test_non_suse_reflects_os_release_id_and_version():
+    """A non-SUSE host's identity comes from os-release ID/VERSION_ID.
+
+    Regression guard: the parser must reflect the file contents (ubuntu
+    22.04) rather than fabricating a hardcoded rhel/7 tuple.
+    """
     conn = MagicMock()
     conn.listdir.side_effect = OSError("No such directory")
 
     def _open(path, *args, **kwargs):
         if path == "/etc/os-release":
-            return _open_returning(b"")
+            return _open_returning(_UBUNTU_OS_RELEASE)
         raise FileNotFoundError(path)
 
     conn.open.side_effect = _open
 
     system = parse_system(conn)
-    # Stub returns ("rhel", "7", "x86_64")
-    assert system.get_base() == Product("rhel", "7", "x86_64")
+    assert system.get_base() == Product("ubuntu", "22.04", "unknown")
+
+
+def test_non_suse_os_release_uses_optional_architecture_field():
+    """An optional ARCHITECTURE key overrides the arch placeholder."""
+    conn = MagicMock()
+    conn.listdir.side_effect = OSError("No such directory")
+
+    def _open(path, *args, **kwargs):
+        if path == "/etc/os-release":
+            return _open_returning(b"ID=fedora\nVERSION_ID=40\nARCHITECTURE=aarch64\n")
+        raise FileNotFoundError(path)
+
+    conn.open.side_effect = _open
+
+    system = parse_system(conn)
+    assert system.get_base() == Product("fedora", "40", "aarch64")
+
+
+def test_non_suse_os_release_without_id_falls_back_to_linux(caplog):
+    """A malformed os-release (no ID) warns and uses the spec default.
+
+    os-release(5) defines ``ID``'s default as ``"linux"``, so the parser
+    falls back to that identity with a warning naming the host instead of
+    raising and knocking the host out of the scan.
+    """
+    conn = MagicMock()
+    conn.hostname = "mystery.example.com"
+    conn.listdir.side_effect = OSError("No such directory")
+
+    def _open(path, *args, **kwargs):
+        if path == "/etc/os-release":
+            return _open_returning(b'PRETTY_NAME="Mystery OS"\n')
+        raise FileNotFoundError(path)
+
+    conn.open.side_effect = _open
+
+    with caplog.at_level(logging.WARNING):
+        system = parse_system(conn)
+
+    assert system.get_base() == Product("linux", "", "unknown")
+    warning = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    )
+    assert warning == (
+        "mystery.example.com: /etc/os-release has no usable ID field; "
+        "falling back to the os-release(5) default ID 'linux'"
+    )
 
 
 def test_non_suse_without_osrelease_returns_rhel6_default():
@@ -300,13 +362,13 @@ async def test_async_non_suse_falls_back_to_os_release():
 
     def _open(path, *args, **kwargs):
         if path == "/etc/os-release":
-            return _async_open_returning(b"")
+            return _async_open_returning(_UBUNTU_OS_RELEASE)
         raise FileNotFoundError(path)
 
     conn.open.side_effect = _open
 
     system = await parse_system_async(conn)
-    assert system.get_base() == Product("rhel", "7", "x86_64")
+    assert system.get_base() == Product("ubuntu", "22.04", "unknown")
 
 
 async def test_async_non_suse_without_osrelease_returns_rhel6_default():

--- a/tests/types/test_transformations.py
+++ b/tests/types/test_transformations.py
@@ -12,9 +12,15 @@ from repose.types.refhost.transformations import transform_version_partialy
         ("15-SP3", {"major": 15, "minor": "SP3"}),
         ("12-SP5", {"major": 12, "minor": "SP5"}),
         ("15.3", {"major": 15, "minor": 3}),
+        ("15.6", {"major": 15, "minor": 6}),
         ("ALL", {"major": "ALL"}),
         ("15", {"major": 15}),
         ("7", {"major": 7}),
+        # Non-SUSE-shaped os-release VERSION_ID values pass through
+        # unchanged instead of raising ValueError:
+        ("", ""),
+        ("3.19.1", "3.19.1"),
+        ("tumbleweed", "tumbleweed"),
     ],
 )
 def test_transformations_table(version, expected):


### PR DESCRIPTION
## What

`__parse_os_release` ignored the opened `/etc/os-release` file entirely
and always returned a hardcoded `("rhel", "7", "x86_64")` tuple, so
every non-SUSE host shipped fabricated identity with no error and no
log.

The parser now reads the real `ID` / `VERSION_ID` (plus an optional
`ARCHITECTURE` key; os-release carries no arch field, so arch defaults
to a documented `"unknown"` placeholder):

- when the file lacks a usable `ID`, the parser falls back to the
  os-release(5) spec default `"linux"` and logs a warning naming the
  host — raising here would be silently discarded by the sync fan-out
  (`concurrent.futures.wait()` without `.result()`) and crash reporting
  far from the cause. The dead, now fully-unreferenced
  `UnknownSystemError` class is removed;
- real-world `VERSION_ID` shapes that the SUSE-oriented
  `transform_version_partialy` could not digest — missing (Arch, Debian
  sid), multi-part `3.19.1` (Alpine), non-numeric — previously became
  reachable uncaught `ValueError`s aborting `list-products --yaml`; the
  transform is now best-effort: SUSE-shaped versions keep their exact
  normalized output, anything else passes through unchanged.

## Verification

Full gate green (ruff format/check, ty, pytest: 553 passed, coverage
82.57%). Tests cover SUSE and non-SUSE os-release contents, the
missing-ID fallback (asserting both the `linux` identity and the
warning via caplog), and the transform's pass-through cases (`""`,
`"3.19.1"`, `"tumbleweed"`) alongside its unchanged SUSE shapes.
Reviewed by a fan-out adversarial code review; all confirmed findings
addressed.

_AI-assisted._
