### PR TITLE
fix(clear): skip zypper rr when the host has no repositories

### DIFF
--- a/repose/command/clear.py
+++ b/repose/command/clear.py
@@ -14,8 +14,18 @@ class Clear(Command, name="clear"):
         return set(r.alias for r in self.targets[host].raw_repos)
 
     def _run(self, host: str, update: UpdateFn) -> bool:
+        """Remove every repository from ``host`` via ``zypper rr``.
+
+        A host without any repositories is an INFO-level no-op, not an
+        error: issuing the command anyway would produce a bare
+        ``zypper -n rr`` that zypper rejects with a non-zero exit.
+        """
         update(host, "clearing repos")
         repoaliases = self._clear(host)
+
+        if not repoaliases:
+            logger.info("No repositories to clear from %s", host)
+            return True
 
         if self.dryrun:
             self.console.dry(host, self.rrcmd.format(repos=shlex.join(repoaliases)))
@@ -26,8 +36,13 @@ class Clear(Command, name="clear"):
         return True
 
     async def _arun_one(self, host: str, update: UpdateFn) -> bool:
+        """Async sibling of ``_run`` with the same no-repos no-op guard."""
         update(host, "clearing repos")
         repoaliases = self._clear(host)
+
+        if not repoaliases:
+            logger.info("No repositories to clear from %s", host)
+            return True
 
         if self.dryrun:
             self.console.dry(host, self.rrcmd.format(repos=shlex.join(repoaliases)))

--- a/repose/command/reset.py
+++ b/repose/command/reset.py
@@ -50,6 +50,12 @@ class Reset(Clear, name="reset"):
     def _run(self, host: str, update: UpdateFn) -> bool:
         update(host, "clearing repos")
         repoaliases = self._clear(host)
+        # A host whose current repo list is empty has nothing to clear;
+        # issuing the removal anyway would produce a bare ``zypper -n rr``
+        # that zypper rejects with a non-zero exit. Skip the ``rr`` step
+        # and proceed straight to re-adding the replacement repos.
+        if not repoaliases:
+            logger.info("No repositories to clear from %s", host)
         ok = True
         try:
             update(host, "resolving new repos")
@@ -80,15 +86,19 @@ class Reset(Clear, name="reset"):
                 return False
 
             if self.dryrun:
-                self.console.dry(host, self.rrcmd.format(repos=shlex.join(repoaliases)))
+                if repoaliases:
+                    self.console.dry(
+                        host, self.rrcmd.format(repos=shlex.join(repoaliases))
+                    )
                 for cmd in cmds:
                     self.console.dry(host, cmd)
                 return True
 
             update(host, f"re-adding {len(cmds)} repo(s)")
-            self.targets[host].run(self.rrcmd.format(repos=shlex.join(repoaliases)))
-            if not self._report_target(host):
-                ok = False
+            if repoaliases:
+                self.targets[host].run(self.rrcmd.format(repos=shlex.join(repoaliases)))
+                if not self._report_target(host):
+                    ok = False
             for cmd in cmds:
                 self.targets[host].run(cmd)
                 if not self._report_target(host):
@@ -130,6 +140,9 @@ class Reset(Clear, name="reset"):
     async def _arun_one(self, host: str, update: UpdateFn) -> bool:
         update(host, "clearing repos")
         repoaliases = self._clear(host)
+        # Same no-repos guard as ``_run``: never issue a bare ``zypper rr``.
+        if not repoaliases:
+            logger.info("No repositories to clear from %s", host)
         ok = True
         try:
             update(host, "resolving new repos")
@@ -160,17 +173,21 @@ class Reset(Clear, name="reset"):
                 return False
 
             if self.dryrun:
-                self.console.dry(host, self.rrcmd.format(repos=shlex.join(repoaliases)))
+                if repoaliases:
+                    self.console.dry(
+                        host, self.rrcmd.format(repos=shlex.join(repoaliases))
+                    )
                 for cmd in cmds:
                     self.console.dry(host, cmd)
                 return True
 
             update(host, f"re-adding {len(cmds)} repo(s)")
-            await self.targets[host].run(
-                self.rrcmd.format(repos=shlex.join(repoaliases))
-            )
-            if not self._report_target(host):
-                ok = False
+            if repoaliases:
+                await self.targets[host].run(
+                    self.rrcmd.format(repos=shlex.join(repoaliases))
+                )
+                if not self._report_target(host):
+                    ok = False
             for cmd in cmds:
                 await self.targets[host].run(cmd)
                 if not self._report_target(host):

--- a/tests/command/test_clear.py
+++ b/tests/command/test_clear.py
@@ -1,6 +1,6 @@
 import concurrent.futures
 from argparse import Namespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from conftest import ImmediateExecutor
@@ -123,7 +123,13 @@ def test_clear_command_dryrun_json_format(monkeypatch, capsys, mock_ssh_client):
     assert "repo1" in payload["cmd"]
 
 
-def test_clear_command_empty_repos(monkeypatch, mock_ssh_client):
+def test_clear_command_empty_repos_skips_rr(monkeypatch, caplog, mock_ssh_client):
+    """A host without repositories is an INFO-level no-op.
+
+    Issuing the command anyway would run a bare ``zypper -n rr`` (no
+    argument), which zypper rejects with a non-zero exit — so no command
+    must be run and the host must still be reported ok.
+    """
     args = Namespace(
         dry=False,
         target=[{"user@host1": MagicMock()}],
@@ -145,11 +151,62 @@ def test_clear_command_empty_repos(monkeypatch, mock_ssh_client):
         MagicMock(return_value=mock_hg),
     )
 
+    with caplog.at_level("INFO", logger="repose.command.clear"):
+        assert Clear(args).run() == 0
+
+    mock_target.run.assert_not_called()
+    assert any("No repositories to clear" in r.message for r in caplog.records)
+
+
+def test_clear_command_mixed_hosts_skips_only_empty(monkeypatch, mock_ssh_client):
+    """Only the repo-less host is skipped; the other still gets ``rr``."""
+    args = Namespace(
+        dry=False,
+        target=[{"h1": MagicMock(), "h2": MagicMock()}],
+        repa=None,
+        config="dummy_config",
+        yaml=False,
+    )
+    t1 = MagicMock()
+    t1.raw_repos = [MockRawRepo("h1-repo")]
+    t2 = MagicMock()
+    t2.raw_repos = []
+    targets = {"h1": t1, "h2": t2}
+
+    mock_hg = MagicMock()
+    mock_hg.keys.return_value = ["h1", "h2"]
+    mock_hg.__getitem__.side_effect = lambda k: targets[k]
+
+    monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr(
+        repose.command._command,
+        "HostGroup",
+        MagicMock(return_value=mock_hg),
+    )
+
     assert Clear(args).run() == 0
 
-    # rr command still issued, just with empty repos list
-    cmd = mock_target.run.call_args[0][0]
-    assert cmd.startswith("zypper -n rr")
+    assert t1.run.call_args[0][0] == "zypper -n rr h1-repo"
+    t2.run.assert_not_called()
+
+
+async def test_clear_arun_one_empty_repos_skips_rr(mock_args, caplog):
+    """Async ``_arun_one`` must mirror the sync no-repos no-op guard."""
+    mock_args.ssh_backend = "asyncssh"
+    clear = Clear(mock_args)
+
+    target = MagicMock()
+    target.raw_repos = []
+    target.run = AsyncMock()
+
+    clear.targets = {"user@host1": target}
+
+    with caplog.at_level("INFO", logger="repose.command.clear"):
+        ok = await clear._arun_one("user@host1", lambda host, msg: None)
+
+    assert ok is True
+    target.run.assert_not_awaited()
+    assert any("No repositories to clear" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/command/test_reset.py
+++ b/tests/command/test_reset.py
@@ -124,7 +124,11 @@ def _setup_reset(
 
     mock_target = MagicMock()
     mock_target.products = products or [MockProduct("SLES", "15-SP4")]
-    mock_target.raw_repos = raw_repos or [MockRawRepo("existing-repo1")]
+    # ``raw_repos=[]`` is meaningful (host without repos) — only ``None``
+    # falls back to the default.
+    if raw_repos is None:
+        raw_repos = [MockRawRepo("existing-repo1")]
+    mock_target.raw_repos = raw_repos
     mock_target.out = out if out is not None else _ok_out()
 
     mock_hg = MagicMock()
@@ -376,6 +380,104 @@ def test_reset_dryrun_predicts_partial_drop_abort(
         assert Reset(mock_args).run() == 2
     target.run.assert_not_called()
     assert any("bad" in r.getMessage() for r in caplog.records)
+
+
+def test_reset_empty_current_repos_skips_rr_still_adds(
+    monkeypatch, mock_args, caplog, mock_ssh_client
+):
+    """A host whose current repo list is empty must not issue a bare ``rr``.
+
+    Pre-fix the removal step ran as ``zypper -n rr`` with no argument,
+    which zypper rejects non-zero, so the exit-code classifier reported
+    the no-op host as failed. The replacement repos must still be added
+    and the host reported ok.
+    """
+    target, _, _ = _setup_reset(
+        monkeypatch,
+        mock_args,
+        repoq_solution={"product": [MockRepo("repo1", "http://r1", refresh=False)]},
+        raw_repos=[],
+    )
+
+    with caplog.at_level("INFO", logger="repose.command.reset"):
+        assert Reset(mock_args).run() == 0
+
+    run_calls = target.run.call_args_list
+    assert len(run_calls) == 1
+    assert run_calls[0][0][0].startswith("zypper -n ar")
+    assert any("No repositories to clear" in r.message for r in caplog.records)
+
+
+def test_reset_dryrun_empty_current_repos_skips_rr_preview(
+    monkeypatch, mock_args, capsys, mock_ssh_client
+):
+    """``--dry`` on a repo-less host must not preview a bare ``zypper -n rr``.
+
+    The dry-run must predict the real run, which skips the removal step
+    entirely and only adds the replacement repos.
+    """
+    mock_args.dry = True
+    target, _, _ = _setup_reset(
+        monkeypatch,
+        mock_args,
+        repoq_solution={"product": [MockRepo("repo1", "http://r1", refresh=False)]},
+        raw_repos=[],
+    )
+
+    assert Reset(mock_args).run() == 0
+
+    target.run.assert_not_called()
+    out = capsys.readouterr().out
+    assert "zypper -n rr" not in out
+    assert "zypper -n ar" in out
+
+
+async def test_reset_arun_one_empty_current_repos_skips_rr(mock_args, caplog):
+    """Async ``_arun_one`` must mirror the sync no-current-repos guard."""
+    mock_args.ssh_backend = "asyncssh"
+    reset = Reset(mock_args)
+
+    target = MagicMock()
+    target.raw_repos = []
+    target.out = _ok_out()
+    target.run = AsyncMock()
+
+    reset.targets = {"user@host1": target}
+    reset._aadd = AsyncMock(
+        return_value=({"zypper -n ar -ckn repo1 http://r1 repo1"}, [])
+    )
+
+    with caplog.at_level("INFO", logger="repose.command.reset"):
+        ok = await reset._arun_one("user@host1", lambda host, msg: None)
+
+    assert ok is True
+    assert target.run.await_count == 1
+    assert target.run.await_args_list[0][0][0].startswith("zypper -n ar")
+    assert any("No repositories to clear" in r.message for r in caplog.records)
+
+
+async def test_reset_arun_one_dryrun_empty_current_repos_skips_rr_preview(mock_args):
+    """Async dry-run must mirror the sync guard: no bare ``rr`` preview."""
+    mock_args.ssh_backend = "asyncssh"
+    mock_args.dry = True
+    reset = Reset(mock_args)
+    reset.console = MagicMock()
+
+    target = MagicMock()
+    target.raw_repos = []
+    target.out = _ok_out()
+    target.run = AsyncMock()
+
+    reset.targets = {"user@host1": target}
+    ar_cmd = "zypper -n ar -ckn repo1 http://r1 repo1"
+    reset._aadd = AsyncMock(return_value=({ar_cmd}, []))
+
+    ok = await reset._arun_one("user@host1", lambda host, msg: None)
+
+    assert ok is True
+    target.run.assert_not_awaited()
+    previews = [c.args[1] for c in reset.console.dry.call_args_list]
+    assert previews == [ar_cmd]
 
 
 async def test_arun_one_aborts_on_partial_probe_drop(mock_args, caplog):


### PR DESCRIPTION
## What

Clear._clear() returns an empty set for a host with no repositories,
and rrcmd.format(repos=' '.join(set())) then issues a bare
"zypper -n rr" with no argument, which zypper rejects with a non-zero
exit. Clear never inspects that exit (it does not call _report_target
and returns True unconditionally), so its pre-fix symptom was a
malformed command executed on the host while the run still reported
the host ok and exited 0; the zypper error was visible only in the
recorded per-command output at verbose logging.

Reset inherits _clear() and hits the same shape with a real failure:
it runs the bare rr through _report_target, whose exit-code classifier
treats the non-zero exit as failure, so a host whose current repo list
is empty was reported failed even though the replacement repos were
added fine.

Mirror the guard remove.py already has: when the repo list is empty,
skip issuing the removal entirely, log an INFO-level no-op, and keep
the host ok. In reset the rr step (and its dry-run preview) is skipped
while the replacement repos are still resolved and added. Both sync
and async twins are fixed.

Regression tests cover clear (sync, async, and mixed hosts where only
the repo-less host is skipped) and reset (sync and async, both the
real rr step and the dry-run preview); all fail on the pre-fix code.

Note: this branch and `fix(clear)` from the same batch both touch `repose/command/clear.py` and `reset.py` and will conflict pairwise; either order merges with a trivial rebase, which I'll provide.

## Verification

Full gate green (ruff format/check, ty, pytest: 553 passed, coverage 83.01%). Tests: clear on a repo-less host issues no zypper rr and stays ok (sync + async); reset's real and dry-run paths skip the bare rr preview for an empty repo list (mutation-verified: reverting the dry-run guards fails exactly the new tests). Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
