### PR TITLE
test(colorlog): cover ColorFormatter.formatColor output paths

### DIFF
--- a/tests/test_colorlog.py
+++ b/tests/test_colorlog.py
@@ -2,7 +2,13 @@
 
 import logging
 
-from repose.colorlog import COLORS, ColorFormatter, PlainFormatter, create_logger
+import repose.colorlog as _colorlog_mod
+from repose.colorlog import (
+    COLORS,
+    ColorFormatter,
+    PlainFormatter,
+    create_logger,
+)
 
 
 def _record(levelname="INFO", msg="hello"):
@@ -15,6 +21,68 @@ def _record(levelname="INFO", msg="hello"):
         args=(),
         exc_info=None,
     )
+
+
+# ``formatColor`` inspects the DEBUG origin frame at a fixed stack depth of
+# ``inspect.getouterframes(caller)[9]`` to build its ``[module:function]`` tag.
+# Asserting that tag deterministically means controlling which frame lands at
+# depth 9 (its function name) and depth 10 (the neighbour a wrong index would
+# report).  Two details make this reproducible across runners:
+#
+#   * The chain is compiled with a synthetic filename so ``inspect.getmodule``
+#     cannot resolve the origin frame to an importable module; the module
+#     component then falls back to the literal ``"unknown"`` everywhere.
+#   * The chain alternates between two mutually recursive functions, so depth 9
+#     always reports ``_origin_odd`` and depth 10 always reports
+#     ``_origin_even`` regardless of how many wrapper frames a runner injects
+#     between the formatter and its caller (the injected count is even).
+_ORIGIN_SRC = """
+def _origin_even(fmt, record_factory, n):
+    if n <= 0:
+        return fmt.format(record_factory("DEBUG", "hi"))
+    return _origin_odd(fmt, record_factory, n - 1)
+
+
+def _origin_odd(fmt, record_factory, n):
+    if n <= 0:
+        return fmt.format(record_factory("DEBUG", "hi"))
+    return _origin_even(fmt, record_factory, n - 1)
+
+
+def _emit_debug_origin(fmt, record_factory):
+    return _origin_even(fmt, record_factory, 10)
+"""
+
+
+def _format_debug_origin(fmt):
+    namespace: dict = {}
+    exec(compile(_ORIGIN_SRC, "<repose-colorlog-tests>", "exec"), namespace)
+    return namespace["_emit_debug_origin"](fmt, _record)
+
+
+# The exec-above deliberately defeats module resolution (synthetic filename) so
+# ``formatColor``'s ``else`` branch -- ``module = "unknown"`` -- is exercised.
+# To also cover the *truthy* branch at colorlog.py:31-32
+# (``if mod := inspect.getmodule(frame): module = mod.__name__``) the SAME chain
+# is compiled instead against the module-under-test's own ``__file__`` (read
+# live from the imported module).  ``inspect.getmodule`` resolves a frame by
+# matching ``frame.f_code.co_filename`` against a loaded module's ``__file__``,
+# so tagging the origin frames with colorlog's real path makes it resolve the
+# depth-9 frame to the (always-importable) colorlog module and take the truthy
+# branch.
+#
+# Deriving both the compile filename and the expected module name from the same
+# live module object keeps this stable under mutmut: mutmut writes the mutant
+# ``colorlog.py`` to its ``mutants/`` tree, so ``_colorlog_mod.__file__`` there
+# points at that on-disk copy and the frames resolve identically.  (Tagging the
+# frames with the *test* module's filename would be fragile -- a stale, copied
+# ``__pycache__`` can leave the compiled test carrying its original path, which
+# no longer matches the copy's ``__file__`` and silently falls back to
+# ``"unknown"``.)
+def _format_debug_origin_resolved(fmt):
+    namespace: dict = {}
+    exec(compile(_ORIGIN_SRC, _colorlog_mod.__file__, "exec"), namespace)
+    return namespace["_emit_debug_origin"](fmt, _record)
 
 
 def test_color_constants_cover_all_standard_levels():
@@ -130,3 +198,53 @@ def test_create_logger_default_attaches_color_formatter():
     logger = create_logger("repose.test.color")
     formatted = logger.handlers[-1].format(_record("ERROR", "boom"))
     assert "\x1b[1;31m" in formatted
+
+
+def test_non_debug_record_has_erase_line_prefix_and_no_origin_tag():
+    # Setup: a non-DEBUG record through the full ``%(levelname)s`` format.
+    fmt = ColorFormatter("%(levelname)s: %(message)s")
+
+    # Exercise
+    out = fmt.format(_record("INFO", "hi"))
+
+    # Verify: exact byte sequence -- \033[2K erase-line prefix, bold-green
+    # (30 + GREEN == 32) level, lowercased name, reset, and *no*
+    # ``[module:function]`` origin tag (that is DEBUG-only).
+    assert out == "\033[2K\033[1;32minfo\033[0m: hi"
+
+
+def test_debug_record_appends_origin_tag_with_level_color():
+    # Setup
+    fmt = ColorFormatter("%(levelname)s: %(message)s")
+
+    # Exercise: emit from a controlled 9-frame-deep stack (see helper above).
+    out = _format_debug_origin(fmt)
+
+    # Verify: exact byte sequence -- \033[2K erase-line prefix, bold-blue
+    # (30 + BLUE == 34) level, lowercased ``debug``, reset, then the
+    # ``[module:function]`` origin tag recovered from the frame at depth 9.
+    assert out == "\033[2K\033[1;34mdebug\033[0m [unknown:_origin_odd]: hi"
+
+
+def test_debug_origin_tag_reports_resolved_module_not_unknown_or_none():
+    # Setup
+    fmt = ColorFormatter("%(levelname)s: %(message)s")
+
+    # Exercise: origin frames now carry colorlog's own ``__file__``, so
+    # ``inspect.getmodule(frame)`` resolves the depth-9 frame to a real module
+    # and the truthy branch (``module = mod.__name__``) runs.
+    out = _format_debug_origin_resolved(fmt)
+
+    # Verify: the module component is a real, non-empty name -- never the
+    # ``else`` fallback ``"unknown"`` (which mutating ``getmodule(frame)`` to
+    # ``getmodule(None)`` forces) nor the stringified ``None`` (which mutating
+    # ``module = mod.__name__`` to ``module = None`` produces).  The name is
+    # parsed out of the tag rather than hard-coded so the kill holds even if a
+    # runner aliases the module's ``__name__``; ``_origin_odd`` at depth 9 stays
+    # fixed by the alternating recursion.
+    prefix = "\033[2K\033[1;34mdebug\033[0m ["
+    assert out.startswith(prefix)
+    module, rest = out[len(prefix) :].split(":", 1)
+    assert rest == "_origin_odd]: hi"
+    assert module and module not in ("unknown", "None")
+    assert module == _colorlog_mod.__name__


### PR DESCRIPTION
## What
Add tests for `ColorFormatter.formatColor` — the colored-log path: the
per-level ANSI colour sequence, the `\033[2K` erase-line prefix,
`RESET_SEQ`, the lowercased level name, and the DEBUG-only
`[module:function]` origin tag built from the inspected caller frame.

Tests only; no production code change.

## Why
Mutation testing (mutmut, scoped to `repose.colorlog`) surfaced 24
surviving mutants in `formatColor`: existing tests ran the code but only
checked that *a* colour code and the lowercased level appeared somewhere,
so mutating the exact escape sequences, the erase-line prefix, the reset
terminator, or the whole DEBUG origin-tag branch left the suite green.

The new tests assert the exact byte sequences for both branches (a
non-DEBUG record: erase-line + coloured level + reset, no tag; a DEBUG
record: additionally the origin tag), killing all 24 mutants —
`formatColor` now has zero survivors and colorlog.py reaches 100% branch
coverage. The DEBUG origin frame is read at a fixed stack depth
(`inspect.getouterframes(caller)[9]`); the test drives it through a
controlled call chain compiled against the imported module's file, so
the reported module/function stays deterministic across runners
(including under mutmut's copied-tree execution).

## Verification
- `uv run ruff format --check . && uv run ruff check . && uv run ty check repose` — clean.
- `uv run pytest --cov-fail-under=80` — 583 passed, total coverage 82.50%.
- mutmut on `repose.colorlog.*`: the 24 previously-surviving `formatColor`
  mutants now die. Pre-existing survivors elsewhere in colorlog
  (`create_logger`, `format`) are unchanged and out of scope here.

Touches only `tests/test_colorlog.py`; may need a trivial rebase against
#204/#205 (which also add colorlog tests) once those merge.

_AI-assisted._
