### PR TITLE
fix(utils): retry GET on any non-success HEAD in async probe

### DIFF
--- a/repose/utils.py
+++ b/repose/utils.py
@@ -64,8 +64,12 @@ async def check_repo_url_async(url: str, *, timeout: float = 5.0) -> bool:
     semantic.
 
     HEAD is used in preference to GET to avoid pulling the full
-    ``repomd.xml`` payload, with a GET fallback because some mirrors
-    return 405 on HEAD even though the resource exists.
+    ``repomd.xml`` payload, with a GET fallback on *any* non-success
+    HEAD status. Some servers reject HEAD outright — 405, but also
+    400/401/403 from nginx ``limit_except``, WAFs, or S3/proxy layers —
+    while serving GET fine; without the broad fallback such a repo,
+    judged live by the sync ``urlopen`` (GET) probe, would be reported
+    dead here and break backend parity.
 
     TLS is verified against the system trust store (see
     :func:`_system_ssl_context`) rather than ``httpx``'s bundled
@@ -87,11 +91,12 @@ async def check_repo_url_async(url: str, *, timeout: float = 5.0) -> bool:
                 resp = await client.head(target, follow_redirects=True)
                 if resp.status_code < 400:
                     return True
-                if resp.status_code == 405:
-                    # Some mirrors disallow HEAD; retry with GET.
-                    resp = await client.get(target, follow_redirects=True)
-                    if resp.status_code < 400:
-                        return True
+                # Any non-success HEAD (405, but also 400/401/403 from
+                # servers that reject HEAD yet serve GET) retries with
+                # GET, matching the sync urllib (GET) probe's semantics.
+                resp = await client.get(target, follow_redirects=True)
+                if resp.status_code < 400:
+                    return True
             except (httpx.HTTPError, OSError):
                 continue
     return False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,8 @@ import ssl
 from unittest.mock import MagicMock
 from urllib.error import HTTPError, URLError
 
+import pytest
+
 import repose.utils
 
 
@@ -171,13 +173,18 @@ import httpx  # noqa: E402
 from unittest.mock import AsyncMock  # noqa: E402
 
 
-def _async_client_returning(responses: list[object]):
+def _async_client_returning(responses: list[object], probed: list[str] | None = None):
     """Patch ``httpx.AsyncClient`` to yield a context manager whose
-    ``.head`` / ``.get`` consume the given response queue."""
+    ``.head`` / ``.get`` consume the given response queue.
+
+    When ``probed`` is given, every requested URL is appended to it so
+    tests can assert which targets were actually probed."""
     client = MagicMock()
     queue = list(responses)
 
     async def _next(target, **kw):
+        if probed is not None:
+            probed.append(target)
         return queue.pop(0)
 
     client.head = _next
@@ -196,16 +203,31 @@ async def test_check_repo_url_async_returns_true_on_2xx(monkeypatch):
 
 
 async def test_check_repo_url_async_falls_back_to_suse_layout(monkeypatch):
-    """First probe (repodata/) → 404; second (suse/repodata/) → 200."""
+    """First suffix (repodata/) fails both HEAD and its GET retry;
+    the probe must then fall back to the suse/ layout → 200 → True."""
     bad = MagicMock(status_code=404)
     good = MagicMock(status_code=200)
-    monkeypatch.setattr(httpx, "AsyncClient", _async_client_returning([bad, good]))
+    probed: list[str] = []
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        _async_client_returning([bad, bad, good], probed=probed),
+    )
     assert (await repose.utils.check_repo_url_async("http://example.com/")) is True
+    assert probed == [
+        "http://example.com/repodata/repomd.xml",  # HEAD -> 404
+        "http://example.com/repodata/repomd.xml",  # GET retry -> 404
+        "http://example.com/suse/repodata/repomd.xml",  # HEAD -> 200
+    ]
 
 
 async def test_check_repo_url_async_returns_false_when_both_4xx(monkeypatch):
+    # Each of the two suffixes probes HEAD then falls back to GET, so a
+    # dead repo yields four 4xx responses.
     bad = MagicMock(status_code=404)
-    monkeypatch.setattr(httpx, "AsyncClient", _async_client_returning([bad, bad]))
+    monkeypatch.setattr(
+        httpx, "AsyncClient", _async_client_returning([bad, bad, bad, bad])
+    )
     assert (await repose.utils.check_repo_url_async("http://example.com/")) is False
 
 
@@ -226,16 +248,25 @@ async def test_check_repo_url_async_swallows_httpx_errors(monkeypatch):
     assert (await repose.utils.check_repo_url_async("http://example.com/")) is False
 
 
-async def test_check_repo_url_async_retries_get_on_405(monkeypatch):
-    """A 405 on HEAD must trigger a GET retry; a 200 on GET wins."""
-    head_405 = MagicMock(status_code=405)
+@pytest.mark.parametrize("head_status", [400, 401, 403, 404, 405, 500])
+async def test_check_repo_url_async_retries_get_on_non_success_head(
+    monkeypatch, head_status
+):
+    """Any non-success HEAD must trigger a GET retry; a 200 on GET wins.
+
+    Backend-parity regression: 405 covers mirrors that disallow HEAD
+    outright, while 400/401/403 come from nginx ``limit_except``, WAFs,
+    or S3/proxy layers that reject HEAD yet serve GET. Such repos are
+    live for the sync ``urlopen`` (GET) probe, so the async probe must
+    judge them live too."""
+    head_resp = MagicMock(status_code=head_status)
     get_200 = MagicMock(status_code=200)
 
     calls: list[str] = []
 
     async def _head(target, **kw):
         calls.append("head")
-        return head_405
+        return head_resp
 
     async def _get(target, **kw):
         calls.append("get")


### PR DESCRIPTION
## What

`check_repo_url_async` only retried with GET when HEAD returned exactly
405, while the sync `check_repo_url` probes with GET (via urllib) from
the start. A repo whose server rejects HEAD with 400/401/403 (nginx
`limit_except`, WAFs, S3/proxy layers) but serves GET 200 was reported
dead by the async backend and live by the sync one. The async probe now
retries with GET on any non-success HEAD status, restoring backend
parity.

## Verification

Full gate green (ruff format/check, ty, pytest: 552 passed, coverage
82.49%). The GET-retry regression is a single parametrized test over
400/401/403/404/405/500 HEAD statuses; the suse-layout fallback test
now fails both HEAD and GET on the first suffix and asserts the actual
probed URLs, so it genuinely pins the layout fallback again. Reviewed
by a fan-out adversarial code review; all confirmed findings addressed.

_AI-assisted._
