### PR TITLE
fix(mangen): tolerate malformed SOURCE_DATE_EPOCH

### DIFF
--- a/repose/mangen.py
+++ b/repose/mangen.py
@@ -31,9 +31,11 @@ Reproducibility: the ``.TH`` header stamps a date. We pin it via
 ``SOURCE_DATE_EPOCH`` (reproducible-builds standard) so ``uv run
 repose-mangen`` is byte-stable across machines and dates; CI uses this
 to catch drift via ``git diff --exit-code``. If callers already export
-``SOURCE_DATE_EPOCH`` (e.g. distro builds), their value wins.
+``SOURCE_DATE_EPOCH`` (e.g. distro builds), their value wins; malformed
+values are warned about and ignored as if the variable were unset.
 """
 
+import logging
 import os
 import textwrap
 import time
@@ -47,6 +49,8 @@ import typer
 
 from repose import __version__
 from repose.cli import app
+
+logger = logging.getLogger("repose.mangen")
 
 # Fallback epoch (UTC ``2024-01-01 00:00:00``) used when callers
 # haven't already exported ``SOURCE_DATE_EPOCH``. Pinning a constant
@@ -379,32 +383,53 @@ def _wrap(text: str) -> str:
     return "\n".join(_neutralize_leading(line) for line in wrapped.split("\n"))
 
 
+def _source_date_epoch() -> int:
+    """Return ``SOURCE_DATE_EPOCH`` as a usable int, tolerating bad values.
+
+    Per the reproducible-builds convention, a malformed value (empty,
+    non-integer, or out of range for the platform's timestamp type, e.g.
+    a leaked nanosecond epoch) is warned about and ignored: generation
+    proceeds as if the variable were unset, using the pinned fallback
+    epoch. The ``time.gmtime`` probe rejects values ``int()`` accepts
+    but the later strftime conversion would crash on (OverflowError or
+    OSError, platform-dependent).
+    """
+    raw = os.environ.get("SOURCE_DATE_EPOCH", _FALLBACK_SOURCE_DATE_EPOCH)
+    try:
+        epoch = int(raw)
+        time.gmtime(epoch)
+    except (ValueError, OverflowError, OSError):
+        logger.warning(
+            "Ignoring malformed SOURCE_DATE_EPOCH %r; using fallback %s",
+            raw,
+            _FALLBACK_SOURCE_DATE_EPOCH,
+        )
+        return int(_FALLBACK_SOURCE_DATE_EPOCH)
+    return epoch
+
+
 def _th_date() -> str:
     """Return the ``.TH`` date string from ``SOURCE_DATE_EPOCH``."""
-    epoch = int(os.environ.get("SOURCE_DATE_EPOCH", _FALLBACK_SOURCE_DATE_EPOCH))
-    return time.strftime("%Y-%m-%d", time.gmtime(epoch))
+    return time.strftime("%Y-%m-%d", time.gmtime(_source_date_epoch()))
 
 
 @contextmanager
 def _pinned_source_date() -> Iterator[None]:
-    """Temporarily set ``SOURCE_DATE_EPOCH`` if unset, restore on exit.
+    """Temporarily pin ``SOURCE_DATE_EPOCH`` to a usable value.
 
-    Caller-provided values take precedence — distro builds frequently
-    export this from a changelog timestamp and we don't want to clobber
-    that.
+    Usable caller-provided values take precedence — distro builds
+    frequently export this from a changelog timestamp and we don't want
+    to clobber that. Resolving (and, for a present-but-malformed value,
+    warning) happens exactly once per run here; the per-page
+    ``_th_date()`` calls then parse the validated value silently. The
+    prior value is restored on exit.
     """
-    had_value = "SOURCE_DATE_EPOCH" in os.environ
     prior = os.environ.get("SOURCE_DATE_EPOCH")
-    if not had_value:
-        os.environ["SOURCE_DATE_EPOCH"] = _FALLBACK_SOURCE_DATE_EPOCH
+    os.environ["SOURCE_DATE_EPOCH"] = str(_source_date_epoch())
     try:
         yield
     finally:
-        if had_value:
-            # ``had_value`` is True iff the key was present at entry,
-            # which means ``prior`` was bound to ``os.environ[...]``
-            # and is therefore ``str`` (never ``None``).
-            assert prior is not None
+        if prior is not None:
             os.environ["SOURCE_DATE_EPOCH"] = prior
         else:
             os.environ.pop("SOURCE_DATE_EPOCH", None)

--- a/tests/test_mangen.py
+++ b/tests/test_mangen.py
@@ -15,6 +15,7 @@ edit that strips the enriched sections, should fail here rather than
 silently shipping unhelpful pages.
 """
 
+import logging
 from pathlib import Path
 
 import click
@@ -160,6 +161,88 @@ def test_th_header_uses_pinned_date_and_version(man_dir: Path):
     from repose import __version__
 
     assert f'"{__version__}"' in first
+
+
+# Date rendered from _FALLBACK_SOURCE_DATE_EPOCH (2024-01-01T00:00:00Z).
+# Hardcoded (not derived from the constant) so an accidental edit to the
+# constant or the strftime format fails here instead of tracking along.
+_FALLBACK_DATE = "2024-01-01"
+
+# int()-parseable but unusable epochs: a nanosecond-epoch leak (e.g.
+# ``date +%s%N``) raises OSError in time.gmtime on Linux, and a value
+# beyond time_t raises OverflowError.
+_OUT_OF_RANGE_EPOCHS = ["1704067200000000000", "99999999999999999999"]
+
+
+@pytest.mark.parametrize("bad", ["", "abc", "12.5", *_OUT_OF_RANGE_EPOCHS])
+def test_malformed_source_date_epoch_warns_and_falls_back(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, bad: str
+):
+    """Regression: a bad SOURCE_DATE_EPOCH used to abort generation.
+
+    ``_pinned_source_date`` only injected the fallback when the variable
+    was entirely absent, so a present-but-empty or non-integer value
+    reached ``int()`` unguarded (ValueError), and an int-parseable but
+    out-of-range value crashed ``time.gmtime()`` (OverflowError/OSError).
+    The reproducible-builds convention is to warn and ignore invalid
+    values, behaving exactly as if the variable were unset.
+    """
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", bad)
+    with caplog.at_level(logging.WARNING, logger="repose.mangen"):
+        assert mangen._th_date() == _FALLBACK_DATE
+    assert any("SOURCE_DATE_EPOCH" in rec.message for rec in caplog.records)
+
+
+def test_absent_source_date_epoch_falls_back(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+    assert mangen._th_date() == _FALLBACK_DATE
+
+
+@pytest.mark.parametrize("bad", ["", "abc", *_OUT_OF_RANGE_EPOCHS])
+def test_invalid_epoch_behaves_exactly_like_absent(
+    monkeypatch: pytest.MonkeyPatch, bad: str
+):
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+    absent = mangen._th_date()
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", bad)
+    assert mangen._th_date() == absent
+
+
+def test_valid_source_date_epoch_wins(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1750000000")  # 2025-06-15 UTC
+    with caplog.at_level(logging.WARNING, logger="repose.mangen"):
+        assert mangen._th_date() == "2025-06-15"
+    assert not caplog.records
+
+
+def test_malformed_epoch_warns_once_per_run(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """The malformed-value warning fires once per run, not once per page.
+
+    ``main()`` renders ~10 pages inside one ``_pinned_source_date``
+    block; resolution (and the warning) must happen there exactly once,
+    with every per-page ``_th_date()`` reusing the validated value.
+    """
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "garbage")
+    with caplog.at_level(logging.WARNING, logger="repose.mangen"):
+        with mangen._pinned_source_date():
+            for _ in range(3):
+                assert mangen._th_date() == _FALLBACK_DATE
+    warnings = [r for r in caplog.records if "SOURCE_DATE_EPOCH" in r.message]
+    assert len(warnings) == 1
+
+
+def test_generation_proceeds_with_malformed_epoch(monkeypatch: pytest.MonkeyPatch):
+    """A full page renders (rather than crashing) under a bad value."""
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "garbage")
+    cli = typer.main.get_command(app)
+    with mangen._pinned_source_date():
+        root_ctx = click.Context(cli, info_name="repose")
+        page = mangen._render_page("repose", "repose", root_ctx)
+    assert page.startswith(f'.TH "REPOSE" "1" "{_FALLBACK_DATE}"')
 
 
 def test_leading_control_chars_are_neutralized(man_dir: Path):


### PR DESCRIPTION
## What

_th_date() parsed SOURCE_DATE_EPOCH with a bare int(), and
_pinned_source_date() only injects the pinned fallback when the
variable is entirely absent. A present-but-empty or non-integer value
(SOURCE_DATE_EPOCH="" or "abc", as distro build wrappers sometimes
leak) therefore reached int() unguarded, raised ValueError, and
aborted repose-mangen before a single page was written. Values that
int() accepts but the timestamp conversion cannot represent (e.g. a
leaked nanosecond epoch from date +%s%N, or anything beyond time_t)
crashed the same way inside time.gmtime() with a platform-dependent
OverflowError or OSError.

The reproducible-builds convention is to warn about an invalid
SOURCE_DATE_EPOCH and ignore it. Guard the single parse site in a new
_source_date_epoch() helper: parse and probe time.gmtime() inside one
try block, and on ValueError, OverflowError, or OSError log a warning
and fall back to the pinned epoch, so any unusable value behaves
exactly like an unset variable and generation proceeds.

_pinned_source_date(), entered once per run by main(), now resolves
the epoch up front and pins the validated value into the environment,
so the warning fires once per run instead of once per rendered page
(~10 times), and the per-page parses reuse the validated value.

Regression tests cover empty, garbage, float-like, and out-of-range
values (warn and fall back), absent (fallback date), a valid epoch
(wins, no warning), invalid-equals-absent equivalence, warn-once-per-
run, and that a full page still renders under a malformed value.
Expected dates are hardcoded literals ("2024-01-01", "2025-06-15") so
an accidental edit to the fallback constant or the strftime format
fails the tests instead of tracking along.

## Verification

Full gate green (ruff format/check, ty, pytest: 560 passed, coverage 82.62%). Tests: empty, non-integer, and out-of-range values (nanosecond epochs, 20-digit values) all behave exactly like an absent variable, warn once per run (was ~10x), and generation proceeds; expected dates are hardcoded literals. Verified to fail pre-fix. Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
