### PR TITLE
fix(connection): close SFTP client when an SFTP operation raises

### DIFF
--- a/repose/connection.py
+++ b/repose/connection.py
@@ -442,9 +442,10 @@ class Connection:
         logger.debug("getting %s:%s:%s listing", self.hostname, self.port, path)
         sftp = self.__sftp_reconnect()
 
-        listdir = sftp.listdir(path)
-        sftp.close()
-        return listdir
+        try:
+            return sftp.listdir(path)
+        finally:
+            sftp.close()
 
     def open(self, filename, mode="r", bufsize=-1) -> SFTPFile:
         """open remote file
@@ -471,9 +472,10 @@ class Connection:
         logger.debug("read link %s:%s:%s", self.hostname, self.port, path)
 
         sftp = self.__sftp_reconnect()
-        link = sftp.readlink(path)
-        sftp.close()
-        return link
+        try:
+            return sftp.readlink(path)
+        finally:
+            sftp.close()
 
     def is_active(self) -> bool:
         return self.client._transport and self.client._transport.is_active()  # type: ignore

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -113,6 +113,18 @@ def test_listdir_uses_sftp(mock_ssh_client):
     sftp.close.assert_called_once()
 
 
+def test_listdir_closes_sftp_when_op_raises(mock_ssh_client):
+    """A failing listdir op must still close the SFTP client (channel leak)."""
+    sftp = MagicMock()
+    sftp.listdir.side_effect = FileNotFoundError("/missing")
+    mock_ssh_client.open_sftp.return_value = sftp
+
+    conn = Connection("h", "u", 22)
+    with pytest.raises(FileNotFoundError):
+        conn.listdir("/missing")
+    sftp.close.assert_called_once()
+
+
 def test_readlink_uses_sftp(mock_ssh_client):
     sftp = MagicMock()
     sftp.readlink.return_value = "/target"
@@ -121,6 +133,18 @@ def test_readlink_uses_sftp(mock_ssh_client):
     conn = Connection("h", "u", 22)
     assert conn.readlink("/link") == "/target"
     sftp.readlink.assert_called_once_with("/link")
+
+
+def test_readlink_closes_sftp_when_op_raises(mock_ssh_client):
+    """A failing readlink op must still close the SFTP client (channel leak)."""
+    sftp = MagicMock()
+    sftp.readlink.side_effect = PermissionError("denied")
+    mock_ssh_client.open_sftp.return_value = sftp
+
+    conn = Connection("h", "u", 22)
+    with pytest.raises(PermissionError):
+        conn.readlink("/protected/link")
+    sftp.close.assert_called_once()
 
 
 def test_open_returns_sftp_file(mock_ssh_client):


### PR DESCRIPTION
## What

listdir() and readlink() opened an SFTP client, ran the operation and
then called sftp.close() as a plain sequential statement. When the
operation raised -- IOError/FileNotFoundError for a missing path or
PermissionError for a denied one -- close() was skipped and the SFTP
channel leaked on the shared paramiko transport. Repeated failures
(e.g. probing /etc/products.d on hosts without it) accumulate open
channels until the server's per-session channel limit is hit, after
which further SFTP and exec requests on that connection fail. open()
already guarded its sftp.open() call, leaving the three methods
inconsistent.

Wrap the operation in try/finally so the SFTP client is always closed
while the original exception still propagates unchanged. Regression
tests assert that a raising listdir()/readlink() both propagates the
exception and closes the client; they fail on the pre-fix code.

Note: this is one of five single-concern fixes in this batch touching `repose/connection.py` (several also `repose/aiossh.py`), on top of the four already-open connection PRs #182–#185. They conflict pairwise; any merge order works and later ones get a trivial rebase, which I'll provide.

## Verification

Full gate green (ruff format/check, ty, pytest: 549 passed, coverage 82.50%). Regression tests assert the SFTP client is closed when listdir/readlink raise, with the exception propagating unchanged; verified to fail pre-fix. The async backend caches one SFTP client per connection, so no per-op leak exists there (checked). Review returned no in-scope findings. Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
