### PR TITLE
fix(repository): skip malformed repo entries instead of aborting host parse

### DIFF
--- a/repose/target/parsers/repository.py
+++ b/repose/target/parsers/repository.py
@@ -1,17 +1,45 @@
+import logging
 from xml.etree import ElementTree as ET
 
 from ..parsers import Repository
 
+logger = logging.getLogger("repose.target.parsers.repository")
 
-def parse_repositories(xml) -> set[Repository]:
-    repos = set()
+_REQUIRED_ATTRIBUTES = frozenset(["alias", "name", "enabled"])
+
+
+def parse_repositories(xml: str) -> set[Repository]:
+    """Parse ``zypper -x lr`` XML output into a set of repositories.
+
+    A ``<repo>`` element missing one of the required attributes
+    (``alias``, ``name``, ``enabled``) or lacking a non-empty ``<url>``
+    child is skipped with a warning instead of aborting the parse, so
+    well-formed sibling repositories are still returned.
+
+    Args:
+        xml: XML document produced by ``zypper -x lr``.
+
+    Returns:
+        Set of well-formed repositories found in the document.
+    """
+    repos: set[Repository] = set()
     root = ET.fromstring(xml)
 
     for repo in root.findall("./repo-list/repo"):
-        alias = repo.attrib["alias"]
-        name = repo.attrib["name"]
-        enabled = True if repo.attrib["enabled"] == "1" else False
-        url = repo.find("./url").text  # ty: ignore[unresolved-attribute]  # FOLLOWUP-ty-residuals
-        repos.add(Repository(alias, name, url, enabled))  # ty: ignore[invalid-argument-type]  # FOLLOWUP-ty-residuals
+        missing = [attr for attr in _REQUIRED_ATTRIBUTES if attr not in repo.attrib]
+        url_element = repo.find("./url")
+        url = url_element.text if url_element is not None else None
+        if missing or not url:
+            if not url:
+                missing.append("url")
+            identifier = repo.attrib.get("alias") or repo.attrib.get("name") or "?"
+            logger.warning(
+                "skipping malformed repository entry '%s': missing %s",
+                identifier,
+                ", ".join(missing),
+            )
+            continue
+        enabled = repo.attrib["enabled"] == "1"
+        repos.add(Repository(repo.attrib["alias"], repo.attrib["name"], url, enabled))
 
     return repos

--- a/tests/target/parsers/test_repository.py
+++ b/tests/target/parsers/test_repository.py
@@ -1,5 +1,7 @@
 """Tests for ``repose.target.parsers.repository.parse_repositories``."""
 
+import logging
+
 import pytest
 
 from repose.target.parsers import Repository
@@ -40,3 +42,81 @@ def test_malformed_xml_raises():
 
     with pytest.raises(ParseError):
         parse_repositories("not <xml")
+
+
+VALID_REPO = (
+    '<repo alias="good" name="Good" enabled="1">'
+    "<url>http://example.com/good/</url></repo>"
+)
+GOOD_REPOSITORY = Repository("good", "Good", "http://example.com/good/", True)
+
+
+def _wrap(repo_elements: str) -> str:
+    return f"<stream><repo-list>{repo_elements}</repo-list></stream>"
+
+
+@pytest.mark.parametrize(
+    "malformed,name_hint,missing_hint",
+    [
+        pytest.param(
+            '<repo name="Bad" enabled="1"><url>http://e</url></repo>',
+            "Bad",
+            "alias",
+            id="missing-alias-attribute",
+        ),
+        pytest.param(
+            '<repo alias="bad" enabled="1"><url>http://e</url></repo>',
+            "bad",
+            "name",
+            id="missing-name-attribute",
+        ),
+        pytest.param(
+            '<repo alias="bad" name="Bad"><url>http://e</url></repo>',
+            "bad",
+            "enabled",
+            id="missing-enabled-attribute",
+        ),
+        pytest.param(
+            '<repo alias="bad" name="Bad" enabled="1"></repo>',
+            "bad",
+            "url",
+            id="missing-url-element",
+        ),
+        pytest.param(
+            '<repo alias="bad" name="Bad" enabled="1"><url/></repo>',
+            "bad",
+            "url",
+            id="empty-url-element",
+        ),
+    ],
+)
+def test_malformed_repo_is_skipped_with_warning(
+    caplog, malformed, name_hint, missing_hint
+):
+    """A malformed <repo> is skipped; well-formed siblings still parse."""
+    xml = _wrap(malformed + VALID_REPO)
+    with caplog.at_level(logging.WARNING, logger="repose.target.parsers.repository"):
+        repos = parse_repositories(xml)
+    assert repos == {GOOD_REPOSITORY}
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert name_hint in message
+    assert missing_hint in message
+
+
+def test_repo_missing_everything_is_skipped(caplog):
+    """A completely empty <repo/> does not abort the parse."""
+    xml = _wrap("<repo/>" + VALID_REPO)
+    with caplog.at_level(logging.WARNING, logger="repose.target.parsers.repository"):
+        repos = parse_repositories(xml)
+    assert repos == {GOOD_REPOSITORY}
+    assert len(caplog.records) == 1
+
+
+def test_empty_url_never_stored_as_none(caplog):
+    """An empty <url/> must not yield a Repository with url=None."""
+    xml = _wrap('<repo alias="a" name="A" enabled="1"><url/></repo>')
+    with caplog.at_level(logging.WARNING, logger="repose.target.parsers.repository"):
+        repos = parse_repositories(xml)
+    assert repos == set()
+    assert len(caplog.records) == 1


### PR DESCRIPTION
## What

parse_repositories read repo.attrib['alias'/'name'/'enabled'] via bare
subscripts and dereferenced repo.find('./url').text without a guard. A
<repo> element missing any of those attributes raised KeyError, and a
missing <url> child raised AttributeError; either exception aborted the
parse, discarding every repository on the host because of one malformed
entry. An empty <url/> was worse: it silently stored url=None, which
later crashed far from the parse site in check_repo_url (None + suffix
-> TypeError, outside the caught exception tuple).

Validate each <repo> element individually: an entry missing a required
attribute or a non-empty <url> is skipped with a single warning naming
the repository (alias when available, falling back to name) and the
missing pieces, while well-formed siblings still parse. A Repository is
never constructed with url=None anymore, which also removes the two
ty-ignore residuals on the construction site.

Regression tests cover each malformed shape (missing alias, name, or
enabled attribute; missing <url>; empty <url/>) alongside a valid
sibling: the valid repository is returned, a warning is logged, and no
exception escapes.

## Verification

Full gate green (ruff format/check, ty, pytest: full suite green, coverage >= 80%). Tests cover each malformed shape (missing alias/name/enabled attribute, missing <url>, empty <url/>) mixed with valid repos: valid siblings parse, one warning per skipped entry, no exception; verified to fail pre-fix. Known limitation (accepted in review): the warning names the repo but not the host — the parser has no host context; host attribution would need a signature change and is left for a follow-up. Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
