### PR TITLE
chore: finish the const-fn sweep from the #221 perf review

### DIFF
--- a/crates/repose-core/src/console.rs
+++ b/crates/repose-core/src/console.rs
@@ -60,7 +60,7 @@ pub struct Console<W: Write> {
 }
 
 impl<W: Write> Console<W> {
-    pub fn new(stream: W) -> Self {
+    pub const fn new(stream: W) -> Self {
         Self {
             stream,
             format: OutputFormat::Text,

--- a/crates/repose-core/src/shell.rs
+++ b/crates/repose-core/src/shell.rs
@@ -4,7 +4,7 @@
 //! are the merge gate for any remote command interpolation (design R2 / PR2).
 
 /// Python 3 `shlex.quote` uses `_find_unsafe = re.compile(r'[^\w@%+=:,./-]', re.ASCII)`.
-fn is_safe_char(c: char) -> bool {
+const fn is_safe_char(c: char) -> bool {
     c.is_ascii_alphanumeric()
         || matches!(c, '_' | '@' | '%' | '+' | '=' | ':' | ',' | '.' | '/' | '-')
 }

--- a/crates/repose-core/src/template.rs
+++ b/crates/repose-core/src/template.rs
@@ -137,7 +137,7 @@ fn merge_into(map: &mut serde_yaml::Mapping, merged: serde_yaml::Value) -> Resul
     Ok(())
 }
 
-fn yaml_type_name(v: &serde_yaml::Value) -> &'static str {
+const fn yaml_type_name(v: &serde_yaml::Value) -> &'static str {
     match v {
         serde_yaml::Value::Null => "null",
         serde_yaml::Value::Bool(_) => "bool",
@@ -149,7 +149,7 @@ fn yaml_type_name(v: &serde_yaml::Value) -> &'static str {
     }
 }
 
-fn type_name(v: &Value) -> &'static str {
+const fn type_name(v: &Value) -> &'static str {
     match v {
         Value::Null => "null",
         Value::Bool(_) => "bool",

--- a/crates/repose-core/src/types.rs
+++ b/crates/repose-core/src/types.rs
@@ -23,7 +23,7 @@ pub struct System {
 
 impl System {
     #[must_use]
-    pub fn is_transactional(&self) -> bool {
+    pub const fn is_transactional(&self) -> bool {
         self.transactional
     }
 
@@ -33,7 +33,7 @@ impl System {
     }
 
     #[must_use]
-    pub fn get_base(&self) -> &Product {
+    pub const fn get_base(&self) -> &Product {
         &self.base
     }
 

--- a/crates/repose-ssh/src/lib.rs
+++ b/crates/repose-ssh/src/lib.rs
@@ -17,7 +17,7 @@ pub use repose_core::VERSION as CORE_VERSION;
 
 /// Confirms the workspace link to `repose-core` at compile time.
 #[must_use]
-pub fn core_version() -> &'static str {
+pub const fn core_version() -> &'static str {
     CORE_VERSION
 }
 


### PR DESCRIPTION
Completes the `missing_const_for_fn` pass from the #221 performance review: five files' `const fn` qualifiers were prepared during the review but missed the final commit. With these, the workspace is clippy-clean with `-W clippy::missing_const_for_fn -W clippy::redundant_clone`.

Verified: fmt, clippy `-D warnings`, 185 workspace tests `--all-targets --locked` — all green.

_AI-assisted._