### PR TITLE
build(mutmut): add reproducible mutation-testing configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,18 @@ include = ["repose"]
 
 [tool.ty.environment]
 python-version = "3.13"
+
+[tool.mutmut]
+# Mutation-testing config. Run with:
+#   uv run --with 'mutmut>=3.6' mutmut run
+# ``source_paths`` must be the whole package: mutmut copies it into a
+# ``mutants/`` tree that has to ``import repose``, and a single-file
+# scope breaks that import. ``do_not_mutate_patterns`` drops the
+# log-message mutants that otherwise dominate the survivor list -- every
+# ``logger`` call spawns several string/level mutants that no test should
+# pin -- so the surviving mutants reflect real logic gaps rather than
+# logging noise. ``--no-cov`` cancels the ``--cov`` from the pytest
+# addopts above, which the per-mutant test runs neither need nor tolerate.
+source_paths = ["repose/"]
+do_not_mutate_patterns = ['logger\.(debug|info|warning|error|exception|critical)']
+pytest_add_cli_args = ["--no-cov"]


### PR DESCRIPTION
## What
Add a committed `[tool.mutmut]` section to `pyproject.toml` so mutation
testing is reproducible without an out-of-tree throwaway config:

- `source_paths = ["repose/"]` — the whole package. mutmut copies the
  sources into a `mutants/` tree that must `import repose`; a single-file
  scope leaves that import unresolvable.
- `do_not_mutate_patterns = ['logger\.(debug|info|warning|error|exception|critical)']`
  — skips mutation of logging statements. Each `logger.<level>(...)` call
  otherwise spawns several message-string / level-constant mutants that no
  test should pin; they dominate the survivor list and mask real gaps.
- `pytest_add_cli_args = ["--no-cov"]` — cancels the `--cov` from the
  pytest `addopts`; coverage instrumentation is needless overhead for the
  per-mutant test runs.

No production or test code changes. The section is inert for the normal
toolchain — pytest, ruff and ty do not read `[tool.mutmut]`.

## Why
mutmut ≥ 3.6 reads `[tool.mutmut]` from `pyproject.toml` and applies
`do_not_mutate_patterns` as line regexes at mutation-generation time.
Committing the config removes the undocumented per-run setup and makes the
reported mutation score meaningful: on `repose/aiossh.py`, the most
logging-heavy module, logging mutants were the bulk of the survivors,
holding the score near ~52% and burying the genuine logic gaps.

Measured across `AsyncConnection.connect`, `_do_connect` and
`wait_reconnect` (same mutmut version, pattern off vs on): the pattern
removes 66 logging-statement mutants — 180 generated mutants fall to 114
(`connect` 82→31, `wait_reconnect` 36→21; `_do_connect`, which logs
nothing, is unchanged at 62). Surviving mutants drop from 95 to 43 and the
killed/(killed+survived) ratio rises from ~47% to ~62%. Every non-logging
mutant is left exactly as before, so the 43 remaining survivors are the
genuine logic gaps worth writing tests for rather than logging noise.

## How to run
    uv run --with 'mutmut>=3.6' mutmut run                     # whole package
    uv run --with 'mutmut>=3.6' mutmut run "repose.aiossh.*"   # one module

## Verification
- `uv run ruff format --check . && uv run ruff check . && uv run ty check repose` — clean.
- `uv run pytest` — 580 passed, coverage 82% (unchanged; the section does not affect pytest).
- `python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` — parses.

_AI-assisted._
