### PR TITLE
fix(connection): refuse changed host keys without password prompt

### DIFF
--- a/repose/connection.py
+++ b/repose/connection.py
@@ -172,7 +172,16 @@ class Connection:
                 ),
             )
 
-        except (paramiko.AuthenticationException, paramiko.BadHostKeyException):
+        except paramiko.BadHostKeyException:
+            # the server's host key does not match the one on record: the
+            # canonical changed-key / possible-MITM signal. Refuse to
+            # connect instead of prompting for credentials.
+            logger.error(
+                "host key verification failed for %s: refusing to connect",
+                self.hostname,
+            )
+            raise
+        except paramiko.AuthenticationException:
             # if public key auth fails, fallback to a password prompt.
             # other than ssh, mtui asks only once for a password. this could
             # be changed if there is demand for it.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,5 +1,6 @@
 """Tests for ``repose.connection``."""
 
+import logging
 import threading
 from unittest.mock import MagicMock
 
@@ -73,6 +74,31 @@ def test_password_failure_reraises(mock_ssh_client, monkeypatch):
     conn = Connection("h", "u", 22)
     with pytest.raises(paramiko.AuthenticationException):
         conn.connect()
+
+
+def test_bad_host_key_refuses_without_password_prompt(
+    mock_ssh_client, monkeypatch, caplog
+):
+    """A changed host key must fail fast: no password prompt, no retry,
+    a clear error log, and the exception propagated."""
+    mock_ssh_client.connect.side_effect = paramiko.BadHostKeyException(
+        "h", MagicMock(), MagicMock()
+    )
+    prompt = MagicMock()
+    monkeypatch.setattr("getpass.getpass", prompt)
+
+    conn = Connection("h", "u", 22)
+    with caplog.at_level(logging.ERROR, logger="repose.connection"):
+        with pytest.raises(paramiko.BadHostKeyException):
+            conn.connect()
+
+    prompt.assert_not_called()
+    mock_ssh_client.connect.assert_called_once()
+    assert any(
+        record.levelno == logging.ERROR
+        and "host key verification failed for h" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 def test_ssh_exception_propagates(mock_ssh_client):


### PR DESCRIPTION
## What

Connection.connect() caught paramiko.BadHostKeyException together with
AuthenticationException, logged 'AuthKey missing', and prompted the
operator for the root password before retrying. BadHostKeyException is
the changed-key / possible-MITM signal under the yes/accept-new
policies, so a key mismatch did not fail fast: the operator was asked
to type the root credential, and only afterwards did the retry abort
with a raw BadHostKeyException - misleading UX that conditions
operators to enter root passwords on host-key changes.

Catch BadHostKeyException separately: log a clear 'host key
verification failed for <host>: refusing to connect' error and re-raise
immediately, with no password prompt and no retry. The
AuthenticationException fallback-to-password path is unchanged.

Regression test asserts getpass is never called, only one connect
attempt is made, the error is logged, and the exception propagates.

Note: this is one of five single-concern fixes in this batch touching `repose/connection.py` (several also `repose/aiossh.py`), on top of the four already-open connection PRs #182–#185. They conflict pairwise; any merge order works and later ones get a trivial rebase, which I'll provide.

## Verification

Full gate green (ruff format/check, ty, pytest: full suite green, coverage >= 80%). Tests: BadHostKeyException propagates without any getpass prompt and with a clear error logged; the AuthenticationException path is pinned unchanged. Verified to fail pre-fix. Review returned no in-scope findings. Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
