### PR TITLE
fix(product): skip malformed product data instead of aborting host parse

### DIFF
--- a/repose/target/parsers/product.py
+++ b/repose/target/parsers/product.py
@@ -3,7 +3,7 @@ import xml.etree.ElementTree as ET
 from typing import Any
 
 from ...connection import Connection
-from ...types.system import System
+from ...types.system import System, UnknownSystemError
 from ..parsers import Product
 
 logger = logging.getLogger("repose.tartget.parsers.product")
@@ -16,10 +16,23 @@ if False:  # TYPE_CHECKING — but cheaper for ty/ruff
     from ...aiossh import AsyncConnection  # noqa: F401
 
 
-def __parse_product(prod: Any) -> tuple[str, str, str]:
+def __parse_product(prod: Any, filename: str) -> tuple[str, str, str] | None:
+    """Parse one ``.prod`` XML stream into ``(name, version, arch)``.
+
+    Returns ``None`` (after logging a single warning naming *filename*
+    and the defect) when the product file is malformed — missing or
+    empty ``<name>``/``<arch>``, or without any usable version element
+    — so callers can decide how to proceed without an opaque exception
+    aborting the parse of the whole host.
+    """
     root = ET.fromstringlist(prod)
-    name = root.find("./name").text  # ty: ignore[unresolved-attribute]  # FOLLOWUP-ty-residuals
-    arch = root.find("./arch").text  # ty: ignore[unresolved-attribute]  # FOLLOWUP-ty-residuals
+    name_element = root.find("./name")
+    arch_element = root.find("./arch")
+    name = name_element.text if name_element is not None else None
+    arch = arch_element.text if arch_element is not None else None
+    if not name or not arch:
+        logger.warning("malformed product file %s: no usable <name>/<arch>", filename)
+        return None
     try:
         version = root.find("./baseversion").text  # ty: ignore[unresolved-attribute]  # FOLLOWUP-ty-residuals
         sp = (
@@ -27,16 +40,23 @@ def __parse_product(prod: Any) -> tuple[str, str, str]:
             if root.find("./patchlevel").text != "0"  # ty: ignore[unresolved-attribute]  # FOLLOWUP-ty-residuals
             else ""
         )
-        version += f"-SP{sp}" if sp else ""  # ty: ignore[unsupported-operator]  # FOLLOWUP-ty-residuals
+        # An empty <baseversion/> parses to None — guard before the
+        # suffix concatenation or the += would raise TypeError.
+        if version and sp:
+            version += f"-SP{sp}"
     except AttributeError:
-        version = root.find("./version").text  # ty: ignore[unresolved-attribute]  # FOLLOWUP-ty-residuals
+        version_element = root.find("./version")
+        version = version_element.text if version_element is not None else None
         logger.debug("simpleversion")
+    if not version:
+        logger.warning("malformed product file %s: no usable version element", filename)
+        return None
 
     # CAASP uses ALL for update repos and there is only one supported version at time
     # can change in tommorow
     if name == "CAASP":
         version = "ALL"
-    return (name, version, arch)  # ty: ignore[invalid-return-type]  # FOLLOWUP-ty-residuals
+    return (name, version, arch)
 
 
 def __parse_os_release(f: Any, hostname: str) -> tuple[str, str, str]:
@@ -122,6 +142,19 @@ async def __detect_transactional_async(connection: Any) -> bool:
 
 
 def parse_system(connection: Connection) -> System:
+    """Detect the host's installed products from ``/etc/products.d``.
+
+    A malformed addon ``.prod`` file is skipped with a warning instead
+    of aborting the parse of the whole host. A baseproduct symlink
+    whose target is not among the listed ``.prod`` files is tolerated:
+    the parse continues and the target is still used as the base
+    product when it can be read.
+
+    Raises:
+        UnknownSystemError: If no base product can be determined — the
+            baseproduct symlink has no target, its target cannot be
+            read, or the baseproduct file itself is malformed.
+    """
     files = []
     try:
         files = [
@@ -144,23 +177,45 @@ def parse_system(connection: Connection) -> System:
         return System(Product(name, version, arch))
 
     basefile = connection.readlink("/etc/products.d/baseproduct")
-    if "/" in basefile:  # ty: ignore[unsupported-operator]  # FOLLOWUP-ty-residuals
-        basefile = basefile.split("/")[-1]  # ty: ignore[unresolved-attribute]  # FOLLOWUP-ty-residuals
-    files.remove(basefile)  # ty: ignore[invalid-argument-type]  # FOLLOWUP-ty-residuals
+    if basefile is None:
+        logger.warning("baseproduct symlink has no target; no baseproduct")
+        raise UnknownSystemError("/etc/products.d/baseproduct symlink did not resolve")
+    if "/" in basefile:
+        basefile = basefile.split("/")[-1]
+    if basefile in files:
+        files.remove(basefile)
+    else:
+        logger.warning(
+            "baseproduct target %s not among the listed .prod files", basefile
+        )
 
-    with connection.open(f"/etc/products.d/{basefile}") as f:
-        logger.debug("Parsing basefile")
-        name, version, arch = __parse_product(f)
-        base = Product(name, version, arch)
+    try:
+        with connection.open(f"/etc/products.d/{basefile}") as f:
+            logger.debug("Parsing basefile")
+            parsed = __parse_product(f, basefile)
+    except OSError as error:
+        logger.warning(
+            "baseproduct target %s could not be read; no baseproduct", basefile
+        )
+        raise UnknownSystemError(
+            f"baseproduct file {basefile} could not be read"
+        ) from error
+    if parsed is None:
+        raise UnknownSystemError(f"baseproduct file {basefile} is malformed")
+    base = Product(*parsed)
 
     addons = set()
 
     for x in files:
         with connection.open(f"/etc/products.d/{x}") as f:
             logger.debug("parsing - %s", x)
-            name, version, arch = __parse_product(f)
-            if name.rpartition("-")[-1] != "migration":
-                addons.add(Product(name, version, arch))
+            parsed = __parse_product(f, x)
+        if parsed is None:
+            # __parse_product already warned with filename and reason.
+            continue
+        name, version, arch = parsed
+        if name.rpartition("-")[-1] != "migration":
+            addons.add(Product(name, version, arch))
     return System(base, addons, transactional=__detect_transactional(connection))
 
 
@@ -176,6 +231,11 @@ async def parse_system_async(connection: Any) -> System:
     ``connection`` is typed as ``Any`` because importing ``AsyncConnection``
     at module load would force asyncssh into the sync paramiko path's
     import graph for zero runtime benefit.
+
+    Raises:
+        UnknownSystemError: If no base product can be determined — the
+            baseproduct symlink has no target, its target cannot be
+            read, or the baseproduct file itself is malformed.
     """
     files: list[str] = []
     try:
@@ -200,22 +260,44 @@ async def parse_system_async(connection: Any) -> System:
         return System(Product(name, version, arch))
 
     basefile = await connection.readlink("/etc/products.d/baseproduct")
-    if "/" in basefile:  # FOLLOWUP-ty-residuals
-        basefile = basefile.split("/")[-1]  # FOLLOWUP-ty-residuals
-    files.remove(basefile)  # FOLLOWUP-ty-residuals
+    if basefile is None:
+        logger.warning("baseproduct symlink has no target; no baseproduct")
+        raise UnknownSystemError("/etc/products.d/baseproduct symlink did not resolve")
+    if "/" in basefile:
+        basefile = basefile.split("/")[-1]
+    if basefile in files:
+        files.remove(basefile)
+    else:
+        logger.warning(
+            "baseproduct target %s not among the listed .prod files", basefile
+        )
 
-    async with connection.open(f"/etc/products.d/{basefile}") as f:
-        logger.debug("Parsing basefile")
-        name, version, arch = __parse_product(f)
-        base = Product(name, version, arch)
+    try:
+        async with connection.open(f"/etc/products.d/{basefile}") as f:
+            logger.debug("Parsing basefile")
+            parsed = __parse_product(f, basefile)
+    except OSError as error:
+        logger.warning(
+            "baseproduct target %s could not be read; no baseproduct", basefile
+        )
+        raise UnknownSystemError(
+            f"baseproduct file {basefile} could not be read"
+        ) from error
+    if parsed is None:
+        raise UnknownSystemError(f"baseproduct file {basefile} is malformed")
+    base = Product(*parsed)
 
     addons = set()
 
     for x in files:
         async with connection.open(f"/etc/products.d/{x}") as f:
             logger.debug("parsing - %s", x)
-            name, version, arch = __parse_product(f)
-            if name.rpartition("-")[-1] != "migration":
-                addons.add(Product(name, version, arch))
+            parsed = __parse_product(f, x)
+        if parsed is None:
+            # __parse_product already warned with filename and reason.
+            continue
+        name, version, arch = parsed
+        if name.rpartition("-")[-1] != "migration":
+            addons.add(Product(name, version, arch))
     transactional = await __detect_transactional_async(connection)
     return System(base, addons, transactional=transactional)

--- a/repose/types/system.py
+++ b/repose/types/system.py
@@ -11,6 +11,10 @@ if TYPE_CHECKING:
     from ..target.parsers import Product
 
 
+class UnknownSystemError(ValueError):
+    """Raised when a host's base product cannot be determined."""
+
+
 @dataclass(frozen=True, slots=True)
 class SystemData:
     """Typed internal storage for System.

--- a/tests/target/parsers/test_product.py
+++ b/tests/target/parsers/test_product.py
@@ -4,9 +4,11 @@ import logging
 from contextlib import asynccontextmanager, contextmanager
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from repose.target.parsers import Product
 from repose.target.parsers.product import parse_system, parse_system_async
-from repose.types.system import System
+from repose.types.system import System, UnknownSystemError
 
 
 def _prod_xml(name, baseversion=None, patchlevel=None, version=None, arch="x86_64"):
@@ -378,3 +380,213 @@ async def test_async_non_suse_without_osrelease_returns_rhel6_default():
 
     system = await parse_system_async(conn)
     assert system.get_base() == Product("rhel", "6", "x86_64")
+
+
+# ---------------------------------------------------------------------------
+# Malformed product data must be skipped, not abort the whole host parse.
+# Regressions for review findings N7 (missing <name>/<arch> raised
+# AttributeError), N8 (files.remove(basefile) raised ValueError when the
+# baseproduct target was not a listed .prod file) and v1 #24 (readlink
+# returning None raised TypeError).
+# ---------------------------------------------------------------------------
+
+_BASE_XML = _prod_xml("SLES", baseversion="15", patchlevel="3")
+_ADDON_XML = _prod_xml("sle-module-basesystem", version="15.3")
+
+# Raw byte literals below: _prod_xml cannot omit <name>/<arch> or emit
+# self-closing empty elements, which is exactly what these shapes need.
+_MALFORMED_PRODS = [
+    pytest.param(
+        b"<product><arch>x86_64</arch><version>1.0</version></product>",
+        id="missing-name",
+    ),
+    pytest.param(
+        b"<product><name>bad</name><version>1.0</version></product>",
+        id="missing-arch",
+    ),
+    pytest.param(
+        b"<product><name/><arch>x86_64</arch><version>1.0</version></product>",
+        id="empty-name",
+    ),
+    pytest.param(
+        b"<product><name>bad</name><arch>x86_64</arch></product>",
+        id="missing-version",
+    ),
+    pytest.param(
+        b"<product><name>bad</name><arch>x86_64</arch>"
+        b"<baseversion/><patchlevel>3</patchlevel></product>",
+        id="empty-baseversion-with-patchlevel",
+    ),
+    pytest.param(
+        b"<product><name>bad</name><arch>x86_64</arch>"
+        b"<baseversion/><patchlevel>0</patchlevel></product>",
+        id="empty-baseversion-patchlevel-zero",
+    ),
+]
+
+
+@pytest.mark.parametrize("bad", _MALFORMED_PRODS)
+def test_malformed_addon_prod_is_skipped(bad):
+    """One malformed .prod skips that file only; siblings still parse."""
+    conn = _make_connection(
+        files=["SLES.prod", "module.prod", "bad.prod"],
+        basefile="SLES.prod",
+        file_contents={
+            "/etc/products.d/SLES.prod": _BASE_XML,
+            "/etc/products.d/module.prod": _ADDON_XML,
+            "/etc/products.d/bad.prod": bad,
+        },
+    )
+
+    system = parse_system(conn)
+
+    assert system.get_base() == Product("SLES", "15-SP3", "x86_64")
+    assert system.get_addons() == {Product("sle-module-basesystem", "15.3", "x86_64")}
+
+
+def test_malformed_baseproduct_raises_unknown_system_error():
+    """A malformed baseproduct cannot yield a System — specific error."""
+    conn = _make_connection(
+        files=["SLES.prod"],
+        basefile="SLES.prod",
+        file_contents={
+            "/etc/products.d/SLES.prod": b"<product><arch>x86_64</arch></product>",
+        },
+    )
+
+    with pytest.raises(UnknownSystemError):
+        parse_system(conn)
+
+
+def test_baseproduct_target_not_in_prod_files_is_tolerated():
+    """A baseproduct target missing from the .prod list must not abort."""
+    conn = _make_connection(
+        files=["module.prod"],
+        basefile="SLES.sav",  # filtered out by the .endswith('.prod') listing
+        file_contents={
+            "/etc/products.d/SLES.sav": _BASE_XML,
+            "/etc/products.d/module.prod": _ADDON_XML,
+        },
+    )
+
+    system = parse_system(conn)
+
+    assert system.get_base() == Product("SLES", "15-SP3", "x86_64")
+    assert system.get_addons() == {Product("sle-module-basesystem", "15.3", "x86_64")}
+
+
+def test_dangling_baseproduct_symlink_raises_unknown_system_error():
+    """A baseproduct symlink whose target file is gone fails clean.
+
+    The open of the resolved target raises FileNotFoundError; that must
+    surface as UnknownSystemError, not abort the parse with an opaque
+    error.
+    """
+    conn = _make_connection(
+        files=["module.prod"],
+        basefile="SLES.prod.old",  # readlink resolves, but the file is gone
+        file_contents={"/etc/products.d/module.prod": _ADDON_XML},
+    )
+
+    with pytest.raises(UnknownSystemError):
+        parse_system(conn)
+
+
+def test_malformed_addon_logs_single_warning_naming_file(caplog):
+    """One malformed addon emits exactly one warning, with the filename."""
+    conn = _make_connection(
+        files=["SLES.prod", "bad.prod"],
+        basefile="SLES.prod",
+        file_contents={
+            "/etc/products.d/SLES.prod": _BASE_XML,
+            "/etc/products.d/bad.prod": b"<product><arch>x86_64</arch></product>",
+        },
+    )
+
+    with caplog.at_level(logging.WARNING):
+        parse_system(conn)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "bad.prod" in warnings[0].getMessage()
+
+
+def test_readlink_none_raises_unknown_system_error():
+    """An unresolvable baseproduct symlink fails clean, not TypeError."""
+    conn = _make_connection(
+        files=["SLES.prod"],
+        basefile=None,
+        file_contents={"/etc/products.d/SLES.prod": _BASE_XML},
+    )
+
+    with pytest.raises(UnknownSystemError):
+        parse_system(conn)
+
+
+@pytest.mark.parametrize("bad", _MALFORMED_PRODS)
+async def test_async_malformed_addon_prod_is_skipped(bad):
+    conn = _make_async_connection(
+        files=["SLES.prod", "module.prod", "bad.prod"],
+        basefile="SLES.prod",
+        file_contents={
+            "/etc/products.d/SLES.prod": _BASE_XML,
+            "/etc/products.d/module.prod": _ADDON_XML,
+            "/etc/products.d/bad.prod": bad,
+        },
+    )
+
+    system = await parse_system_async(conn)
+
+    assert system.get_base() == Product("SLES", "15-SP3", "x86_64")
+    assert system.get_addons() == {Product("sle-module-basesystem", "15.3", "x86_64")}
+
+
+async def test_async_malformed_baseproduct_raises_unknown_system_error():
+    conn = _make_async_connection(
+        files=["SLES.prod"],
+        basefile="SLES.prod",
+        file_contents={
+            "/etc/products.d/SLES.prod": b"<product><arch>x86_64</arch></product>",
+        },
+    )
+
+    with pytest.raises(UnknownSystemError):
+        await parse_system_async(conn)
+
+
+async def test_async_baseproduct_target_not_in_prod_files_is_tolerated():
+    conn = _make_async_connection(
+        files=["module.prod"],
+        basefile="SLES.sav",
+        file_contents={
+            "/etc/products.d/SLES.sav": _BASE_XML,
+            "/etc/products.d/module.prod": _ADDON_XML,
+        },
+    )
+
+    system = await parse_system_async(conn)
+
+    assert system.get_base() == Product("SLES", "15-SP3", "x86_64")
+    assert system.get_addons() == {Product("sle-module-basesystem", "15.3", "x86_64")}
+
+
+async def test_async_dangling_baseproduct_symlink_raises_unknown_system_error():
+    conn = _make_async_connection(
+        files=["module.prod"],
+        basefile="SLES.prod.old",  # readlink resolves, but the file is gone
+        file_contents={"/etc/products.d/module.prod": _ADDON_XML},
+    )
+
+    with pytest.raises(UnknownSystemError):
+        await parse_system_async(conn)
+
+
+async def test_async_readlink_none_raises_unknown_system_error():
+    conn = _make_async_connection(
+        files=["SLES.prod"],
+        basefile=None,
+        file_contents={"/etc/products.d/SLES.prod": _BASE_XML},
+    )
+
+    with pytest.raises(UnknownSystemError):
+        await parse_system_async(conn)


### PR DESCRIPTION
## What

parse_system and parse_system_async turned one bad product entry on a
host into a failed product parse for the whole host, four ways: a
.prod file missing (or with empty) <name>/<arch>, or lacking both
<baseversion> and <version>, raised an uncaught AttributeError from
__parse_product; an empty <baseversion/> alongside a <patchlevel>
element raised TypeError from the "-SP" suffix concatenation;
files.remove(basefile) raised ValueError when the resolved baseproduct
symlink basename was not among the listed .prod files (target not
ending in .prod, pointing elsewhere, or deleted); and
readlink('/etc/products.d/baseproduct') returning None (both backends
are annotated str | None) made "'/' in basefile" raise TypeError.

__parse_product now returns None after a single warning naming the
file and the defect, and the addon loop skips just that file. When no
base product can be determined — an unresolvable baseproduct symlink,
a baseproduct target that cannot be opened (dangling symlink), or a
malformed baseproduct file — raise the existing, specific
UnknownSystemError instead of an opaque exception. A baseproduct
target missing from the .prod listing is tolerated: the parse
continues and the target is still used as the base product when
readable. Sync and async paths stay line-for-line mirrors; regression
tests cover each shape on both backends.

Note: open PR #188 reworks the os-release half of this same file (untouched here); whichever merges second needs a small rebase — and #188 removes the `UnknownSystemError` class this branch still uses for its no-baseproduct path, so the second rebase must reconcile that (I'll provide it).

## Verification

Full gate green (ruff format/check, ty, pytest: 568 passed, coverage 82.94%). Regression tests (sync and async) cover: .prod missing <name>/<arch>, empty <baseversion/> with <patchlevel> (previously an uncaught TypeError), unlisted and dangling baseproduct symlinks (previously ValueError / uncaught FileNotFoundError), and readlink returning None; one warning per malformed file (caplog-pinned). All verified to fail pre-fix. Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
