### PR TITLE
ci(release): ship a versioned, self-contained release tarball + checksum

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,17 @@ jobs:
       - name: Build release binary
         run: cargo build --release --locked -p repose-cli
 
+      - name: Package release artifact
+        run: |
+          triple="x86_64-unknown-linux-gnu"
+          dist="repose-${GITHUB_REF_NAME}-${triple}"
+          mkdir "$dist"
+          cp target/release/repose LICENSE README.md "$dist/"
+          cp -r crates/repose-cli/man crates/repose-cli/completions "$dist/"
+          tar czf "${dist}.tar.gz" "$dist"
+          sha256sum "${dist}.tar.gz" >"${dist}.tar.gz.sha256"
+          echo "DIST=$dist" >>"$GITHUB_ENV"
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -46,4 +57,4 @@ jobs:
           gh release create "$GITHUB_REF_NAME"
           --title "$GITHUB_REF_NAME"
           --generate-notes
-          target/release/repose
+          "${DIST}.tar.gz" "${DIST}.tar.gz.sha256"


### PR DESCRIPTION
The release job (tag -> `gh release create`) attached the bare `repose` binary. This packages it as `repose-<tag>-x86_64-unknown-linux-gnu.tar.gz` (binary + LICENSE + README + man pages + completions) with a `.sha256`, so the release asset is self-describing, verifiable, and won't collide if more architectures are added later. The tag->release trigger and the tag==`version` gate are unchanged.

_AI-assisted._