### PR TITLE
chore(build): make the repository root the Cargo workspace

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Generated man pages + shell completions — produced by the repose-gen tool
-# (`cargo run -p repose-cli --features gen --bin repose-gen -- repose-cli`).
+# (`cargo run -p repose-cli --features gen --bin repose-gen -- crates/repose-cli`).
 # Marking them as generated keeps GitHub from counting them in language stats
 # and auto-collapses them in pull-request diffs. CI's `rust-assets-drift` job
 # regenerates and ensures they stay in sync with the clap CLI.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,9 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates
 version: 2
 updates:
-  # Rust dependencies for the cargo workspace under crates/ (Cargo.toml +
-  # Cargo.lock).
+  # Rust dependencies for the root cargo workspace.
   - package-ecosystem: "cargo"
-    directory: "/crates"
+    directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,11 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Rust workspace (crates/) — the sole implementation since the Python
+  # Rust workspace — the sole implementation since the Python
   # cutover . Python and its jobs were removed.
   rust:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    defaults:
-      run:
-        working-directory: crates
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Install Rust toolchain
@@ -32,14 +29,13 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
-          workspaces: crates -> target
+          workspaces: . -> target
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - name: Layering (core ↛ ssh/russh)
-        # Script lives at repo root; job working-directory is crates/.
-        run: bash ../scripts/check-rust-layering.sh
+        run: bash scripts/check-rust-layering.sh
       - name: Test
         run: cargo test --workspace --all-targets --locked
       - name: Binary version line
@@ -51,7 +47,7 @@ jobs:
           echo "$out" | grep -E '^repose version: [0-9]+\.[0-9]+\.[0-9]+$'
 
   rust-deny:
-    # Dependency policy for the Rust workspace. Config: crates/deny.toml
+    # Dependency policy for the Rust workspace. Config: deny.toml
     # next to the workspace manifest (auto-discovered by cargo-deny).
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -60,7 +56,7 @@ jobs:
       - name: cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          manifest-path: crates/Cargo.toml
+          manifest-path: Cargo.toml
           command: check
           # Empty arguments: do not force --all-features on an empty graph.
           arguments: ""
@@ -77,7 +73,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
-          workspaces: crates -> target
+          workspaces: . -> target
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@d0f4f69b07c0804d1003ca9a5a5f853423872ed9  # v2.62.13
         with:
@@ -105,12 +101,12 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
-          workspaces: crates -> target
+          workspaces: . -> target
       - name: Build Rust binary
-        run: cargo build --locked -p repose-cli --manifest-path crates/Cargo.toml
+        run: cargo build --locked -p repose-cli
       - name: CLI consistency self-check
         env:
-          REPOSE_RS: crates/target/debug/repose
+          REPOSE_RS: target/debug/repose
         run: bash scripts/check-cli.sh
 
   rust-assets-drift:
@@ -118,9 +114,6 @@ jobs:
     # and fail if they drift.
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    defaults:
-      run:
-        working-directory: crates
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Install Rust toolchain
@@ -128,15 +121,15 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
-          workspaces: crates -> target
+          workspaces: . -> target
       - name: Regenerate man pages + completions
-        run: cargo run --locked -p repose-cli --features gen --bin repose-gen -- repose-cli
+        run: cargo run --locked -p repose-cli --features gen --bin repose-gen -- crates/repose-cli
       - name: Check for drift
         # Fail on modified tracked assets AND on untracked leftovers (e.g. a
         # renamed page that regeneration no longer produces/overwrites).
         run: |
-          git diff --exit-code -- repose-cli/man repose-cli/completions
-          untracked="$(git status --porcelain -- repose-cli/man repose-cli/completions)"
+          git diff --exit-code -- crates/repose-cli/man crates/repose-cli/completions
+          untracked="$(git status --porcelain -- crates/repose-cli/man crates/repose-cli/completions)"
           if [ -n "$untracked" ]; then
             echo "::error::untracked generated assets:"
             echo "$untracked"
@@ -145,12 +138,9 @@ jobs:
 
   rust-msrv:
     # Build with the minimum supported Rust version (rust-version in
-    # crates/Cargo.toml) so MSRV cannot silently drift.
+    # Cargo.toml) so MSRV cannot silently drift.
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    defaults:
-      run:
-        working-directory: crates
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Install Rust toolchain (MSRV)
@@ -158,6 +148,6 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
-          workspaces: crates -> target
+          workspaces: . -> target
       - name: Build (MSRV)
         run: cargo build --workspace --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,18 +26,18 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
-          workspaces: crates -> target
+          workspaces: . -> target
 
       - name: Verify tag matches workspace version
         run: |
-          pkg="$(sed -n 's/^version = "\(.*\)"/\1/p' crates/Cargo.toml | head -1)"
+          pkg="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
           if [ "$pkg" != "$GITHUB_REF_NAME" ]; then
             echo "::error::tag '$GITHUB_REF_NAME' != workspace version '$pkg'"
             exit 1
           fi
 
       - name: Build release binary
-        run: cargo build --release --locked -p repose-cli --manifest-path crates/Cargo.toml
+        run: cargo build --release --locked -p repose-cli
 
       - name: Create GitHub release
         env:
@@ -46,4 +46,4 @@ jobs:
           gh release create "$GITHUB_REF_NAME"
           --title "$GITHUB_REF_NAME"
           --generate-notes
-          crates/target/release/repose
+          target/release/repose

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-# Rust / Cargo (workspace under crates/)
-/crates/target/
+# Rust / Cargo
 /target/
+# Ignore artifacts left by the former crates/ workspace root.
+/crates/target/
 /coverage/
 *.rs.bk
 Cargo.lock.bak

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 # Rust Workspace Guidelines
 
-These instructions apply to this repository — a Rust workspace
-(sources under `crates/`).
+These instructions apply to this repository — a root Rust workspace with
+sources under `crates/`.
 
 ## Workspace Commands
 
-Run commands from `crates/`:
+Run commands from the repository root:
 
 ```bash
 cargo fmt --check
@@ -32,7 +32,7 @@ committed `Cargo.lock`, so use `--locked` for verification.
   `repose-cli -> repose-core`, `repose-cli -> repose-ssh`, and
   `repose-ssh -> repose-core`.
 
-Run `../scripts/check-rust-layering.sh` after changing Cargo dependencies or
+Run `scripts/check-rust-layering.sh` after changing Cargo dependencies or
 crate boundaries.
 
 ## Rust Style and APIs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -426,6 +426,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "const-oid"
@@ -754,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -813,9 +823,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -844,9 +854,9 @@ checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -901,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -915,7 +925,7 @@ version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4e5aa225bc56696909483320f0ff9b600f1a971b52e07a17d70f3d9b43254b"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
  "rustversion",
  "typenum",
 ]
@@ -1141,7 +1151,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1346,6 +1355,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "jobserver"
@@ -1797,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1840,6 +1898,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -1872,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2000,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -2020,11 +2079,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2257,8 +2313,8 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2288,11 +2344,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -2318,6 +2402,15 @@ checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
 dependencies = [
  "cfg-if",
  "cipher",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2444,18 +2537,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,6 +2631,22 @@ name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -3005,6 +3102,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,6 +3199,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace]
 resolver = "2"
 members = [
-    "repose-core",
-    "repose-ssh",
-    "repose-cli",
+    "crates/repose-core",
+    "crates/repose-ssh",
+    "crates/repose-cli",
 ]
 
 [workspace.package]

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,30 @@
-# repose — Rust workspace under crates/. Convenience targets; CI runs the
+# repose — Rust workspace convenience targets; CI runs the
 # same commands (see .github/workflows/ci.yml).
 .PHONY: build release test fmt fmt-fix clippy deny layer cli assets check install clean
 
 build:        ## debug build (locked)
-	cd crates && cargo build --locked
+	cargo build --locked
 release:      ## optimized `repose` binary
-	cd crates && cargo build --release --locked -p repose-cli
+	cargo build --release --locked -p repose-cli
 test:         ## workspace tests
-	cd crates && cargo test --workspace --all-targets --locked
+	cargo test --workspace --all-targets --locked
 fmt:          ## check formatting
-	cd crates && cargo fmt --all -- --check
+	cargo fmt --all -- --check
 fmt-fix:      ## apply formatting
-	cd crates && cargo fmt --all
+	cargo fmt --all
 clippy:       ## lint (deny warnings), incl. the `gen` feature
-	cd crates && cargo clippy --workspace --all-targets --locked -- -D warnings
-	cd crates && cargo clippy --workspace --all-targets --features gen --locked -- -D warnings
+	cargo clippy --workspace --all-targets --locked -- -D warnings
+	cargo clippy --workspace --all-targets --features gen --locked -- -D warnings
 deny:         ## dependency policy
-	cd crates && cargo deny check
+	cargo deny check
 layer:        ## enforce core -/-> ssh layering
 	bash scripts/check-rust-layering.sh
 cli:          ## CLI consistency self-check vs committed expected output
 	bash scripts/check-cli.sh
 assets:       ## regenerate committed man pages + shell completions
-	cd crates && cargo run --locked -p repose-cli --features gen --bin repose-gen -- repose-cli
+	cargo run --locked -p repose-cli --features gen --bin repose-gen -- crates/repose-cli
 check: fmt clippy test deny layer cli  ## everything CI runs
 install:      ## install `repose` into ~/.cargo/bin
-	cd crates && cargo install --path repose-cli --locked
+	cargo install --path crates/repose-cli --locked
 clean:
-	cd crates && cargo clean
+	cargo clean

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ repose <TAB>           # add remove reset install clear uninstall ...
 Regenerate the committed completions (and man pages) from the CLI with:
 
 ```
-cargo run -p repose-cli --features gen --bin repose-gen -- repose-cli
+cargo run -p repose-cli --features gen --bin repose-gen -- crates/repose-cli
 ```
 
 ## Internal Functionality
@@ -282,15 +282,15 @@ when `IdentitiesOnly yes` is set for a host.
 
 ## Building
 
-Repose is a Rust workspace under `crates/`. Build the binary with:
+Repose is a root Rust workspace with crate sources under `crates/`. Build the
+binary with:
 
 ```
-cargo build --release -p repose-cli --manifest-path crates/Cargo.toml
-# binary at crates/target/release/repose
+cargo build --release -p repose-cli
+# binary at target/release/repose
 ```
 
 ## License
 
 This project is licensed under the GPLv3 license, see LICENSE file for
 details.
-

--- a/crates/README.md
+++ b/crates/README.md
@@ -1,7 +1,8 @@
-# repose Rust workspace
+# repose Rust crates
 
-The openSUSE/repose implementation — a Rust workspace (`repose-core` domain
-layer, `repose-ssh` transport, `repose-cli` binary).
+The openSUSE/repose implementation consists of three crates in the root Rust
+workspace (`repose-core` domain layer, `repose-ssh` transport, `repose-cli`
+binary).
 
 ## SSH configuration compatibility
 
@@ -34,19 +35,19 @@ file protected from untrusted writers.
 
 ```bash
 # from repository root
-cargo test --manifest-path crates/Cargo.toml
-cargo fmt --manifest-path crates/Cargo.toml --all -- --check
-cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings
-cargo deny --manifest-path crates/Cargo.toml check   # needs cargo-deny >= 0.18.4 (0.20.x preferred)
-cargo run --manifest-path crates/Cargo.toml -p repose-cli --bin repose
+cargo test --workspace --all-targets --locked
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo deny check   # needs cargo-deny >= 0.18.4 (0.20.x preferred)
+cargo run -p repose-cli --bin repose
 ```
 
-Or `cd crates` and run the same commands without `--manifest-path`.
+Run these commands from the repository root.
 
 ## Policy notes
 
 - **Layering:** `repose-core` must never depend on `repose-ssh` or `russh` (enforced more strictly in PR0.5).
-- **Single SSH backend:** `crates/deny.toml` bans `ssh2` / `libssh2-sys` / async-ssh2-* crates.
+- **Single SSH backend:** `deny.toml` bans `ssh2` / `libssh2-sys` / async-ssh2-* crates.
 - **Path deps** pin the workspace version (`version = "3.0.0"`) so `cargo-deny` `wildcards = "deny"` accepts them.
 - **Binary name:** `repose` (replace strategy; no `repose-rs`).
 
@@ -67,7 +68,7 @@ generator crates):
 
 ```bash
 # from repository root (the argument is the output directory)
-cargo run --manifest-path crates/Cargo.toml -p repose-cli --features gen --bin repose-gen -- crates/repose-cli
+cargo run -p repose-cli --features gen --bin repose-gen -- crates/repose-cli
 ```
 
 CI (`rust-assets-drift`) regenerates and `git diff --exit-code`s these paths,

--- a/crates/repose-core/Cargo.toml
+++ b/crates/repose-core/Cargo.toml
@@ -20,11 +20,9 @@ serde_json = "1"
 serde_yaml = "0.9"
 thiserror = "2"
 # URL probe (async path baseline).
-# rustls-tls-native-roots loads the OS/system trust store (rustls-native-certs)
-# so internal enterprise mirrors signed by a private CA (e.g. SUSE Trust Root)
-# validate, matching Python's system-CA behavior. The system store also carries
-# the public Mozilla roots on real hosts, so public https keeps working.
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "http2"] }
+# reqwest's rustls feature uses the platform verifier, so internal enterprise
+# mirrors signed by a private CA validate against the OS trust configuration.
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "http2"] }
 # Bounded-concurrency probe fan-out (StreamExt::buffered)
 futures-util = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 # XML parsers (zypper -x lr, .prod)

--- a/crates/repose-core/src/probe.rs
+++ b/crates/repose-core/src/probe.rs
@@ -9,11 +9,9 @@ use crate::traits::Probe;
 
 const SUFFIXES: &[&str] = &["repodata/repomd.xml", "suse/repodata/repomd.xml"];
 
-/// Default async probe using rustls with the OS/system trust store
-/// (`rustls-tls-native-roots`), so internal enterprise mirrors signed by a
-/// private CA (e.g. the internal SUSE CA / "SUSE Trust Root") validate just as
-/// they do under Python's system-CA probe. Public https keeps working because
-/// real hosts also carry the Mozilla roots in their system store.
+/// Default async probe using rustls's platform verifier, so internal enterprise
+/// mirrors signed by a private CA (e.g. the internal SUSE CA / "SUSE Trust
+/// Root") validate just as they do under Python's system-CA probe.
 #[derive(Debug, Clone)]
 pub struct HttpProbe {
     /// `None` when client construction failed (e.g. the native root store

--- a/deny.toml
+++ b/deny.toml
@@ -1,12 +1,10 @@
 # cargo-deny config for the repose Rust workspace (cargo-deny >= 0.18.4 / 0.20.x).
 #
-# From crates/:
+# From the repository root:
 #   cargo deny check
-# From repo root:
-#   cargo deny -c crates/deny.toml --manifest-path crates/Cargo.toml check
 #
-# CI: EmbarkStudios/cargo-deny-action@v2 with manifest-path=crates/Cargo.toml
-# (discovers this file next to the workspace Cargo.toml).
+# CI: EmbarkStudios/cargo-deny-action@v2 discovers this file next to the
+# workspace Cargo.toml.
 
 [graph]
 all-features = false

--- a/scripts/check-cli.sh
+++ b/scripts/check-cli.sh
@@ -6,7 +6,7 @@
 # subcommands). Fully self-contained — no external `repose` is consulted.
 #
 # Env:
-#   REPOSE_RS   command for the Rust binary (default: crates/target/debug/repose).
+#   REPOSE_RS   command for the Rust binary (default: target/debug/repose).
 #   FIXTURE     products.yml used for known-products (default: the committed
 #               sample fixture).
 #   GOLDEN      expected known-products output (default: the committed vector).
@@ -14,7 +14,7 @@
 # Run from the repository root.
 set -euo pipefail
 
-read -ra RS <<<"${REPOSE_RS:-crates/target/debug/repose}"
+read -ra RS <<<"${REPOSE_RS:-target/debug/repose}"
 FIXTURE="${FIXTURE:-tests/vectors/template/sample.yml}"
 GOLDEN="${GOLDEN:-tests/vectors/cli/known_products.txt}"
 
@@ -22,41 +22,44 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
 fail() {
-  echo "CLI CHECK FAIL: $*" >&2
-  exit 1
+	echo "CLI CHECK FAIL: $*" >&2
+	exit 1
 }
 ok() { echo "  ok: $*"; }
 
 # Run `<binary> -c FIXTURE known-products` into $2, or fail with diagnostics.
 # `-c` must precede the subcommand (it is a global option).
 known_products() {
-  local label="$1" out="$2"
-  shift 2
-  "$@" -c "$FIXTURE" known-products >"$out" 2>"$tmp/err" ||
-    { cat "$tmp/err" >&2; fail "$label known-products exited non-zero"; }
+	local label="$1" out="$2"
+	shift 2
+	"$@" -c "$FIXTURE" known-products >"$out" 2>"$tmp/err" ||
+		{
+			cat "$tmp/err" >&2
+			fail "$label known-products exited non-zero"
+		}
 }
 
-[ -f "${RS[0]}" ] || fail "Rust binary not found: ${RS[*]} (build: cargo build -p repose-cli --manifest-path crates/Cargo.toml)"
+[ -f "${RS[0]}" ] || fail "Rust binary not found: ${RS[*]} (build: cargo build -p repose-cli)"
 [ -f "$FIXTURE" ] || fail "fixture not found: $FIXTURE"
 [ -f "$GOLDEN" ] || fail "expected output not found: $GOLDEN"
 
 # 1. known-products == committed expected output (byte-exact, trailing bytes included).
 known_products "Rust" "$tmp/rs.txt" "${RS[@]}"
 if ! cmp -s "$tmp/rs.txt" "$GOLDEN"; then
-  diff "$GOLDEN" "$tmp/rs.txt" >&2 || true
-  fail "known-products differs from committed expected output $GOLDEN"
+	diff "$GOLDEN" "$tmp/rs.txt" >&2 || true
+	fail "known-products differs from committed expected output $GOLDEN"
 fi
 ok "known-products == committed expected output (byte-exact)"
 
 # 2. Must NOT expose --ssh-backend (intentional single-backend CLI surface).
 if "${RS[@]}" --help 2>&1 | grep -q -- '--ssh-backend'; then
-  fail "help reintroduced --ssh-backend"
+	fail "help reintroduced --ssh-backend"
 fi
 ok "no --ssh-backend in help"
 
 # 3. Version line shape: `repose version: X.Y.Z` (whole line).
 if ! "${RS[@]}" --version 2>&1 | grep -Eq '^repose version: [0-9]+\.[0-9]+\.[0-9]+$'; then
-  fail "--version line does not match 'repose version: X.Y.Z'"
+	fail "--version line does not match 'repose version: X.Y.Z'"
 fi
 ok "version line shape"
 
@@ -64,8 +67,8 @@ ok "version line shape"
 #    (anchored so e.g. `uninstall` cannot stand in for a removed `install`).
 rs_help="$("${RS[@]}" --help 2>&1)"
 for sub in add remove reset install clear uninstall list-products list-repos known-products; do
-  printf '%s\n' "$rs_help" | grep -qE "^[[:space:]]+${sub}([[:space:]]|\$)" ||
-    fail "subcommand missing from help command column: $sub"
+	printf '%s\n' "$rs_help" | grep -qE "^[[:space:]]+${sub}([[:space:]]|\$)" ||
+		fail "subcommand missing from help command column: $sub"
 done
 ok "all nine subcommands present"
 

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -15,7 +15,7 @@ command -v jq >/dev/null || {
 }
 
 mkdir -p "$COVERAGE_DIR"
-cd "$ROOT/crates"
+cd "$ROOT"
 
 cargo llvm-cov clean --workspace
 cargo llvm-cov --workspace --all-targets --locked --no-report

--- a/scripts/check-rust-layering.sh
+++ b/scripts/check-rust-layering.sh
@@ -3,26 +3,26 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-MANIFEST="${ROOT}/crates/Cargo.toml"
+MANIFEST="${ROOT}/Cargo.toml"
 
 if ! command -v cargo >/dev/null 2>&1; then
-  echo "cargo not found" >&2
-  exit 1
+	echo "cargo not found" >&2
+	exit 1
 fi
 
 tree="$(cargo tree --manifest-path "$MANIFEST" -p repose-core --edges normal --prefix none --format '{p}')"
 
 if echo "$tree" | grep -E '(^| )repose-ssh( |$)|(^| )russh( |$)|russh-' >/dev/null; then
-  echo "LAYERING VIOLATION: repose-core must not depend on repose-ssh or russh" >&2
-  echo "$tree" >&2
-  exit 1
+	echo "LAYERING VIOLATION: repose-core must not depend on repose-ssh or russh" >&2
+	echo "$tree" >&2
+	exit 1
 fi
 
 # Positive check: core package appears.
 if ! echo "$tree" | grep -q 'repose-core'; then
-  echo "unexpected cargo tree output for repose-core" >&2
-  echo "$tree" >&2
-  exit 1
+	echo "unexpected cargo tree output for repose-core" >&2
+	echo "$tree" >&2
+	exit 1
 fi
 
 echo "layering ok: repose-core has no repose-ssh/russh dependency"


### PR DESCRIPTION
## Summary
Move the Cargo workspace metadata and dependency policy to the repository root so standard Cargo commands work without working-directory or manifest-path exceptions. Crate sources remain under `crates/`, and the Rust 1.96 MSRV is preserved.

## Changes
- move `Cargo.toml`, `Cargo.lock`, and `deny.toml` from `crates/` to the repository root
- update CI, release, Dependabot, Makefile, scripts, and documentation for root-level Cargo commands and `target/`
- refresh the dependency graph and upgrade reqwest to 0.13 with rustls platform verification

## Breaking Changes
None. Crate names, source locations, CLI behavior, and the declared MSRV are unchanged.

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy --workspace --all-targets --features gen --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked` (185 tests)
- `cargo deny check`
- explicit Rust 1.96 workspace build
- `bash scripts/check-rust-layering.sh`
- `bash scripts/check-cli.sh`
- generated asset drift check
- `shellcheck` for changed shell scripts
- `cargo update --verbose` reports no further compatible updates

## Reviewer notes
The stable crypto releases reported by `cargo update --verbose` remain blocked by `russh`'s prerelease dependency constraints; the lockfile is otherwise current.