### PR TITLE
fix(connection): fail fire_and_forget when the command is never dispatched

### DIFF
--- a/repose/aiossh.py
+++ b/repose/aiossh.py
@@ -547,15 +547,50 @@ class AsyncConnection:
         Starts ``command`` on a new channel and closes the connection;
         a dropped link (e.g. from a reboot) is expected. Follow up with
         :meth:`wait_reconnect`.
+
+        The connection is closed whether or not the dispatch succeeded.
+
+        Raises:
+            asyncssh.ChannelOpenError: If there is no connection or the
+                channel never opened, i.e. the command was never
+                dispatched to the host. Silently swallowing this would
+                let a follow-up :meth:`wait_reconnect` instantly
+                "succeed" against a host that never acted on the
+                command. Post-dispatch link teardown, by contrast, is
+                expected and still tolerated.
         """
         logger.debug("fire-and-forget %r on %s:%s", command, self.hostname, self.port)
-        if self._conn is not None:
-            try:
-                # create_process sends the exec request without waiting
-                # for the command to finish — right for a reboot.
-                await self._conn.create_process(command)
-            except Exception:  # noqa: BLE001 - link teardown is expected
-                logger.debug("fire-and-forget dispatch raised", exc_info=True)
+        if self._conn is None:
+            await self.close()
+            logger.error(
+                "%s:%s: not connected, command %r was never dispatched",
+                self.hostname,
+                self.port,
+                command,
+            )
+            raise asyncssh.ChannelOpenError(
+                asyncssh.OPEN_CONNECT_FAILED,
+                f"not connected to {self.hostname}:{self.port}: "
+                f"command {command!r} was never dispatched",
+            )
+        try:
+            # create_process sends the exec request without waiting
+            # for the command to finish — right for a reboot.
+            await self._conn.create_process(command)
+        except asyncssh.ChannelOpenError:
+            # The channel never opened, so the exec request was never
+            # sent — the same never-dispatched failure as above, unlike
+            # a link drop after dispatch.
+            await self.close()
+            logger.error(
+                "%s:%s: could not open a channel, command %r was never dispatched",
+                self.hostname,
+                self.port,
+                command,
+            )
+            raise
+        except Exception:  # noqa: BLE001 - post-dispatch teardown is expected
+            logger.debug("fire-and-forget dispatch raised", exc_info=True)
         await self.close()
 
     async def boot_id(self) -> str:

--- a/repose/connection.py
+++ b/repose/connection.py
@@ -223,12 +223,32 @@ class Connection:
         :meth:`wait_reconnect`. Avoids :meth:`run`'s reconnect recovery,
         which would otherwise fight the still-rebooting host.
 
+        The connection is closed whether or not the dispatch succeeded.
+
         Args:
             command: The command to dispatch.
+
+        Raises:
+            paramiko.SSHException: If no session could be opened, i.e.
+                the command was never dispatched to the host. Silently
+                swallowing this would let a follow-up
+                :meth:`wait_reconnect` instantly "succeed" against a
+                host that never acted on the command.
         """
         logger.debug("fire-and-forget %r on %s:%s", command, self.hostname, self.port)
-        self.__run_command(command)
+        session = self.__run_command(command)
         self.close()
+        if session is None:
+            logger.error(
+                "%s:%s: could not open a session, command %r was never dispatched",
+                self.hostname,
+                self.port,
+                command,
+            )
+            raise paramiko.SSHException(
+                f"could not open a session on {self.hostname}:{self.port}: "
+                f"command {command!r} was never dispatched"
+            )
 
     def boot_id(self) -> str:
         """Return the host's current boot id, or "" if unreadable.

--- a/tests/test_aiossh.py
+++ b/tests/test_aiossh.py
@@ -801,6 +801,52 @@ async def test_async_fire_and_forget_dispatches_then_closes(fake_conn):
     assert c._conn is None  # closed
 
 
+async def test_async_fire_and_forget_raises_when_channel_never_opens(fake_conn):
+    """A refused channel open must surface instead of dropping the command.
+
+    Async mirror of the sync silent-drop regression: ``ChannelOpenError``
+    means the exec request was never sent, so treating it as dispatched
+    would let ``wait_reconnect`` instantly "succeed" against a host that
+    never went down.
+    """
+    fake_conn.create_process = AsyncMock(
+        side_effect=asyncssh.ChannelOpenError(
+            asyncssh.OPEN_CONNECT_FAILED, "open failed"
+        )
+    )
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+
+    with pytest.raises(asyncssh.ChannelOpenError):
+        await c.fire_and_forget("systemctl reboot")
+
+    fake_conn.close.assert_called()
+    assert c._conn is None  # still closed on failure
+
+
+async def test_async_fire_and_forget_raises_when_not_connected():
+    """Without a connection the command cannot have been dispatched."""
+    c = AsyncConnection("h", "u", 22)
+    assert c._conn is None
+
+    with pytest.raises(asyncssh.ChannelOpenError, match="never dispatched"):
+        await c.fire_and_forget("systemctl reboot")
+
+
+async def test_async_fire_and_forget_tolerates_post_dispatch_teardown(fake_conn):
+    """A link drop after dispatch stays tolerated (fire-and-forget contract)."""
+    fake_conn.create_process = AsyncMock(
+        side_effect=asyncssh.ConnectionLost("link dropped")
+    )
+    c = AsyncConnection("h", "u", 22)
+    c._conn = fake_conn
+
+    await c.fire_and_forget("systemctl reboot")
+
+    fake_conn.close.assert_called()
+    assert c._conn is None  # closed
+
+
 async def test_async_boot_id_returns_stripped(monkeypatch):
     c = AsyncConnection("h", "u", 22)
     monkeypatch.setattr(c, "run", AsyncMock(return_value=("abc-123\n", "", 0)))

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -266,6 +266,26 @@ def test_fire_and_forget_dispatches_then_closes(mock_ssh_client):
     mock_ssh_client.close.assert_called()
 
 
+def test_fire_and_forget_raises_when_session_never_opens(mock_ssh_client):
+    """A failed session open must surface instead of dropping the command.
+
+    Regression test for the silent-drop defect: with the session-open
+    failure swallowed, the reboot is never dispatched, yet the caller
+    proceeds to ``wait_reconnect`` which instantly "succeeds" against a
+    host that never went down.
+    """
+    conn = Connection("h", "u", 22)
+    conn.connect()
+    transport = mock_ssh_client.get_transport.return_value
+    transport.open_session.side_effect = paramiko.SSHException("no session")
+
+    with pytest.raises(paramiko.SSHException, match="never dispatched"):
+        conn.fire_and_forget("systemctl reboot")
+
+    # The link is still torn down; the command was never exec'd.
+    mock_ssh_client.close.assert_called()
+
+
 def test_boot_id_returns_stripped_output(mock_ssh_client, monkeypatch):
     conn = Connection("h", "u", 22)
     monkeypatch.setattr(conn, "run", lambda *a, **k: ("abc-123\n", "", 0))


### PR DESCRIPTION
## What

fire_and_forget dispatched the command via __run_command and ignored
its return value, but __run_command returns None (without raising)
when the session cannot be opened. The command -- typically the
reboot after a transactional update -- was silently dropped, the
connection closed, and the caller moved on to wait_reconnect, which
instantly "succeeded" against a host that never went down. The flow
then verified products against a host still running the pre-reboot
snapshot, masking the missed reboot.

Detect the None result and raise paramiko.SSHException with a clear
message (plus a logger.error with host context). The raise propagates
through Target.reboot into the per-host worker, whose future records
the exception, so _aggregate counts the host as failed instead of
crashing the fan-out.

The asyncssh backend had the identical silent-drop shape: with no
connection it skipped the dispatch entirely, and a ChannelOpenError
from create_process (channel never opened, exec request never sent)
was swallowed by the catch-all meant for post-dispatch link teardown.
Both never-dispatched cases now raise asyncssh.ChannelOpenError;
genuine post-dispatch teardown exceptions stay tolerated, matching
the fire-and-forget contract. The connection is closed on both the
success and the failure paths in both backends.

Note: this is one of five single-concern fixes in this batch touching `repose/connection.py` (several also `repose/aiossh.py`), on top of the four already-open connection PRs #182–#185. They conflict pairwise; any merge order works and later ones get a trivial rebase, which I'll provide.

## Verification

Full gate green (ruff format/check, ty, pytest: full suite green, coverage >= 80%). Callers audited: the only users are Target.reboot/AsyncTarget.reboot, whose worker wrappers record the raise as a per-host failure — no fan-out crash. Regression tests on both backends verify a failed session open now surfaces instead of being treated as dispatched; verified to fail pre-fix. Review returned no in-scope findings. Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
