### PR TITLE
fix(connection): honor retry budget in wait_reconnect (both backends)

### DIFF
--- a/repose/aiossh.py
+++ b/repose/aiossh.py
@@ -578,7 +578,7 @@ class AsyncConnection:
         self._sftp = None
         count = 0
         rtimeout = timeout
-        while not self.is_active() and count <= retry:
+        while not self.is_active() and count < retry:
             count += 1
             await asyncio.sleep(rtimeout)
             if backoff:

--- a/repose/connection.py
+++ b/repose/connection.py
@@ -268,7 +268,7 @@ class Connection:
         """
         count = 0
         rtimeout = timeout
-        while not self.is_active() and count <= retry:
+        while not self.is_active() and count < retry:
             count += 1
             # Wait first: right after a reboot dispatch the host is still
             # going down, so an immediate connect would only race the

--- a/tests/test_aiossh.py
+++ b/tests/test_aiossh.py
@@ -825,6 +825,7 @@ async def test_async_wait_reconnect_succeeds_after_retries(monkeypatch, fake_con
 
 
 async def test_async_wait_reconnect_gives_up(monkeypatch):
+    """A host that never comes back gets exactly ``retry`` attempts."""
     c = AsyncConnection("h", "u", 22)
     calls = {"n": 0}
 
@@ -836,4 +837,4 @@ async def test_async_wait_reconnect_gives_up(monkeypatch):
     ok = await c.wait_reconnect(retry=2, timeout=0, backoff=False)
 
     assert ok is False
-    assert calls["n"] == 3  # retry=N → N+1 attempts
+    assert calls["n"] == 2

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -301,14 +301,14 @@ def test_wait_reconnect_succeeds_after_retries(mock_ssh_client):
 
 
 def test_wait_reconnect_gives_up_after_retry_budget(mock_ssh_client):
+    """A host that never comes back gets exactly ``retry`` attempts."""
     conn = Connection("h", "u", 22)
     mock_ssh_client._transport.is_active.return_value = False
 
     ok = conn.wait_reconnect(retry=2, timeout=0, backoff=False)
 
     assert ok is False
-    # count increments after entering, so retry=N yields N+1 attempts.
-    assert mock_ssh_client.connect.call_count == 3
+    assert mock_ssh_client.connect.call_count == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Both Connection.wait_reconnect (paramiko) and
AsyncConnection.wait_reconnect (asyncssh) looped with
"while not is_active() and count <= retry" where count starts at 0
and is pre-incremented inside the body, so the body ran for
count = 1..retry+1: one connect attempt more than the documented
maximum of retry.

With the default retry=10 a host that never comes back after a
reboot was probed 11 times, and with backoff enabled the extra
final attempt was preceded by a 120s sleep (each iteration sleeps
the rtimeout computed at the end of the previous one, here
2*(10 + 5*10)), delaying the False return well past the intended
budget.

Tighten the loop bound to "count < retry" in both backends so
exactly retry attempts run, keeping the wait-first ordering and
backoff growth unchanged. Regression tests on both backends assert
a host that never returns gets exactly retry connect attempts and
wait_reconnect returns False.

Note: this is one of five single-concern fixes in this batch touching `repose/connection.py` (several also `repose/aiossh.py`), on top of the four already-open connection PRs #182–#185. They conflict pairwise; any merge order works and later ones get a trivial rebase, which I'll provide.

## Verification

Full gate green (ruff format/check, ty, pytest: 547 passed, coverage 82.50%). Tests on both backends assert a never-returning host gets exactly `retry` connect attempts and False; they encoded the buggy retry+1 behavior before and were rewritten (verified failing pre-fix: "assert 3 == 2"). Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
