### PR TITLE
ci(dependabot): ignore dtolnay/rust-toolchain updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,13 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # dtolnay/rust-toolchain pins the Rust version in the git ref (e.g.
+    # @1.96 installs Rust 1.96), not the action's own release version.
+    # Dependabot reads the ref as semver and "bumps" it to nonexistent
+    # Rust toolchains (e.g. 1.100). The MSRV must only change deliberately
+    # alongside Cargo.toml `rust-version` and rust-toolchain.toml.
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"
     groups:
       actions-minor-patch:
         update-types:


### PR DESCRIPTION
Dependabot (see #229) tried to bump `dtolnay/rust-toolchain@1.96` -> `1.100`, but Rust 1.100 does not exist.

## Why this happens

The `dtolnay/rust-toolchain` action encodes the **Rust version** in the git ref (`@1.96` installs Rust 1.96), not in the action's own release tags. Dependabot reads the ref as semver and, since numerically `1.100 > 1.96`, proposes a "newer" version — a nonexistent toolchain. Merging it would break the MSRV job by trying to install a Rust release that was never published.

## Fix

Exclude `dtolnay/rust-toolchain` from Dependabot updates. The MSRV pin must only change deliberately alongside `Cargo.toml` `rust-version` and `rust-toolchain.toml`. `taiki-e/install-action` remains managed by the `actions-minor-patch` group, so legitimate action bumps keep flowing.