### PR TITLE
fix(types): stop sharing SystemData addon set by reference

### DIFF
--- a/repose/types/system.py
+++ b/repose/types/system.py
@@ -19,14 +19,22 @@ class UnknownSystemError(ValueError):
 class SystemData:
     """Typed internal storage for System.
 
+    ``addons`` is snapshotted into a ``frozenset`` on construction, so
+    later mutation of the iterable passed by the caller cannot alter
+    this record.
+
     ``transactional`` marks an immutable / transactional-update host (SL
     Micro, SLE Micro, MicroOS): package operations must go through
     ``transactional-update`` and a reboot, rather than direct ``zypper``.
     """
 
     base: Product
-    addons: set[Product]
+    addons: frozenset[Product]
     transactional: bool = False
+
+    def __post_init__(self) -> None:
+        """Defensively copy ``addons`` so the frozen record owns its state."""
+        object.__setattr__(self, "addons", frozenset(self.addons))
 
 
 @dataclass(eq=False)
@@ -55,7 +63,7 @@ class System:
         """
         self._data = SystemData(
             base=base,
-            addons=addons if addons else set(),
+            addons=frozenset(addons) if addons else frozenset(),
             transactional=transactional,
         )
 
@@ -111,7 +119,11 @@ class System:
     # __ne__ is automatically derived from __eq__ in Python 3 — no override needed.
 
     def get_addons(self) -> set[Product]:
-        return self._data.addons
+        """Return a fresh copy of the addon products.
+
+        Mutating the returned set does not affect this ``System``.
+        """
+        return set(self._data.addons)
 
     def get_base(self) -> Product:
         return self._data.base

--- a/tests/types/test_system.py
+++ b/tests/types/test_system.py
@@ -105,3 +105,37 @@ def test_flatten_returns_base_plus_addons():
     addon = make_addon()
     s = System(base, addons={addon})
     assert s.flatten() == {base, addon}
+
+
+def test_mutating_input_set_after_construction_does_not_leak_in():
+    addon = make_addon()
+    addons = {addon}
+    s = System(make_base(), addons=addons)
+
+    addons.add(make_addon("sneaky-module", "15-SP3"))
+    addons.remove(addon)
+
+    assert s.get_addons() == {addon}
+    assert str(s) == "sles-modules-15-SP3-x86_64"
+
+
+def test_mutating_get_addons_return_does_not_leak_in():
+    addon = make_addon()
+    s = System(make_base(), addons={addon})
+
+    leaked = s.get_addons()
+    leaked.clear()
+
+    assert s.get_addons() == {addon}
+    assert s.flatten() == {make_base(), addon}
+
+
+def test_eq_unaffected_by_caller_side_mutation():
+    addons = {make_addon()}
+    s1 = System(make_base(), addons=addons)
+    s2 = System(make_base(), addons={make_addon()})
+    assert s1 == s2
+
+    addons.add(make_addon("extra-module", "15-SP3"))
+
+    assert s1 == s2


### PR DESCRIPTION
## What

SystemData is declared frozen=True to advertise immutability, but its
addons field was a mutable set[Product] stored by reference from the
caller-supplied set, and System.get_addons() returned that same
internal set. frozen only prevents field rebinding, not mutation of
the set's contents, so a caller mutating either the original set or
the get_addons() return value silently rewrote the "immutable" record
and everything derived from it: __eq__, __str__, pretty(), flatten()
and the refhost dicts.

Snapshot addons into a frozenset in SystemData.__post_init__ (via
object.__setattr__, as required for a frozen dataclass) and in
System.__init__, and have get_addons() return a fresh mutable copy so
callers keep set semantics without aliasing internal state. All
existing callers only iterate or compare the set, so behaviour is
unchanged; set/frozenset equality is content-based, preserving
existing equality semantics.

Add regression tests covering mutation of the input set after
construction, mutation of the get_addons() result, and equality
stability under caller-side mutation.

## Verification

Full gate green (ruff format/check, ty, pytest: 550 passed, coverage 82.51%). Tests: mutating the caller's input set after construction and mutating get_addons()'s return leave the SystemData unaffected; equality semantics preserved. All constructors/callers grepped — none mutate. Verified to fail pre-fix. Review returned no in-scope findings. Reviewed by a fan-out adversarial code review (two finder lenses per branch, two verifier lenses per finding); all confirmed findings were addressed before opening.

_AI-assisted._
