### PR TITLE
fix(template): handle empty or non-mapping products.yml cleanly

### DIFF
--- a/repose/cli.py
+++ b/repose/cli.py
@@ -27,7 +27,7 @@ from repose import __version__
 from repose.colorlog import create_logger
 from repose.command import Command
 from repose.host import ParseHosts
-from repose.template import load_template
+from repose.template import TemplateError, load_template
 from repose.types.connection_config import ConnectionConfig
 from repose.types.repa import Repa
 
@@ -158,8 +158,9 @@ def _complete_repa(ctx: typer.Context, incomplete: str) -> list[str]:
     (``:VERSION:ARCH:REPO``) are left to free-form user input.
 
     Any failure to read or parse the YAML — missing file, permission
-    error, malformed YAML — collapses to an empty completion list so
-    the user's shell never raises mid-keystroke.
+    error, malformed YAML, non-mapping top level — collapses to an
+    empty completion list so the user's shell never raises
+    mid-keystroke.
     """
     # The root callback populates ``ctx.obj``; during completion it
     # has typically already run. Fall back gracefully if not.
@@ -171,7 +172,7 @@ def _complete_repa(ctx: typer.Context, incomplete: str) -> list[str]:
         config_path = Path("/etc/repose/products.yml")
     try:
         template = load_template(config_path)
-    except (OSError, YAMLError):
+    except (OSError, ValueError, YAMLError):
         return []
     # Only complete the first ``:``-separated segment (product name).
     # If the user has already typed past a colon, return nothing so we
@@ -247,6 +248,11 @@ def _dispatch(name: str, ns: argparse.Namespace) -> int:
         if ns.debug:
             raise
         logger.error("invalid YAML in config: %s", e)
+        return 2
+    except TemplateError as e:
+        if ns.debug:
+            raise
+        logger.error("invalid config: %s", e)
         return 2
     except KeyboardInterrupt:
         logger.error("interrupted")

--- a/repose/template/__init__.py
+++ b/repose/template/__init__.py
@@ -5,9 +5,28 @@ from typing import Any
 from ruamel.yaml import YAML
 
 
+class TemplateError(ValueError):
+    """The products template file is structurally invalid.
+
+    Raised by :func:`load_template` when the top-level YAML node is not
+    a mapping. Subclasses ``ValueError`` so broad handlers keep working,
+    while letting ``repose.cli._dispatch`` translate it into a friendly
+    one-liner without also swallowing unrelated ``ValueError``s raised
+    deep inside command execution (e.g. unresolvable REPAs or host
+    repository read failures).
+    """
+
+
 @functools.cache
 def load_template(path: Path) -> dict[str, Any]:
     """Load and return the products YAML template file.
+
+    An empty or comment-only file loads as ``None`` and is normalized
+    to an empty mapping so consumers can iterate ``.keys()``/``.items()``
+    without a ``None`` guard. Any other non-mapping top level (e.g. a
+    YAML sequence or a bare scalar) is a configuration error and raises
+    :class:`TemplateError` instead of surfacing later as
+    ``AttributeError``.
 
     The result is cached for the lifetime of the process keyed by
     ``path``. This is safe for the CLI (one invocation = one process)
@@ -20,8 +39,19 @@ def load_template(path: Path) -> dict[str, Any]:
         path: Path to the products YAML configuration file.
 
     Returns:
-        Dictionary mapping product names to their template definitions.
+        Dictionary mapping product names to their template definitions;
+        empty if the file has no YAML content.
+
+    Raises:
+        TemplateError: If the file's top-level YAML node is not a
+            mapping.
     """
     with path.open(mode="r", encoding="utf-8") as f:
-        template: dict[str, Any] = YAML(typ="safe").load(f)
+        template = YAML(typ="safe").load(f)
+    if template is None:
+        return {}
+    if not isinstance(template, dict):
+        raise TemplateError(
+            f"template {path} must be a YAML mapping, got {type(template).__name__}"
+        )
     return template

--- a/tests/command/test_known.py
+++ b/tests/command/test_known.py
@@ -6,6 +6,7 @@ import pytest
 import repose.command._command
 import repose.command.known
 from repose.command.known import KnownProducts
+from repose.template import TemplateError
 
 
 @pytest.fixture
@@ -37,6 +38,69 @@ def test_known_products_command(monkeypatch, mock_args):
     known_command.display.list_known_products.assert_called_once_with(
         ["product-a", "product-b", "product-c"]
     )
+
+
+def test_known_products_empty_template_lists_nothing(monkeypatch, mock_args, tmp_path):
+    """An empty products.yml yields a clean, empty listing (exit 0).
+
+    Regression: safe-YAML loads an empty file as ``None``; before
+    ``load_template`` normalized it to ``{}``, ``template.keys()``
+    raised ``AttributeError`` and the command died with a traceback.
+    Uses the real ``load_template`` on a real empty file on purpose.
+    """
+    empty = tmp_path / "products.yml"
+    empty.write_text("")
+    mock_args.config = empty
+    monkeypatch.setattr(repose.command._command, "HostGroup", MagicMock())
+
+    known_command = KnownProducts(mock_args)
+    known_command.display = MagicMock()
+
+    assert known_command.run() == 0
+    known_command.display.list_known_products.assert_called_once_with([])
+
+
+def test_known_products_comment_only_template_lists_nothing(
+    monkeypatch, mock_args, tmp_path
+):
+    """A comment-only products.yml also yields a clean, empty listing.
+
+    Same regression as the empty-file case: safe-YAML loads a
+    comment-only document as ``None``.
+    """
+    comments = tmp_path / "products.yml"
+    comments.write_text("# no products defined yet\n")
+    mock_args.config = comments
+    monkeypatch.setattr(repose.command._command, "HostGroup", MagicMock())
+
+    known_command = KnownProducts(mock_args)
+    known_command.display = MagicMock()
+
+    assert known_command.run() == 0
+    known_command.display.list_known_products.assert_called_once_with([])
+
+
+def test_known_products_non_mapping_template_raises_template_error(
+    monkeypatch, mock_args, tmp_path
+):
+    """A top-level-sequence products.yml raises ``TemplateError``.
+
+    The command layer propagates it untouched so ``repose.cli._dispatch``
+    can translate it into the one-line config error + exit 2 (covered
+    end to end by ``test_friendly_message_on_non_mapping_config`` in
+    ``tests/test_cli.py``).
+    """
+    listy = tmp_path / "products.yml"
+    listy.write_text("- SLES\n- openSUSE-Leap\n")
+    mock_args.config = listy
+    monkeypatch.setattr(repose.command._command, "HostGroup", MagicMock())
+
+    known_command = KnownProducts(mock_args)
+    known_command.display = MagicMock()
+
+    with pytest.raises(TemplateError, match="must be a YAML mapping, got list"):
+        known_command.run()
+    known_command.display.list_known_products.assert_not_called()
 
 
 def test_known_products_format_json_end_to_end(monkeypatch, mock_args, capsys):

--- a/tests/template/test_loader.py
+++ b/tests/template/test_loader.py
@@ -3,7 +3,7 @@
 import pytest
 from ruamel.yaml import YAML
 
-from repose.template import load_template
+from repose.template import TemplateError, load_template
 
 
 YAML_FIXTURE = """\
@@ -31,6 +31,42 @@ def test_load_template_returns_dict(tmp_path):
 def test_load_template_missing_file_raises(tmp_path):
     with pytest.raises(FileNotFoundError):
         load_template(tmp_path / "missing.yml")
+
+
+def test_load_template_empty_file_returns_empty_dict(tmp_path):
+    """An empty products.yml loads as ``{}``, not ``None``.
+
+    ``YAML(typ='safe').load`` returns ``None`` for a file with no YAML
+    content; consumers call ``.keys()``/``.items()`` on the result, so
+    ``load_template`` must normalize to an empty mapping.
+    """
+    path = tmp_path / "products.yml"
+    path.write_text("")
+
+    assert load_template(path) == {}
+
+
+def test_load_template_comment_only_file_returns_empty_dict(tmp_path):
+    """A comment-only products.yml also loads as ``{}``."""
+    path = tmp_path / "products.yml"
+    path.write_text("# no products defined yet\n# another comment\n")
+
+    assert load_template(path) == {}
+
+
+def test_load_template_top_level_sequence_raises_template_error(tmp_path):
+    """A top-level YAML sequence is rejected with a clear error.
+
+    Without the guard the list travels to consumers and crashes far
+    from the parse site with ``AttributeError`` on ``.keys()``. The
+    exception is a ``TemplateError`` (a ``ValueError`` subclass) so
+    ``repose.cli._dispatch`` can translate exactly this failure.
+    """
+    path = tmp_path / "products.yml"
+    path.write_text("- SLES\n- openSUSE-Leap\n")
+
+    with pytest.raises(TemplateError, match="must be a YAML mapping, got list"):
+        load_template(path)
 
 
 def test_load_template_caches(tmp_path, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -566,6 +566,29 @@ def test_friendly_message_on_yaml_error(monkeypatch, caplog):
     assert "invalid yaml" in caplog.text.lower()
 
 
+def test_friendly_message_on_non_mapping_config(tmp_path, caplog):
+    """A list-shaped products.yml gets the one-liner + exit 2, end to end.
+
+    Regression: ``load_template`` raises ``TemplateError`` for a
+    non-mapping top level, but ``_dispatch`` only translated
+    ``FileNotFoundError``/``PermissionError``/``IsADirectoryError``/
+    ``YAMLError`` — the new exception escaped every real command as a
+    raw traceback (exit 1) while malformed YAML got the friendly
+    treatment. Uses the real loader on a real file on purpose.
+    """
+    listy = tmp_path / "products.yml"
+    listy.write_text("- SLES\n- openSUSE-Leap\n")
+
+    with caplog.at_level("ERROR", logger="repose.cli"):
+        result = runner.invoke(app, ["-c", str(listy), "known-products"])
+
+    assert result.exit_code == 2
+    assert not isinstance(result.exception, ValueError), (
+        "the config error must be translated, not raised as a traceback"
+    )
+    assert "must be a YAML mapping" in caplog.text
+
+
 def test_debug_propagates_traceback(monkeypatch):
     """With ``--debug``, the original exception is re-raised intact so
     contributors see the full stack instead of the friendly summary."""

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -128,6 +128,41 @@ def test_repa_complete_malformed_yaml_returns_empty(tmp_path: Path) -> None:
     assert _complete_repa(ctx, "") == []
 
 
+def test_repa_complete_empty_config_returns_empty(tmp_path: Path) -> None:
+    """An empty products.yml collapses to an empty completion list.
+
+    Regression: safe-YAML loads an empty file as ``None``; before the
+    ``load_template`` normalization, ``template.keys()`` raised
+    ``AttributeError`` past the ``except (OSError, YAMLError)`` guard,
+    crashing the completion callback mid-keystroke.
+    """
+    empty = tmp_path / "empty.yml"
+    empty.write_text("")
+    ctx = _StubCtx(obj=_make_globals(empty))
+    assert _complete_repa(ctx, "") == []
+
+
+def test_repa_complete_comment_only_config_returns_empty(tmp_path: Path) -> None:
+    """A comment-only products.yml also collapses to an empty list."""
+    comments = tmp_path / "comments.yml"
+    comments.write_text("# nothing here yet\n")
+    ctx = _StubCtx(obj=_make_globals(comments))
+    assert _complete_repa(ctx, "") == []
+
+
+def test_repa_complete_non_mapping_config_returns_empty(tmp_path: Path) -> None:
+    """A top-level YAML sequence collapses to an empty list.
+
+    Regression: ``load_template`` now raises ``ValueError`` for a
+    non-mapping top level; the callback must swallow it like the other
+    parse failures rather than raising in the user's shell.
+    """
+    listy = tmp_path / "list.yml"
+    listy.write_text("- SLES\n- openSUSE-Leap\n")
+    ctx = _StubCtx(obj=_make_globals(listy))
+    assert _complete_repa(ctx, "") == []
+
+
 def test_repa_complete_no_ctx_obj_uses_default_path() -> None:
     """When ``ctx.obj`` is missing, the helper falls back to the default
     ``/etc/repose/products.yml``; if that file is unreadable, return [].


### PR DESCRIPTION
## What

load_template returned YAML(typ='safe').load(f) verbatim: an empty or
comment-only products.yml loads as None and a top-level sequence loads
as a list. Both crash consumers far from the parse site with
AttributeError on .keys()/.items():

- the REPA shell-completion callback _complete_repa promises that any
  config failure collapses to an empty completion list, but it only
  caught OSError/YAMLError, so the AttributeError escaped into the
  user's shell mid-keystroke;
- KnownProducts._srun aborted 'repose known-products' with a raw
  traceback instead of a clean empty listing.

Fix at the source: load_template now normalizes None to {} so an
empty or comment-only template means 'no products' everywhere, and
raises TemplateError (a ValueError subclass) naming the offending
type for any other non-mapping top level. _dispatch translates
TemplateError into the same one-line error + exit 2 that the other
config-load failures (missing file, permission denied, YAMLError)
already get, so every command fails cleanly instead of with a raw
traceback; subclassing keeps unrelated ValueErrors raised during
command execution (unresolvable REPAs, host repository read
failures) out of that handler. _complete_repa additionally swallows
ValueError so a malformed template still collapses to empty
completions. known-products with an empty template now lists nothing
and exits 0.

Regression tests, all failing on the pre-fix code: the loader and
the completion callback each cover the empty, comment-only and
top-level-sequence templates; known-products covers empty and
comment-only (clean empty listing, exit 0) plus the sequence case
(TemplateError propagates out of run() for _dispatch to translate);
a CLI-level test drives known-products end to end with a list-shaped
products.yml and asserts the one-line error + exit 2 with no
traceback.

Note: this branch and the `fix(cli)` no-color branch from this batch both touch `repose/cli.py` and will conflict; either order merges with a trivial rebase, which I'll provide.

## Verification

Full gate green (ruff format/check, ty, pytest: 557 passed, coverage 82.53%). Tests at three layers: loader (empty / comment-only / sequence), completion (collapses to empty), known-products (empty / comment-only / sequence), plus a CLI end-to-end test asserting a list-shaped products.yml gets the clean one-liner and exit 2 instead of a traceback. The non-mapping error is a dedicated TemplateError (ValueError subclass) so _dispatch does not mislabel unrelated ValueErrors. Verified to fail pre-fix. Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
