### PR TITLE
fix(cli): honor --no-color and NO_COLOR in log output

### DIFF
--- a/repose/cli.py
+++ b/repose/cli.py
@@ -14,6 +14,7 @@ test. The shim is surgical and matches the layout this PR replaces.
 
 import argparse
 import logging
+import os
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -418,8 +419,13 @@ def main_callback(
 
     # Configure root logger level from -d/-q. This used to live in
     # ``main.py`` after parsing; the Typer port relocates it here
-    # because the callback runs before any subcommand body.
-    root_logger = create_logger("repose")
+    # because the callback runs before any subcommand body. The log
+    # formatter honors --no-color and the NO_COLOR environment
+    # variable (https://no-color.org: present and non-empty, the same
+    # truthy check ``Console._use_color`` applies) so redirected log
+    # output stays free of ANSI escapes.
+    log_no_color = no_color or bool(os.environ.get("NO_COLOR"))
+    root_logger = create_logger("repose", no_color=log_no_color)
     if debug:
         root_logger.setLevel("DEBUG")
     elif quiet:

--- a/repose/colorlog.py
+++ b/repose/colorlog.py
@@ -54,8 +54,32 @@ class ColorFormatter(logging.Formatter):
         return logging.Formatter.format(self, record)
 
 
-def create_logger(name: str | None = None, level: str = "INFO") -> Logger:
-    """Return the named (or root) logger with a color handler installed.
+class PlainFormatter(logging.Formatter):
+    """``ColorFormatter``'s message layout without escape sequences.
+
+    Attached instead of :class:`ColorFormatter` when color output is
+    disabled (``--no-color`` or the ``NO_COLOR`` environment variable),
+    so logs redirected to files or non-ANSI terminals stay clean. The
+    line layout is preserved: lowercased level name, plus the
+    ``[module:function]`` origin tag on DEBUG records (sourced from the
+    record's logger name, which repose names after the module).
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format ``record`` with a decorated but color-free levelname."""
+        if self._fmt and self._fmt.find("%(levelname)") >= 0:
+            levelname = record.levelname.lower()
+            if record.levelname == "DEBUG":
+                levelname += f" [{record.name!s}:{record.funcName!s}]"
+            record.levelname = levelname
+
+        return logging.Formatter.format(self, record)
+
+
+def create_logger(
+    name: str | None = None, level: str = "INFO", no_color: bool = False
+) -> Logger:
+    """Return a logger with a stream handler and repose's log format.
 
     Handler installation is idempotent: if the logger already has a
     handler, no new one is added. Without this guard, every invocation
@@ -65,8 +89,11 @@ def create_logger(name: str | None = None, level: str = "INFO") -> Logger:
     emitted once per accumulated handler.
 
     Args:
-        name: Logger name; the root logger is used when omitted.
-        level: Logging level name to set on the logger.
+        name: Logger to configure; the root logger when omitted.
+        level: Initial log level name (e.g. ``"INFO"``).
+        no_color: When ``True``, attach a :class:`PlainFormatter` so no
+            ANSI escape sequences are emitted; otherwise attach the
+            default :class:`ColorFormatter`.
 
     Returns:
         The configured :class:`logging.Logger`.
@@ -75,7 +102,7 @@ def create_logger(name: str | None = None, level: str = "INFO") -> Logger:
     out.setLevel(level)
     if not out.handlers:
         handler = logging.StreamHandler()
-        formatter = ColorFormatter("%(levelname)s: %(message)s")
-        handler.setFormatter(formatter)
+        formatter_cls = PlainFormatter if no_color else ColorFormatter
+        handler.setFormatter(formatter_cls("%(levelname)s: %(message)s"))
         out.addHandler(handler)
     return out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ SSH host-key transport globals. Where the old tests inspected an
 ``CliRunner``.
 """
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -156,6 +157,71 @@ def test_no_color_sets_true(mock_registry):
     result = runner.invoke(app, ["--no-color", "add", "-t", "h", "x"])
     assert result.exit_code == 0, result.stderr
     assert _ns(mock_registry, "add").no_color is True
+
+
+@pytest.fixture
+def repose_logger(monkeypatch):
+    """Isolate the ``repose`` logger for one CLI invocation.
+
+    ``main_callback`` attaches a fresh handler per invocation; clearing
+    the handler list first makes ``handlers[-1]`` the one installed by
+    the invocation under test, and teardown restores the prior state.
+    ``NO_COLOR`` is unset so only the test controls the color decision.
+    """
+    lg = logging.getLogger("repose")
+    saved_handlers = lg.handlers[:]
+    saved_level = lg.level
+    lg.handlers = []
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    yield lg
+    lg.handlers = saved_handlers
+    lg.setLevel(saved_level)
+
+
+def _log_record(levelname: str = "WARNING", msg: str = "boom") -> logging.LogRecord:
+    return logging.LogRecord(
+        name="repose.cli",
+        level=getattr(logging, levelname),
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
+
+
+def test_no_color_flag_log_output_has_no_ansi(mock_registry, repose_logger):
+    result = runner.invoke(app, ["--no-color", "known-products"])
+    assert result.exit_code == 0, result.stderr
+    formatted = repose_logger.handlers[-1].format(_log_record())
+    assert "\x1b" not in formatted
+    assert formatted == "warning: boom"
+
+
+def test_no_color_env_log_output_has_no_ansi(mock_registry, repose_logger, monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    result = runner.invoke(app, ["known-products"])
+    assert result.exit_code == 0, result.stderr
+    formatted = repose_logger.handlers[-1].format(_log_record())
+    assert "\x1b" not in formatted
+
+
+def test_no_color_env_empty_string_keeps_ansi(
+    mock_registry, repose_logger, monkeypatch
+):
+    """NO_COLOR="" does not disable color (no-color.org: non-empty only)."""
+    monkeypatch.setenv("NO_COLOR", "")
+    result = runner.invoke(app, ["known-products"])
+    assert result.exit_code == 0, result.stderr
+    formatted = repose_logger.handlers[-1].format(_log_record())
+    assert "\x1b[1;33m" in formatted
+
+
+def test_color_on_log_output_keeps_ansi(mock_registry, repose_logger):
+    result = runner.invoke(app, ["known-products"])
+    assert result.exit_code == 0, result.stderr
+    formatted = repose_logger.handlers[-1].format(_log_record())
+    assert "\x1b[1;33m" in formatted
 
 
 def test_format_default_text(mock_registry):

--- a/tests/test_colorlog.py
+++ b/tests/test_colorlog.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from repose.colorlog import COLORS, ColorFormatter, create_logger
+from repose.colorlog import COLORS, ColorFormatter, PlainFormatter, create_logger
 
 
 def _record(levelname="INFO", msg="hello"):
@@ -87,3 +87,46 @@ def test_create_logger_twice_emits_record_once(capsys):
         for handler in list(logger.handlers):
             logger.removeHandler(handler)
     assert capsys.readouterr().err.count("emitted-once") == 1
+
+
+def test_plain_formatter_emits_no_escape_sequences():
+    fmt = PlainFormatter("%(levelname)s: %(message)s")
+    out = fmt.format(_record("WARNING", "warn"))
+    assert "\x1b" not in out
+    assert out == "warning: warn"
+
+
+def test_plain_formatter_debug_keeps_origin_tag_without_ansi():
+    record = logging.LogRecord(
+        name="repose.test",
+        level=logging.DEBUG,
+        pathname=__file__,
+        lineno=1,
+        msg="dbg",
+        args=(),
+        exc_info=None,
+        func="my_func",
+    )
+    fmt = PlainFormatter("%(levelname)s: %(message)s")
+    out = fmt.format(record)
+    assert "\x1b" not in out
+    assert out == "debug [repose.test:my_func]: dbg"
+
+
+def test_plain_formatter_without_levelname_token_passes_through():
+    fmt = PlainFormatter("%(message)s")
+    out = fmt.format(_record("INFO", "plain"))
+    assert out == "plain"
+
+
+def test_create_logger_no_color_attaches_plain_formatter():
+    logger = create_logger("repose.test.nocolor", no_color=True)
+    formatted = logger.handlers[-1].format(_record("ERROR", "boom"))
+    assert "\x1b" not in formatted
+    assert formatted == "error: boom"
+
+
+def test_create_logger_default_attaches_color_formatter():
+    logger = create_logger("repose.test.color")
+    formatted = logger.handlers[-1].format(_record("ERROR", "boom"))
+    assert "\x1b[1;31m" in formatted


### PR DESCRIPTION
## What

The --no-color option is documented as disabling ANSI color in
console output (honoring the NO_COLOR convention), and the
command-layer Console respects it, but main_callback always
installed a ColorFormatter on the 'repose' logger. Every log
record was decorated with color sequences plus a \033[2K
clear-line escape, with no check of the flag or the environment.

Running e.g. 'NO_COLOR=1 repose --no-color add ... 2> log.txt'
therefore wrote raw escapes ('\033[2K\033[1;33mwarning\033[0m
...') into the redirected file, contradicting the option's
contract and corrupting output on non-ANSI terminals.

Resolve the no-color decision in main_callback (--no-color flag,
or NO_COLOR present and non-empty per https://no-color.org --
the same truthy check the Console applies, so an empty NO_COLOR
leaves both log and console color untouched) and thread it into
create_logger, which now attaches a PlainFormatter when color is
off: the same line layout as ColorFormatter (lowercased level
name, [module:function] origin tag on DEBUG records) with zero
escape sequences. The color-on path keeps ColorFormatter
unchanged.

Note: this branch and the other `fix(cli)` logger branch from this batch both touch `repose/colorlog.py`/`repose/cli.py` and will conflict pairwise; either order merges with a trivial rebase, which I'll provide.

## Verification

Full gate green (ruff format/check, ty, pytest: 556 passed, coverage 82.57%). Tests: --no-color and non-empty NO_COLOR yield zero escape sequences in log output; empty NO_COLOR keeps color (matching no-color.org and the Console's existing truthy check); color-on path byte-identical. Verified to fail pre-fix. Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
