### PR TITLE
fix(connection): tolerate non-UTF-8 command output when decoding

### DIFF
--- a/repose/aiossh.py
+++ b/repose/aiossh.py
@@ -465,7 +465,14 @@ class AsyncConnection:
         """
         assert self._conn is not None, "connect() must run first"
         try:
-            result = await self._conn.run(command, check=False, timeout=self.timeout)
+            # errors="replace": asyncssh's default strict UTF-8 decode
+            # raises ProtocolError (from UnicodeDecodeError) as soon as
+            # a command emits a non-UTF-8 byte, killing the whole
+            # connection mid-command. Replacing undecodable bytes with
+            # U+FFFD matches the paramiko backend's tolerant decode.
+            result = await self._conn.run(
+                command, check=False, timeout=self.timeout, errors="replace"
+            )
         except asyncio.TimeoutError as exc:
             # asyncssh raises asyncio.TimeoutError when its own timeout
             # fires; translate to the project-wide exception type.

--- a/repose/connection.py
+++ b/repose/connection.py
@@ -412,7 +412,14 @@ class Connection:
         exitcode = session.recv_exit_status()
         self.close_session(session)
 
-        return (stdout.decode(), stderr.decode(), exitcode)
+        # Decode tolerantly: remote commands may emit non-UTF-8 bytes
+        # (locale-encoded package descriptions, binary noise), and a
+        # strict decode would raise UnicodeDecodeError out of run().
+        return (
+            stdout.decode("utf-8", errors="replace"),
+            stderr.decode("utf-8", errors="replace"),
+            exitcode,
+        )
 
     def __sftp_open(self) -> SFTPClient | None:
         sftp: SFTPClient | None = None

--- a/tests/test_aiossh.py
+++ b/tests/test_aiossh.py
@@ -563,6 +563,32 @@ async def test_run_returns_stdout_stderr_exitcode(fake_conn):
     assert kwargs["check"] is False
 
 
+async def test_run_requests_tolerant_decode(fake_conn):
+    """run() must ask asyncssh for ``errors="replace"`` decoding.
+
+    Regression test: asyncssh decodes command output with strict UTF-8
+    by default and raises ProtocolError (from UnicodeDecodeError) on
+    the first non-UTF-8 byte (e.g. ``b"ok\\xff\\xfe"``), tearing down
+    the connection mid-command. Requesting ``errors="replace"`` makes
+    such output come back with U+FFFD replacements instead, matching
+    the paramiko backend.
+    """
+    result = MagicMock()
+    result.stdout = "ok\ufffd\ufffd"
+    result.stderr = ""
+    result.exit_status = 0
+    fake_conn.run = AsyncMock(return_value=result)
+
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+
+    stdout, _, _ = await c.run("zypper lr")
+
+    assert stdout == "ok\ufffd\ufffd"
+    _, kwargs = fake_conn.run.call_args
+    assert kwargs["errors"] == "replace"
+
+
 async def test_run_translates_timeout_to_command_timeout(fake_conn):
     fake_conn.run = AsyncMock(side_effect=asyncio.TimeoutError())
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -250,6 +250,36 @@ def test_accept_new_policy_persists_when_path_given(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# run() — output decoding
+# ---------------------------------------------------------------------------
+
+
+def test_run_tolerates_non_utf8_output(mock_ssh_client, monkeypatch):
+    """Non-UTF-8 bytes in command output are replaced, not fatal.
+
+    Regression test: the final decode used strict UTF-8, so a single
+    non-UTF-8 byte from the remote command raised UnicodeDecodeError
+    out of run(), killing the host worker mid-run.
+    """
+    session = mock_ssh_client.get_transport.return_value.open_session.return_value
+    # First loop iteration delivers the payloads, second sees EOF.
+    session.recv_ready.side_effect = [True, False]
+    session.recv.return_value = b"ok\xff\xfe"
+    session.recv_stderr_ready.side_effect = [True, False]
+    session.recv_stderr.return_value = b"err\xfd"
+    session.recv_exit_status.return_value = 0
+    # Pretend data is always ready so the timeout prompt never triggers.
+    monkeypatch.setattr(
+        "repose.connection.select.select", lambda *a, **k: ([session], [], [])
+    )
+
+    conn = Connection("h", "u", 22)
+    stdout, stderr, exitcode = conn.run("zypper lr")
+
+    assert (stdout, stderr, exitcode) == ("ok\ufffd\ufffd", "err\ufffd", 0)
+
+
+# ---------------------------------------------------------------------------
 # Transactional reboot support: fire_and_forget / boot_id / wait_reconnect
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Connection.run() accumulated raw bytes from the channel and returned
them via stdout.decode()/stderr.decode() with the default strict
UTF-8 error mode. Any non-UTF-8 byte in a remote command's output
(locale-encoded package descriptions, binary noise) raised
UnicodeDecodeError out of run(), which is neither CommandTimeout nor
the expected result tuple, so it escaped unhandled and killed the
host worker mid-run. The streaming debug path already decoded with a
tolerant mode, making the strict final decode an oversight.

The asyncssh backend had the same defect one layer down: asyncssh
decodes session output with encoding='utf-8' and errors='strict' by
default, and its channel wraps the UnicodeDecodeError in a
ProtocolError that tears down the whole connection on the first bad
byte.

Decode the paramiko backend's final output with errors="replace" and
pass errors="replace" through AsyncConnection.run() to asyncssh, so
undecodable bytes come back as U+FFFD on both backends instead of
raising. The paramiko regression test feeds b"ok\xff\xfe"-style
output through run()'s decode and asserts the replaced text is
returned; the asyncssh regression test asserts errors="replace" is
passed through to asyncssh, which performs the decode in its channel
layer.

Note: this is one of five single-concern fixes in this batch touching `repose/connection.py` (several also `repose/aiossh.py`), on top of the four already-open connection PRs #182–#185. They conflict pairwise; any merge order works and later ones get a trivial rebase, which I'll provide.

## Verification

Full gate green (ruff format/check, ty, pytest: 549 passed, coverage 83.49%). The paramiko regression test feeds non-UTF-8 bytes through the real decode; the asyncssh test pins the errors="replace" pass-through (the decode happens inside asyncssh's channel layer). Both verified to fail on the pre-fix code. Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
