### PR TITLE
fix(tests): remove duplicate logging import in test_connection

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2,7 +2,6 @@
 
 import logging
 import threading
-import logging
 import os
 from unittest.mock import MagicMock
 


### PR DESCRIPTION
## What
Remove a duplicate `import logging` in `tests/test_connection.py`.

## Why
The file imported `logging` twice — the original at line 5 (`6346153f`)
plus a second copy added at line 3 by `077b0f9` ("refuse changed host
keys without password prompt", #195). Each commit branched from a master
that lacked the other's import, so the duplication merged textually
clean and neither PR's own CI could see it — but ruff's `F811`
(redefinition of unused `logging`) fires on the merged result.

As a consequence the **`lint` job has been failing on master since
`39f1098`** (every other job — test 3.13/3.14, typecheck, docs,
man-drift — passes). This blocks a green master and shows red CI on all
open PRs once they include the merged tree.

## Verification
- `uv run ruff format --check . && uv run ruff check . && uv run ty check repose` — clean.
- `uv run pytest tests/test_connection.py` — 45 passed.
- One-line deletion; no behaviour change.

_AI-assisted._
