### PR TITLE
ci(coverage): enable branch coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,13 @@ markers = [
 ]
 
 [tool.coverage.run]
+# Branch coverage records both directions of every conditional, not merely
+# whether the line executed -- exactly where edge-case bugs hide in the
+# untaken guard arc of an otherwise line-covered file. New code (the
+# codecov/patch gate) must now exercise both arcs of the conditionals it
+# adds. Only active when a run passes --cov (CI); a plain pytest run is
+# unaffected.
+branch = true
 source = ["repose"]
 omit = [
   "*/tests/*",


### PR DESCRIPTION
## What

Enable branch coverage in `[tool.coverage.run]` (`branch = true`). Coverage previously ran in statement-only mode.

## Why

In statement mode a conditional is "covered" the instant its line runs once, even if only one direction is ever taken. The recent bug-hunt found several defects sitting in exactly that never-exercised guard arc of files that were otherwise 100% line-covered. Branch coverage turns that blind spot into signal and — via `codecov/patch` — forces new code to exercise both directions of the conditionals it adds.

## Impact (measured on the full suite)

- Overall: **85% → 82%** (−3pp), comfortably above the `--cov-fail-under=80` gate — no gate breaks.
- +724 branches tracked, 61 currently partial (new triage surface).
- Runtime unchanged (~22s). A plain `pytest` run (no `--cov`) is unaffected; only `--cov` runs (CI) measure branches.

The existing `[tool.coverage.report]` `exclude_lines` already suppresses the structurally-unreachable arcs (`TYPE_CHECKING` imports, `NotImplementedError` stubs, the `__main__` guard), so no report changes are needed.

## Verification

Full gate green on the whole repo: `ruff format --check .`, `ruff check .`, `ty check repose`, and `pytest` (578 passed, 82.24% with branch coverage active).

_AI-assisted._