### PR TITLE
fix(install): merge repos across REPAs sharing a product name

### DIFF
--- a/repose/command/install.py
+++ b/repose/command/install.py
@@ -3,22 +3,42 @@ import logging
 
 from . import Command, UpdateFn
 from ..target.async_hostgroup import AsyncHostGroup
+from ..template.resolver import Repos
 from ..types import ExitCode
 
 logger = logging.getLogger("repose.command.install")
 
 
+def _merge_repos(
+    repositories: dict[str, list[Repos]], resolved: dict[str, list[Repos]]
+) -> None:
+    """Merge a resolved REPA solution into the accumulator in place.
+
+    Two REPAs may name the same product (e.g. differing only in the
+    requested repo). A plain ``dict.update`` would overwrite the first
+    product's repo list with the second's, silently dropping the repos
+    from the earlier REPA. Instead, extend each product's list with any
+    repos not already present so every resolved repo is retained.
+    """
+    for product, repos in resolved.items():
+        existing = repositories.setdefault(product, [])
+        for repo in repos:
+            if repo not in existing:
+                existing.append(repo)
+
+
 class Install(Command, name="install"):
     def _run(self, target: str, update: UpdateFn) -> bool:
         update(target, "resolving repos")
-        repositories = {}
+        repositories: dict[str, list[Repos]] = {}
         ok = True
         for repa in self.repa:
             try:
-                repositories.update(
+                _merge_repos(
+                    repositories,
                     self.repoq.solve_repa(
                         repa, self.targets[target].products.get_base()
-                    )
+                    ),
                 )
             except ValueError as error:
                 logger.error(error)
@@ -85,14 +105,15 @@ class Install(Command, name="install"):
         calls become ``await``s.
         """
         update(target, "resolving repos")
-        repositories: dict = {}
+        repositories: dict[str, list[Repos]] = {}
         ok = True
         for repa in self.repa:
             try:
-                repositories.update(
+                _merge_repos(
+                    repositories,
                     self.repoq.solve_repa(
                         repa, self.targets[target].products.get_base()
-                    )
+                    ),
                 )
             except ValueError as error:
                 logger.error(error)

--- a/tests/command/test_install.py
+++ b/tests/command/test_install.py
@@ -377,6 +377,42 @@ def test_install_command_solve_repa_value_error_logged(
     assert any("Unknow product" in r.message for r in caplog.records)
 
 
+def test_install_two_repas_same_product_keeps_all_repos(monkeypatch, mock_ssh_client):
+    """Two REPAs naming the same product must contribute *both* their
+    repos to the add-command set — the earlier REPA's repos must not be
+    dropped by the accumulation of the later one (key-collision bug)."""
+    repa_a = Repa("dummy-repa-a")
+    repa_b = Repa("dummy-repa-b")
+    args = Namespace(
+        dry=False,
+        target=[{"user@host1": MagicMock()}],
+        repa=[repa_a, repa_b],
+        config="dummy_config",
+        yaml=False,
+    )
+
+    mock_target, _, mock_repoq = _setup_install(monkeypatch, args, {})
+    # Both REPAs resolve to the same product but different repos.
+    # side_effect takes precedence over the helper's return_value.
+    mock_repoq.solve_repa.side_effect = [
+        {"product": [MockRepo("repo-a", "http://repo-a.url", refresh=False)]},
+        {"product": [MockRepo("repo-b", "http://repo-b.url", refresh=False)]},
+    ]
+
+    install_command = Install(args)
+    assert install_command.run() == 0
+
+    issued = [c.args[0] for c in mock_target.run.call_args_list]
+    expected_a = install_command.addcmd.format(
+        name="repo-a", url="http://repo-a.url", params="-ckn"
+    )
+    expected_b = install_command.addcmd.format(
+        name="repo-b", url="http://repo-b.url", params="-ckn"
+    )
+    assert expected_a in issued, "repos from the first REPA must be retained"
+    assert expected_b in issued, "repos from the second REPA must be retained"
+
+
 # ---------------------------------------------------------------------------
 # Exit code propagation (PR 06)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The install workers accumulated resolved repositories with
`repositories.update(self.repoq.solve_repa(...))`, and `solve_repa`
returns a dict keyed solely by `repa.product`. When two REPA arguments
referenced the same product but different repos, the second result's
`{product: [repoB]}` overwrote the first's `{product: [repoA]}` — repoA
was silently dropped (no error, no warning) and never added to the
host.

Both the sync and async paths now merge per product via a
`_merge_repos` helper: repo lists for the same product are concatenated
with order-preserving deduplication, so every explicitly requested repo
survives.

## Verification

Full gate green (ruff format/check, ty, pytest: 548 passed, coverage
82.55%). Regression test drives two REPAs resolving to the same product
with different repos through `Install.run()` and asserts both repos are
added — it fails on the pre-fix code (the second silently replaced the
first). Reviewed by a fan-out adversarial code review; all confirmed
findings addressed.

_AI-assisted._
