### PR TITLE
test: prevent CLI and SSH coverage regressions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+*
+!tests/
+!tests/vectors/
+!tests/vectors/refhosts/
+!tests/vectors/refhosts/sles-16-0/
+!tests/vectors/refhosts/sles-16-0/products.d/
+!tests/vectors/refhosts/sles-16-0/products.d/*.prod
+!tests/vectors/refhosts/sles-16-0/zypper-x-lr.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,33 @@ jobs:
           # Empty arguments: do not force --all-features on an empty graph.
           arguments: ""
 
+  rust-coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: crates -> target
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@d0f4f69b07c0804d1003ca9a5a5f853423872ed9  # v2.62.13
+        with:
+          tool: cargo-llvm-cov@0.8.7
+      - name: Test with OpenSSH and enforce coverage ratchet
+        run: tests/ssh/run.sh scripts/check-coverage.sh
+      - name: Upload LCOV report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: rust-lcov
+          path: coverage/lcov.info
+          if-no-files-found: error
+
   rust-cli:
     # CLI consistency self-check: known-products byte-identity vs the committed
     # expected output (tests/vectors/cli/known_products.txt) + CLI-surface

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Rust / Cargo (workspace under crates/)
 /crates/target/
 /target/
+/coverage/
 *.rs.bk
 Cargo.lock.bak

--- a/crates/repose-cli/tests/cli.rs
+++ b/crates/repose-cli/tests/cli.rs
@@ -1,0 +1,184 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn repose(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_repose"))
+        .args(args)
+        .env_remove("COLOR")
+        .env_remove("NO_COLOR")
+        .output()
+        .expect("repose process should start")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn vector(path: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/vectors")
+        .join(path)
+}
+
+#[test]
+fn no_command_prints_help_and_succeeds() {
+    let output = repose(&[]);
+
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert!(stdout(&output).contains("Usage: repose [OPTIONS] [COMMAND]"));
+}
+
+#[test]
+fn help_and_version_are_process_visible() {
+    let help = repose(&["--help"]);
+    let version = repose(&["--version"]);
+
+    assert!(help.status.success());
+    assert!(stdout(&help).contains("known-products"));
+    assert!(version.status.success());
+    assert_eq!(
+        stdout(&version),
+        format!("repose version: {}\n", env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[test]
+fn conflicting_verbosity_exits_two() {
+    let output = repose(&["--debug", "--quiet", "known-products"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr(&output).contains("mutually exclusive"));
+}
+
+#[test]
+fn clap_rejects_missing_command_arguments() {
+    for args in [&["add"][..], &["add", "-t", "host"][..]] {
+        let output = repose(args);
+        assert_eq!(output.status.code(), Some(2), "args: {args:?}");
+        assert!(stderr(&output).contains("required"), "args: {args:?}");
+    }
+}
+
+#[test]
+fn invalid_host_and_repa_exit_two_without_connecting() {
+    let host = repose(&["list-products", "-t", "host:not-a-port"]);
+    let repa = repose(&["remove", "-t", "host", "a:b:c:d:e"]);
+
+    assert_eq!(host.status.code(), Some(2));
+    assert!(stderr(&host).contains("Wrong port specification"));
+    assert_eq!(repa.status.code(), Some(2));
+    assert!(stderr(&repa).contains("invalid REPA"));
+}
+
+#[test]
+fn known_products_matches_text_golden() {
+    let config = vector("template/sample.yml");
+    let golden = std::fs::read(vector("cli/known_products.txt"))
+        .expect("known-products golden should be readable");
+    let output = repose(&["--config", path(&config), "known-products"]);
+
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert_eq!(output.stdout, golden);
+}
+
+#[test]
+fn known_products_json_is_ndjson() {
+    let config = vector("template/sample.yml");
+    let output = repose(&["--config", path(&config), "--format=json", "known-products"]);
+
+    assert!(output.status.success(), "{}", stderr(&output));
+    let output_text = stdout(&output);
+    let lines: Vec<&str> = output_text.lines().collect();
+    assert_eq!(lines.len(), 3);
+    assert!(lines[0].contains(r#""event": "known_product""#));
+    assert!(lines[0].contains(r#""name": "PackageHub""#));
+    assert!(lines[2].contains(r#""name": "SLES""#));
+}
+
+#[test]
+fn missing_products_config_exits_two() {
+    let output = repose(&[
+        "--config",
+        "/definitely/missing/repose-products.yml",
+        "known-products",
+    ]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr(&output).starts_with("error:"));
+}
+
+#[test]
+fn no_color_output_contains_no_ansi_escape() {
+    let config = vector("template/sample.yml");
+    let output = repose(&["--no-color", "--config", path(&config), "known-products"]);
+
+    assert!(output.status.success());
+    assert!(!output.stdout.contains(&0x1b));
+    assert!(!output.stderr.contains(&0x1b));
+}
+
+#[test]
+fn ssh_fixture_exercises_query_and_dry_run_commands() {
+    let Some(target) = std::env::var_os("REPOSE_SSH_TARGET") else {
+        assert!(
+            std::env::var_os("REPOSE_SSH_REQUIRED").is_none(),
+            "OpenSSH fixture variables are required"
+        );
+        return;
+    };
+    let known_hosts = std::env::var_os("REPOSE_SSH_KNOWN_HOSTS")
+        .expect("fixture should provide REPOSE_SSH_KNOWN_HOSTS");
+    let common = [
+        "--strict-host-key-checking=yes",
+        "--known-hosts",
+        path(Path::new(&known_hosts)),
+    ];
+    let target = target.to_string_lossy();
+
+    let products = repose_with(&common, &["list-products", "-t", &target]);
+    assert!(products.status.success(), "{}", stderr(&products));
+    assert!(stdout(&products).contains("Base product: SLES-16.0-x86_64"));
+    assert!(stdout(&products).contains("Addon: qa"));
+
+    let products_json = repose_with(&common, &["--format=json", "list-products", "-t", &target]);
+    assert!(products_json.status.success(), "{}", stderr(&products_json));
+    assert!(stdout(&products_json).contains(r#""event": "product""#));
+
+    let repos = repose_with(&common, &["list-repos", "-t", &target]);
+    assert!(repos.status.success(), "{}", stderr(&repos));
+    assert!(stdout(&repos).contains("SLES:16.0::pool"));
+
+    let repos_json = repose_with(&common, &["--format=json", "list-repos", "-t", &target]);
+    assert!(repos_json.status.success(), "{}", stderr(&repos_json));
+    assert!(stdout(&repos_json).contains(r#""event": "repo""#));
+
+    let dry = repose_with(&common, &["--print", "clear", "-t", &target]);
+    assert!(dry.status.success(), "{}", stderr(&dry));
+    assert!(stdout(&dry).contains("zypper rr"));
+
+    let dry_json = repose_with(
+        &common,
+        &["--print", "--format=json", "clear", "-t", &target],
+    );
+    assert!(dry_json.status.success(), "{}", stderr(&dry_json));
+    assert!(stdout(&dry_json).contains(r#""event":"dry""#));
+}
+
+fn repose_with(common: &[&str], args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_repose"))
+        .args(common)
+        .args(args)
+        .env_remove("SSH_AUTH_SOCK")
+        .env_remove("COLOR")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("repose process should start")
+}
+
+fn path(path: &Path) -> &str {
+    path.to_str().expect("test paths should be UTF-8")
+}

--- a/crates/repose-cli/tests/cli.rs
+++ b/crates/repose-cli/tests/cli.rs
@@ -158,7 +158,7 @@ fn ssh_fixture_exercises_query_and_dry_run_commands() {
 
     let dry = repose_with(&common, &["--print", "clear", "-t", &target]);
     assert!(dry.status.success(), "{}", stderr(&dry));
-    assert!(stdout(&dry).contains("zypper rr"));
+    assert!(stdout(&dry).contains("zypper -n rr"));
 
     let dry_json = repose_with(
         &common,

--- a/crates/repose-ssh/tests/ssh_integration.rs
+++ b/crates/repose-ssh/tests/ssh_integration.rs
@@ -1,0 +1,240 @@
+use std::path::{Path, PathBuf};
+
+use repose_core::host_parse::{parse_host, HostSpec};
+use repose_core::{ConnectionConfig, HostKeyPolicy};
+use repose_ssh::{Host, HostGroup, RusshHost, RusshHostGroup, RusshSession, SshSession};
+use tempfile::tempdir;
+
+struct Fixture {
+    host: String,
+    port: u16,
+    user: String,
+    identity: PathBuf,
+    wrong_identity: PathBuf,
+    known_hosts: PathBuf,
+    wrong_host_key: PathBuf,
+}
+
+impl Fixture {
+    fn from_env() -> Option<Self> {
+        let fixture = Self {
+            host: std::env::var("REPOSE_SSH_HOST").ok()?,
+            port: std::env::var("REPOSE_SSH_PORT").ok()?.parse().ok()?,
+            user: std::env::var("REPOSE_SSH_USER").ok()?,
+            identity: std::env::var_os("REPOSE_SSH_IDENTITY")?.into(),
+            wrong_identity: std::env::var_os("REPOSE_SSH_WRONG_IDENTITY")?.into(),
+            known_hosts: std::env::var_os("REPOSE_SSH_KNOWN_HOSTS")?.into(),
+            wrong_host_key: std::env::var_os("REPOSE_SSH_WRONG_HOST_KEY")?.into(),
+        };
+        Some(fixture)
+    }
+
+    fn config(
+        &self,
+        policy: HostKeyPolicy,
+        known_hosts: PathBuf,
+        timeout: f64,
+    ) -> ConnectionConfig {
+        ConnectionConfig {
+            host_key_policy: policy,
+            known_hosts: Some(known_hosts),
+            timeout,
+        }
+    }
+
+    fn session(&self, config: ConnectionConfig) -> RusshSession {
+        RusshSession::new(&self.host, self.port, &self.user, config)
+            .with_identity(self.identity.clone())
+    }
+
+    fn spec(&self) -> HostSpec {
+        parse_host(&format!("{}@{}:{}", self.user, self.host, self.port))
+            .expect("fixture target should parse")
+    }
+}
+
+#[tokio::test]
+async fn live_session_covers_auth_host_keys_commands_sftp_and_reconnect() {
+    let Some(fixture) = fixture() else { return };
+    let temp = tempdir().expect("temporary known_hosts directory should be created");
+    let known_hosts = temp.path().join("known_hosts");
+
+    let mut unauthorized = RusshSession::new(
+        &fixture.host,
+        fixture.port,
+        &fixture.user,
+        fixture.config(HostKeyPolicy::Off, known_hosts.clone(), 2.0),
+    )
+    .with_identity(fixture.wrong_identity.clone());
+    assert!(unauthorized.connect().await.is_err());
+
+    let mut strict_unknown =
+        fixture.session(fixture.config(HostKeyPolicy::Yes, known_hosts.clone(), 2.0));
+    assert!(strict_unknown.connect().await.is_err());
+
+    let mut accept_new =
+        fixture.session(fixture.config(HostKeyPolicy::AcceptNew, known_hosts.clone(), 2.0));
+    accept_new
+        .connect()
+        .await
+        .expect("accept-new should connect");
+    assert!(accept_new.is_active());
+    let recorded = std::fs::read_to_string(&known_hosts).expect("host key should be recorded");
+    assert!(recorded.contains(&format!("[{}]:{}", fixture.host, fixture.port)));
+    accept_new.close().await.expect("session should close");
+
+    let mut strict = fixture.session(fixture.config(HostKeyPolicy::Yes, known_hosts.clone(), 2.0));
+    strict
+        .connect()
+        .await
+        .expect("recorded host key should connect");
+    let (stdout, stderr, status) = strict
+        .run("printf stdout; printf stderr >&2; exit 7")
+        .await
+        .expect("remote command should complete");
+    assert_eq!(
+        (stdout.as_str(), stderr.as_str(), status),
+        ("stdout", "stderr", 7)
+    );
+
+    let listing = strict
+        .listdir("/etc/products.d")
+        .await
+        .expect("products directory should be listed");
+    assert!(listing.iter().any(|entry| entry == "SLES.prod"));
+    assert!(listing.iter().any(|entry| entry == "qa.prod"));
+    let link = strict
+        .readlink("/etc/products.d/baseproduct")
+        .await
+        .expect("baseproduct should be a symlink");
+    assert_eq!(link.as_deref(), Some("SLES.prod"));
+    let product = strict
+        .read_file("/etc/products.d/SLES.prod")
+        .await
+        .expect("base product should be readable");
+    assert!(product
+        .windows(b"<name>SLES</name>".len())
+        .any(|window| window == b"<name>SLES</name>"));
+    let second_read = strict
+        .read_file("/etc/products.d/qa.prod")
+        .await
+        .expect("cached SFTP session should remain usable");
+    assert!(second_read
+        .windows(b"<name>qa</name>".len())
+        .any(|window| window == b"<name>qa</name>"));
+
+    strict.close().await.expect("session should close");
+    assert!(!strict.is_active());
+    strict
+        .connect()
+        .await
+        .expect("closed session should reconnect");
+    assert_eq!(
+        strict
+            .run("printf reconnected")
+            .await
+            .expect("command should run")
+            .0,
+        "reconnected"
+    );
+
+    let mut timeout = fixture.session(fixture.config(HostKeyPolicy::Yes, known_hosts, 0.1));
+    timeout
+        .connect()
+        .await
+        .expect("timeout session should connect");
+    let error = timeout
+        .run("sleep 2")
+        .await
+        .expect_err("slow command should time out");
+    assert!(error.to_string().contains("timed out"));
+}
+
+#[tokio::test]
+async fn live_session_rejects_a_changed_host_key_and_off_accepts_it() {
+    let Some(fixture) = fixture() else { return };
+    let temp = tempdir().expect("temporary known_hosts directory should be created");
+    let known_hosts = temp.path().join("known_hosts");
+    write_known_host(
+        &known_hosts,
+        &fixture.host,
+        fixture.port,
+        &fixture.wrong_host_key,
+    );
+
+    let mut strict =
+        fixture.session(fixture.config(HostKeyPolicy::AcceptNew, known_hosts.clone(), 2.0));
+    assert!(strict.connect().await.is_err());
+
+    let mut off = fixture.session(fixture.config(HostKeyPolicy::Off, known_hosts.clone(), 2.0));
+    off.connect()
+        .await
+        .expect("off policy should bypass the changed key");
+    assert!(off.is_active());
+
+    let mut no = fixture.session(fixture.config(HostKeyPolicy::No, known_hosts, 2.0));
+    no.connect()
+        .await
+        .expect("no policy should bypass the changed key");
+}
+
+#[tokio::test]
+async fn live_host_discovers_system_repositories_and_isolates_connection_failures() {
+    let Some(fixture) = fixture() else { return };
+    let config = fixture.config(HostKeyPolicy::Yes, fixture.known_hosts.clone(), 2.0);
+    let mut host = RusshHost::from_spec(fixture.spec(), config.clone());
+
+    host.connect().await.expect("host should connect");
+    host.read_products()
+        .await
+        .expect("products should be discovered");
+    let system = host.products().expect("discovered system should be stored");
+    assert_eq!(system.base.name, "SLES");
+    assert_eq!(system.base.version, "16.0");
+    assert!(system.addons.iter().any(|product| product.name == "qa"));
+    host.read_repos()
+        .await
+        .expect("repositories should be discovered");
+    let repos = host.raw_repos().expect("repositories should be stored");
+    assert_eq!(repos.len(), 2);
+    assert!(repos.iter().any(|repo| repo.alias == "SLES:16.0::pool"));
+    assert_eq!(
+        host.out()
+            .last()
+            .expect("zypper invocation should be recorded")
+            .0,
+        "zypper -x lr"
+    );
+
+    let failed = HostSpec {
+        key: format!("localhost:{}", fixture.port),
+        hostname: "localhost".into(),
+        port: fixture.port,
+        username: fixture.user.clone(),
+    };
+    let good_key = fixture.spec().key;
+    let mut group = RusshHostGroup::from_targets(vec![fixture.spec(), failed], config);
+    group.connect_and_prune().await;
+
+    assert_eq!(group.keys(), vec![good_key]);
+    group.close().await;
+}
+
+fn write_known_host(path: &Path, host: &str, port: u16, public_key: &Path) {
+    let key = std::fs::read_to_string(public_key).expect("wrong public key should be readable");
+    let fields: Vec<&str> = key.split_whitespace().take(2).collect();
+    std::fs::write(
+        path,
+        format!("[{host}]:{port} {} {}\n", fields[0], fields[1]),
+    )
+    .expect("known_hosts should be writable");
+}
+
+fn fixture() -> Option<Fixture> {
+    let fixture = Fixture::from_env();
+    assert!(
+        fixture.is_some() || std::env::var_os("REPOSE_SSH_REQUIRED").is_none(),
+        "OpenSSH fixture variables are required"
+    );
+    fixture
+}

--- a/plans/improve-test-coverage.md
+++ b/plans/improve-test-coverage.md
@@ -1,0 +1,53 @@
+# Improve test coverage
+
+## Current state
+
+CI does not check coverage; it only runs tests at `.github/workflows/ci.yml:43-44`. Current line coverage is 81.47%, with major gaps in CLI wiring (21.66%) and SSH session/host behavior (about 22–26%).
+
+Assumptions: use a ratcheted workspace line baseline, run containerized OpenSSH tests on pull requests, generate test keys dynamically, and avoid production refactoring unless required for testability.
+
+## Plan
+
+1. [small] Add process-level CLI tests in `crates/repose-cli/tests/cli.rs` covering help/version, conflicting flags, missing command, invalid host/REPA, known-products text/JSON, exit codes, and color behavior — verify: CLI integration tests pass and `lib.rs` coverage increases.
+2. [medium] Add an OpenSSH fixture image in `tests/ssh/Dockerfile`, pinned to an immutable base, with SFTP and representative product/repository files — verify: the container passes a health check and accepts only the generated test key.
+3. [small] Add `tests/ssh/run.sh` to generate temporary host/client keys, start the container on an ephemeral port, export connection details, and always clean up — verify: no credentials are committed and repeated runs leave no containers or files behind.
+4. [large] Add `crates/repose-ssh/tests/ssh_integration.rs` covering public-key connection, host-key policies, stdout/stderr/exit status, timeout, SFTP list/read/readlink, cached SFTP reuse, close/reconnect, system discovery, and per-host failure isolation — verify: tests fail when transport behavior is deliberately broken and pass against the fixture.
+5. [medium] Extend CLI integration coverage through the SSH fixture for `list-products`, `list-repos`, and one dry-run mutation command, checking text/NDJSON and process exit codes — verify: binary behavior succeeds end-to-end without external network access.
+6. [small] Add `scripts/check-coverage.sh` running `cargo llvm-cov --workspace --all-targets --locked`, producing text/LCOV reports and enforcing the committed line-coverage baseline — verify: lowering observed coverage below the baseline makes the script fail.
+7. [small] Add a coverage job to `.github/workflows/ci.yml`: install pinned `cargo-llvm-cov`, start the SSH fixture, run the coverage script, and upload the LCOV artifact — verify: pull-request CI displays a coverage job and rejects regressions.
+8. [trivial] Update `tests/vectors/inventory.md` to document the SSH fixture, covered scenarios, local command, and ratchet procedure — verify: the instructions reproduce the CI check.
+9. [small] Update `crates/Cargo.lock` only if test tooling introduces dependencies — verify: `cargo test --workspace --all-targets --locked` succeeds.
+
+## Files
+
+- Modify:
+  - `.github/workflows/ci.yml`
+  - `tests/vectors/inventory.md`
+  - `crates/Cargo.lock` if needed
+- Create:
+  - `crates/repose-cli/tests/cli.rs`
+  - `crates/repose-ssh/tests/ssh_integration.rs`
+  - `tests/ssh/Dockerfile`
+  - `tests/ssh/run.sh`
+  - `scripts/check-coverage.sh`
+- Delete: none
+
+## Risks
+
+- Container startup can make CI slower or flaky; use health checks, pinned images, ephemeral ports, and deterministic retries.
+- Aggregate coverage can mask regressions in low-covered crates; record workspace and per-crate results, with SSH/CLI floors once stable.
+- SIGINT and timeout tests can become timing-sensitive; use bounded synchronization rather than fixed sleeps.
+
+## Alternatives considered
+
+- Mocking russh internals — rejected because it would not validate authentication, protocol, SFTP, or host-key behavior.
+- Report-only coverage — rejected because it permits silent regressions.
+
+## Success criteria
+
+- [ ] All existing 172 tests still pass.
+- [ ] New CLI and SSH integration tests pass locally and in CI.
+- [ ] CI publishes an LCOV artifact and fails below the ratcheted baseline.
+- [ ] CLI and SSH coverage materially rises from the current 21–26%.
+- [ ] `cargo fmt`, Clippy, layering, locked tests, and `cargo deny check` pass.
+- [ ] No private keys, passwords, or persistent containers remain.

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COVERAGE_DIR="${COVERAGE_DIR:-$ROOT/coverage}"
+LINE_BASELINE="${REPOSE_COVERAGE_LINE_BASELINE:-83.09}"
+
+command -v cargo-llvm-cov >/dev/null || {
+	echo "cargo-llvm-cov is required: cargo install cargo-llvm-cov --locked" >&2
+	exit 2
+}
+command -v jq >/dev/null || {
+	echo "jq is required" >&2
+	exit 2
+}
+
+mkdir -p "$COVERAGE_DIR"
+cd "$ROOT/crates"
+
+cargo llvm-cov clean --workspace
+cargo llvm-cov --workspace --all-targets --locked --no-report
+cargo llvm-cov report --text --show-missing-lines --output-path "$COVERAGE_DIR/coverage.txt"
+cargo llvm-cov report --lcov --output-path "$COVERAGE_DIR/lcov.info"
+cargo llvm-cov report --summary-only --json --output-path "$COVERAGE_DIR/summary.json"
+
+line_percent="$(jq -r '.data[0].totals.lines.percent' "$COVERAGE_DIR/summary.json")"
+printf 'Workspace line coverage: %.2f%% (baseline %.2f%%)\n' "$line_percent" "$LINE_BASELINE"
+
+if ! awk -v actual="$line_percent" -v baseline="$LINE_BASELINE" 'BEGIN { exit !(actual + 0.000001 >= baseline) }'; then
+	echo "line coverage ${line_percent}% is below the committed baseline ${LINE_BASELINE}%" >&2
+	exit 1
+fi

--- a/tests/ssh/Dockerfile
+++ b/tests/ssh/Dockerfile
@@ -1,0 +1,39 @@
+FROM alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+
+RUN apk add --no-cache openssh \
+    && adduser -D -u 1000 repose \
+    && passwd -d repose \
+    && mkdir -p /etc/products.d /run/sshd \
+    && chown repose:repose /home/repose \
+    && printf '%s\n' \
+        'Port 22' \
+        'ListenAddress 0.0.0.0' \
+        'PasswordAuthentication no' \
+        'KbdInteractiveAuthentication no' \
+        'PermitRootLogin no' \
+        'PubkeyAuthentication yes' \
+        'AuthorizedKeysFile /run/sshd/authorized_keys' \
+        'Subsystem sftp internal-sftp' \
+        'AllowUsers repose' \
+        > /etc/ssh/sshd_config
+
+COPY tests/vectors/refhosts/sles-16-0/products.d/ /etc/products.d/
+COPY tests/vectors/refhosts/sles-16-0/zypper-x-lr.xml /usr/local/share/zypper-x-lr.xml
+
+RUN ln -s SLES.prod /etc/products.d/baseproduct \
+    && printf '%s\n' \
+        '#!/bin/sh' \
+        'if [ "$*" = "-x lr" ]; then' \
+        '  cat /usr/local/share/zypper-x-lr.xml' \
+        '  exit 0' \
+        'fi' \
+        'printf "unsupported zypper arguments: %s\\n" "$*" >&2' \
+        'exit 2' \
+        > /usr/local/bin/zypper \
+    && chmod 0755 /usr/local/bin/zypper
+
+EXPOSE 22
+HEALTHCHECK --interval=1s --timeout=3s --start-period=1s --retries=30 \
+    CMD ssh-keyscan -T 2 -p 22 127.0.0.1 >/dev/null 2>&1 || exit 1
+
+CMD ["sh", "-c", "cp /fixture/authorized_keys /run/sshd/authorized_keys && cp /fixture/host_key /run/sshd/host_key && chown repose:repose /run/sshd/authorized_keys && chmod 0600 /run/sshd/authorized_keys /run/sshd/host_key && exec /usr/sbin/sshd -D -e -f /etc/ssh/sshd_config -h /run/sshd/host_key"]

--- a/tests/ssh/run.sh
+++ b/tests/ssh/run.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE="repose-ssh-test:${REPOSE_SSH_IMAGE_TAG:-local}"
+tmp="$(mktemp -d)"
+container=""
+
+cleanup() {
+	if [[ -n "$container" ]]; then
+		docker rm -f "$container" >/dev/null 2>&1 || true
+	fi
+	rm -rf "$tmp"
+}
+trap cleanup EXIT INT TERM
+
+if [[ $# -eq 0 ]]; then
+	echo "usage: tests/ssh/run.sh COMMAND [ARG ...]" >&2
+	exit 2
+fi
+command -v docker >/dev/null || {
+	echo "docker is required" >&2
+	exit 2
+}
+command -v ssh-keygen >/dev/null || {
+	echo "ssh-keygen is required" >&2
+	exit 2
+}
+
+ssh-keygen -q -t ed25519 -N '' -C repose-integration -f "$tmp/client_key"
+ssh-keygen -q -t ed25519 -N '' -C repose-fixture-host -f "$tmp/host_key"
+ssh-keygen -q -t ed25519 -N '' -C repose-wrong-host -f "$tmp/wrong_host_key"
+cp "$tmp/client_key.pub" "$tmp/authorized_keys"
+chmod 0600 "$tmp/authorized_keys" "$tmp/client_key" "$tmp/host_key"
+
+docker build --tag "$IMAGE" --file "$ROOT/tests/ssh/Dockerfile" "$ROOT"
+container="$(docker run --detach --rm \
+	--publish 127.0.0.1::22 \
+	--mount "type=bind,src=$tmp,dst=/fixture,readonly" \
+	"$IMAGE")"
+
+for _ in $(seq 1 40); do
+	health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container")"
+	[[ "$health" == healthy ]] && break
+	[[ "$health" == unhealthy ]] && {
+		docker logs "$container" >&2
+		exit 1
+	}
+	sleep 0.25
+done
+[[ "${health:-}" == healthy ]] || {
+	docker logs "$container" >&2
+	echo "sshd did not become healthy" >&2
+	exit 1
+}
+
+port="$(docker port "$container" 22/tcp | awk -F: 'NR == 1 { print $NF }')"
+[[ "$port" =~ ^[0-9]+$ ]] || {
+	echo "could not determine fixture port" >&2
+	exit 1
+}
+
+mkdir -p "$tmp/home/.ssh"
+cat >"$tmp/home/.ssh/config" <<EOF
+Host 127.0.0.1
+  IdentityFile $tmp/client_key
+  IdentitiesOnly yes
+EOF
+chmod 0700 "$tmp/home/.ssh"
+chmod 0600 "$tmp/home/.ssh/config"
+
+host_public="$(cut -d' ' -f1,2 "$tmp/host_key.pub")"
+printf '[127.0.0.1]:%s %s\n' "$port" "$host_public" >"$tmp/known_hosts"
+
+export HOME="$tmp/home"
+export SSH_AUTH_SOCK="$tmp/no-agent"
+export REPOSE_SSH_HOST="127.0.0.1"
+export REPOSE_SSH_PORT="$port"
+export REPOSE_SSH_USER="repose"
+export REPOSE_SSH_TARGET="repose@127.0.0.1:$port"
+export REPOSE_SSH_IDENTITY="$tmp/client_key"
+export REPOSE_SSH_WRONG_IDENTITY="$tmp/wrong_host_key"
+export REPOSE_SSH_KNOWN_HOSTS="$tmp/known_hosts"
+export REPOSE_SSH_WRONG_HOST_KEY="$tmp/wrong_host_key.pub"
+export REPOSE_SSH_REQUIRED=1
+
+"$@"

--- a/tests/vectors/inventory.md
+++ b/tests/vectors/inventory.md
@@ -34,9 +34,32 @@ The CLI vector (`cli/known_products.txt`) is the committed `known-products`
 output for `template/sample.yml`. `scripts/check-cli.sh` asserts the Rust
 binary matches this expected output byte-for-byte and upholds the CLI-surface
 invariants (no `--ssh-backend`, `repose version: X.Y.Z` shape, all nine
-subcommands). Run in CI by the `rust-cli` job. Dry-run mutation and
-connect/accept-new coverage needs a containerized sshd and is tracked
-separately.
+subcommands). Run in CI by the `rust-cli` job.
+
+## OpenSSH integration and coverage
+
+`tests/ssh/Dockerfile` provides an isolated OpenSSH server with SFTP, the
+`sles-16-0` product and repository vectors, and a deterministic `zypper -x lr`
+response. `tests/ssh/run.sh` generates fresh client and host keys, publishes
+SSH on an ephemeral loopback port, waits for the container health check, runs
+the supplied command, and removes the container and keys on exit.
+
+The live tests cover public-key authentication, strict/accept-new/off host-key
+policies, command streams/status/timeout, SFTP list/read/readlink and reuse,
+close/reconnect, system/repository discovery, per-host failure isolation, CLI
+`list-products`, CLI `list-repos`, and dry-run `clear` in text and NDJSON.
+
+Run the same coverage check as CI from the repository root:
+
+```sh
+tests/ssh/run.sh scripts/check-coverage.sh
+```
+
+The command writes `coverage/coverage.txt`, `coverage/lcov.info`, and
+`coverage/summary.json`. `scripts/check-coverage.sh` rejects workspace line
+coverage below its committed baseline. After adding meaningful tests, raise
+`LINE_BASELINE` in that script to the rounded-down observed percentage; never
+lower it without a reviewed explanation for the coverage loss.
 
 Normative rule: the committed vectors beat the design doc — they define the
 binary's expected behavior and are updated deliberately, never regenerated


### PR DESCRIPTION
## Summary

Add behavior-focused CLI and live OpenSSH integration coverage, then ratchet workspace line coverage so these gains cannot silently regress.

## Changes

- exercise CLI help, version, validation, known-products output, exit codes, and color behavior through the built process
- test public-key authentication, host-key policies, command streams/status, timeout, SFTP, reconnect, discovery, and per-host failure isolation against an ephemeral OpenSSH fixture
- cover `list-products`, `list-repos`, and dry-run `clear` end to end in text and NDJSON
- generate client and host keys at runtime, publish SSH on an ephemeral loopback port, and clean up fixture state on every exit
- generate text, JSON, and LCOV reports while enforcing an 83.09% workspace line baseline
- upload LCOV from a pinned CI coverage job

## Breaking Changes

None. Production APIs and runtime behavior are unchanged.

## Testing

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked` (184 tests)
- `bash ../scripts/check-rust-layering.sh`
- `shellcheck tests/ssh/run.sh scripts/check-coverage.sh`
- `scripts/check-coverage.sh` (83.09% line coverage)
- confirmed the ratchet fails with `REPOSE_COVERAGE_LINE_BASELINE=100`

Docker was unavailable locally, so the containerized OpenSSH run is delegated to the new CI job. `cargo-deny` was also unavailable locally; the existing `rust-deny` CI job remains the dependency-policy gate.

## Reviewer Notes

The fixture is public-key-only, uses generated Ed25519 keys, binds only to loopback, pins the base image digest, and requires fixture variables during the coverage job so live tests cannot silently skip.