### PR TITLE
fix(mangen): prune orphaned man pages for removed subcommands

### DIFF
--- a/repose/mangen.py
+++ b/repose/mangen.py
@@ -3,7 +3,9 @@
 Walks the Typer/Click app object and emits one ``.1`` man page per
 command into ``docs/man/``. The output is committed to the repo so
 downstream packagers don't need any man-gen tooling at build time; a CI
-job regenerates and ``git diff --exit-code``s to catch drift.
+job regenerates and ``git diff --exit-code``s to catch drift. Stale
+``repose-<sub>.1`` pages of renamed/removed subcommands are pruned after
+generation so they surface as deletions in that diff.
 
 This module hand-builds the roff itself rather than delegating to
 ``click_man.core.write_man_pages`` (the ``click-man`` package), which
@@ -37,6 +39,7 @@ values are warned about and ignored as if the variable were unset.
 
 import logging
 import os
+import sys
 import textwrap
 import time
 from contextlib import contextmanager
@@ -612,16 +615,48 @@ def _render_page(command_name: str, page_name: str, ctx: click.Context) -> str:
     return page
 
 
-def main() -> None:
-    """Regenerate ``docs/man/repose*.1`` from the Typer app."""
-    out = Path(__file__).resolve().parent.parent / "docs" / "man"
+def _prune_orphaned_pages(out: Path, generated: set[str]) -> None:
+    """Delete ``repose-<sub>.1`` pages that this run did not generate.
+
+    Pages of renamed or removed subcommands would otherwise linger
+    forever: the CI drift gate is ``git diff --exit-code -- docs/man/``,
+    which cannot flag a stale tracked file that nothing rewrites.
+    Deleting orphans turns them into a deletion in ``git diff`` that the
+    gate catches. Only files matching the ``repose-*.1`` naming scheme
+    are candidates; ``repose.1`` and unrelated files are never touched.
+
+    Each deletion is announced on stderr: ``repose-mangen`` never
+    configures ``logging`` (only the Typer CLI callback does), so a
+    ``logger.info`` here would be silently dropped on every real
+    invocation.
+
+    Args:
+        out: Directory the pages were generated into.
+        generated: File names (not paths) written by this run.
+    """
+    for page in out.glob("repose-*.1"):
+        if page.name not in generated and page.is_file():
+            print(f"Removing orphaned man page {page}", file=sys.stderr)
+            page.unlink()
+
+
+def main(out_dir: Path | None = None) -> None:
+    """Regenerate ``docs/man/repose*.1`` from the Typer app.
+
+    Args:
+        out_dir: Directory to write the pages into. Defaults to the
+            repository's ``docs/man`` directory.
+    """
+    out = out_dir or Path(__file__).resolve().parent.parent / "docs" / "man"
     out.mkdir(parents=True, exist_ok=True)
     cli = cast(click.Command, typer.main.get_command(app))
 
+    generated: set[str] = set()
     with _pinned_source_date():
         # Root page.
         root_ctx = click.Context(cli, info_name="repose")
         (out / "repose.1").write_text(_render_page("repose", "repose", root_ctx))
+        generated.add("repose.1")
 
         # One page per subcommand.
         commands = getattr(cli, "commands", {})
@@ -632,6 +667,9 @@ def main() -> None:
             page_name = f"repose {name}"
             path = out / f"{page_name.replace(' ', '-')}.1"
             path.write_text(_render_page(name, page_name, ctx))
+            generated.add(path.name)
+
+    _prune_orphaned_pages(out, generated)
 
 
 if __name__ == "__main__":

--- a/tests/test_mangen.py
+++ b/tests/test_mangen.py
@@ -245,6 +245,46 @@ def test_generation_proceeds_with_malformed_epoch(monkeypatch: pytest.MonkeyPatc
     assert page.startswith(f'.TH "REPOSE" "1" "{_FALLBACK_DATE}"')
 
 
+def test_main_prunes_orphaned_subcommand_pages(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Regression: pages of removed/renamed subcommands are deleted.
+
+    ``main`` used to only write pages for currently-registered commands,
+    so a page like ``repose-oldcmd.1`` left behind by a rename lingered
+    untouched — invisible to the ``git diff --exit-code -- docs/man/``
+    CI drift gate. Pruning turns the orphan into a deletion the gate
+    catches, and each deletion is announced on stderr (repose-mangen
+    never configures logging, so a logger call would be silent).
+    """
+    stale = tmp_path / "repose-oldcmd.1"
+    stale.write_text('.TH "REPOSE OLDCMD" "1"\n')
+
+    mangen.main(tmp_path)
+
+    assert not stale.exists(), "orphaned repose-oldcmd.1 was not pruned"
+    err = capsys.readouterr().err
+    assert "repose-oldcmd.1" in err, "deletion must be announced on stderr"
+
+
+def test_main_prune_spares_root_page_and_unrelated_files(tmp_path: Path):
+    """Pruning only targets ``repose-<sub>.1``; everything else survives.
+
+    ``repose.1`` (the root page, regenerated every run) and files not
+    matching the naming scheme must never be deleted.
+    """
+    unrelated = tmp_path / "notes.1"
+    unrelated.write_text("not a repose page\n")
+
+    mangen.main(tmp_path)
+
+    assert unrelated.exists(), "non-matching file was wrongly deleted"
+    assert (tmp_path / "repose.1").exists(), "root page missing after prune"
+    for name in SUBCOMMANDS:
+        page = tmp_path / f"repose-{name}.1"
+        assert page.exists(), f"generated page {page.name} missing after prune"
+
+
 def test_leading_control_chars_are_neutralized(man_dir: Path):
     """No rendered text line may start with a bare ``.`` or ``'``.
 


### PR DESCRIPTION
## What

main() wrote docs/man/repose-<name>.1 only for currently-registered
commands and never removed pages of renamed or deleted subcommands.
The CI drift gate is 'git diff --exit-code -- docs/man/', which cannot
notice a stale tracked file that nothing rewrites, so renaming or
dropping a subcommand shipped a green CI while the committed man-page
set no longer matched the CLI.

After generating, delete repose-*.1 files in the output directory that
were not produced by this run. Only files matching the
repose-<sub>.1 naming scheme are candidates; repose.1 and unrelated
files are never touched. An orphaned page now shows up as a deletion
in git diff, which the drift gate catches. Each deletion is announced
on stderr: repose-mangen never configures logging (only the Typer CLI
callback does), so a logger call would be silently dropped on every
real invocation. main() gains an optional out_dir parameter so tests
can drive the full generate-and-prune path against a temp directory.

## Verification

Full gate green (ruff format/check, ty, pytest: 549 passed, coverage 83.06%). Tests: a stray repose-oldcmd.1 is pruned (announced on stderr — mangen configures no logging, so the notice uses print like the rest of main()) while repose.1, generated pages, and non-matching files survive. Verified to fail pre-fix. Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
