### PR TITLE
fix(resolver): raise ValueError with context for unresolvable REPAs

### DIFF
--- a/repose/template/resolver.py
+++ b/repose/template/resolver.py
@@ -29,7 +29,11 @@ class Repoq:
         """.. returns needed repositories for REPA
         ::param:: orepa - instance of Repa object
         ::param:: base -- System.get_base()
-        ::return:: {release-file:[(name, url, refresh-state,),]}"""
+        ::return:: {release-file:[(name, url, refresh-state,),]}
+        ::raises:: ValueError when the REPA cannot be resolved (unknown
+        product or version, missing template key such as
+        ``default_repos``, or an unknown ``$placeholder`` in a repo URL)
+        """
         repa = deepcopy(orepa)
         if repa.product not in self.template:
             candidates = get_close_matches(
@@ -62,25 +66,31 @@ class Repoq:
         # used by for example QA:SLE projects
         shortversion = version.replace("-", "")
 
-        if repa.repo:
-            logger.debug("Return data for %s - %s", name, repa.repo)
-            url = Template(
-                subtemplate.get(repa.repo, {"url": "http://empty.url"})["url"]
-            ).substitute(version=version, arch=repa.arch, shortver=shortversion)
-            rname = name + repa.repo
-            refresh = subtemplate.get(repa.repo, {}).get("enabled", False)
-            result[repa.product] = [Repos(rname, url, refresh)]
-        else:
-            rlist = []
-            for x in subtemplate["default_repos"]:
-                logger.debug("Return data for %s - %s", name, x)
+        try:
+            if repa.repo:
+                logger.debug("Return data for %s - %s", name, repa.repo)
                 url = Template(
-                    subtemplate.get(x, {"url": "http://empty.url"})["url"]
+                    subtemplate.get(repa.repo, {"url": "http://empty.url"})["url"]
                 ).substitute(version=version, arch=repa.arch, shortver=shortversion)
-                rname = name + x
-                refresh = subtemplate.get(x, {}).get("enabled", False)
-                rlist.append(Repos(rname, url, refresh))
-            result[repa.product] = rlist
+                rname = name + repa.repo
+                refresh = subtemplate.get(repa.repo, {}).get("enabled", False)
+                result[repa.product] = [Repos(rname, url, refresh)]
+            else:
+                rlist = []
+                for x in subtemplate["default_repos"]:
+                    logger.debug("Return data for %s - %s", name, x)
+                    url = Template(
+                        subtemplate.get(x, {"url": "http://empty.url"})["url"]
+                    ).substitute(version=version, arch=repa.arch, shortver=shortversion)
+                    rname = name + x
+                    refresh = subtemplate.get(x, {}).get("enabled", False)
+                    rlist.append(Repos(rname, url, refresh))
+                result[repa.product] = rlist
+        except KeyError as error:
+            raise ValueError(
+                f"Cannot resolve REPA {name}{repa.repo or ''}: "
+                f"missing template key or URL placeholder {error}"
+            ) from error
 
         return result
 

--- a/tests/command/test_install.py
+++ b/tests/command/test_install.py
@@ -7,6 +7,8 @@ from conftest import ImmediateExecutor
 
 import repose.command._command
 from repose.command.install import Install
+from repose.target.parsers import Product
+from repose.template.resolver import Repoq
 from repose.types.repa import Repa
 
 
@@ -411,6 +413,43 @@ def test_install_two_repas_same_product_keeps_all_repos(monkeypatch, mock_ssh_cl
     )
     assert expected_a in issued, "repos from the first REPA must be retained"
     assert expected_b in issued, "repos from the second REPA must be retained"
+
+
+def test_install_command_unresolvable_repa_logged_not_crashed(
+    monkeypatch, mock_args_and_repa, caplog, mock_ssh_client
+):
+    """A template KeyError (unknown URL placeholder) must surface via
+    the worker's ValueError handler as a logged error, not escape into
+    the future as a bare KeyError that is never reported."""
+    args, _ = mock_args_and_repa
+    args.repa = [Repa("SLES:15-SP3:x86_64:update")]
+
+    template = {
+        "SLES": {
+            "15-SP3": {
+                "default_repos": ["update"],
+                "update": {
+                    "url": "http://example.com/$releasever/upd",
+                    "enabled": True,
+                },
+            },
+        },
+    }
+
+    target, _, repoq = _setup_install(monkeypatch, args, {})
+    # Deltas from the helper's defaults: a real base product, and the
+    # real resolver behind the mock so the actual KeyError -> ValueError
+    # mapping is exercised end to end.
+    target.products.get_base.return_value = Product("SLES", "15-SP3", "x86_64")
+    repoq.solve_repa.side_effect = Repoq(template).solve_repa
+
+    with caplog.at_level("ERROR", logger="repose.command.install"):
+        # Unresolvable repa, no products → single host fails → exit 2.
+        assert Install(args).run() == 2
+
+    assert any("releasever" in r.message for r in caplog.records), (
+        "the unresolvable REPA must be reported to the operator"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/template/test_resolver.py
+++ b/tests/template/test_resolver.py
@@ -139,6 +139,71 @@ def test_missing_repo_in_template_yields_empty_url(repoq, base):
     assert repo.refresh is False
 
 
+def test_unknown_placeholder_in_repo_url_raises_valueerror(base):
+    """An unknown ``$placeholder`` in a repo URL must raise ValueError
+    naming the REPA and the placeholder, not a bare KeyError."""
+    template = {
+        "SLES": {
+            "15-SP3": {
+                "default_repos": ["update"],
+                "update": {
+                    "url": "http://example.com/$releasever/upd",
+                    "enabled": True,
+                },
+            },
+        },
+    }
+    repa = Repa("SLES:15-SP3:x86_64:update")
+    with pytest.raises(ValueError) as exc:
+        Repoq(template).solve_repa(repa, base)
+    msg = str(exc.value)
+    assert "SLES:15-SP3::update" in msg
+    assert "releasever" in msg
+
+
+def test_unknown_placeholder_in_default_repos_raises_valueerror(base):
+    """The default_repos expansion path must also map KeyError from
+    Template.substitute to a contextful ValueError."""
+    template = {
+        "SLES": {
+            "15-SP3": {
+                "default_repos": ["update"],
+                "update": {
+                    "url": "http://example.com/$basearch/upd",
+                    "enabled": True,
+                },
+            },
+        },
+    }
+    repa = Repa("SLES:15-SP3:x86_64:")
+    with pytest.raises(ValueError) as exc:
+        Repoq(template).solve_repa(repa, base)
+    msg = str(exc.value)
+    assert "SLES:15-SP3::" in msg
+    assert "basearch" in msg
+
+
+def test_missing_default_repos_raises_valueerror(base):
+    """A template entry without ``default_repos`` must raise ValueError
+    naming the REPA and the missing key, not a bare KeyError."""
+    template = {
+        "SLES": {
+            "15-SP3": {
+                "update": {
+                    "url": "http://example.com/$version/$arch/upd",
+                    "enabled": True,
+                },
+            },
+        },
+    }
+    repa = Repa("SLES:15-SP3:x86_64:")
+    with pytest.raises(ValueError) as exc:
+        Repoq(template).solve_repa(repa, base)
+    msg = str(exc.value)
+    assert "SLES:15-SP3::" in msg
+    assert "default_repos" in msg
+
+
 def test_solve_product_happy_path(repoq):
     base = Product("SLES", "15-SP3", "x86_64")
     system = System(base)


### PR DESCRIPTION
## What

solve_repa expanded repo URLs with Template(...).substitute(version,
arch, shortver) and read subtemplate['default_repos'] with a bare
subscript, with no try/except. Any URL placeholder other than the
three provided (e.g. zypper-style $releasever or $basearch) and any
template entry lacking default_repos raised KeyError instead of
ValueError.

Callers only catch ValueError (e.g. the install worker logs it and
marks the host failed), so the KeyError escaped into the worker
future, where _aggregate counts it as a failure without re-raising or
logging: the command exited non-zero with no explanation of which
REPA failed or why, and under the thread pool the operator saw no
error at all.

Wrap the repo-expansion block in try/except KeyError and re-raise as
ValueError naming the REPA and the missing key or placeholder,
mirroring how solve_product maps the same KeyError to
UnsuportedProductMessage. Callers' existing ValueError handling now
reports the failure cleanly. Regression tests cover the unknown
placeholder (specific-repo and default_repos paths), the missing
default_repos key, and the install worker logging the error instead
of crashing.

## Verification

Full gate green (ruff format/check, ty, pytest: 551 passed, coverage 82.52%). Unit tests: templates with a missing URL placeholder or missing default_repos raise ValueError naming the REPA and key. A caller-level test drives the install worker end-to-end through the real resolver and asserts the failure is logged and reported instead of crashing the command. Verified to fail pre-fix. Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
