### PR TITLE
ci: dependency-review, rustdoc-lint, typos, OpenSSF Scorecard

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,41 @@
+---
+name: dependency-review
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+  # Write only so the action can post its summary comment on the PR.
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs, but let master/tag runs finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  dependency-review:
+    # Block PRs that add a vulnerable or GPL-incompatible dependency before
+    # merge. Complements Dependabot, which only alerts once code is on master.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Dependency review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+          # This is a GPL-3.0-or-later project: reject dependencies whose
+          # license is incompatible with GPLv3. Permissive / GPL-compatible
+          # licenses (MIT, Apache-2.0, BSD-2/3-Clause, MPL-2.0, ...) are
+          # intentionally NOT listed here.
+          deny-licenses: >-
+            GPL-2.0-only,
+            LGPL-2.1-only,
+            CDDL-1.0,
+            EPL-1.0,
+            EPL-2.0,
+            MPL-1.1,
+            OSL-3.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,32 @@
+---
+name: docs
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs, but let master/tag runs finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  docs:
+    # Build rustdoc with warnings as errors so broken intra-doc links fail CI.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: . -> target
+      - name: cargo doc
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --workspace --no-deps --locked

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,54 @@
+---
+name: scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "42 3 * * 1"
+  push:
+    branches:
+      - master
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to OpenSSF REST API for easy access by consumers
+          # and to enable the Scorecard badge on the repository.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,25 @@
+---
+name: typos
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs, but let master runs finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  typos:
+    # Source spell-check (code, docs, comments). Config: typos.toml at the
+    # repo root (allowlist-only; auto-discovered by the action).
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Spell check
+        uses: crate-ci/typos@dbe52f72499cd4ab666928e4d14ecfa9ddbb6852  # v1.48.0

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Adding SDK repository to SLE of any version:
 repose add -t fubar.suse.cz sle-sdk
 ```
 
-Adding specificaly SDK repository of SLE 12 SP2:
+Adding specifically SDK repository of SLE 12 SP2:
 
 ```
 repose add -t fubar.suse.cz sle-sdk:12-SP2

--- a/crates/repose-core/src/commands/mod.rs
+++ b/crates/repose-core/src/commands/mod.rs
@@ -1,4 +1,4 @@
-//! Command algorithms against [`crate::traits::Host`] / [`HostGroup`].
+//! Command algorithms against [`crate::traits::Host`] / [`crate::traits::HostGroup`].
 
 mod add;
 mod clear;

--- a/crates/repose-core/src/display.rs
+++ b/crates/repose-core/src/display.rs
@@ -177,7 +177,7 @@ fn push_version(s: &mut String, v: &Value, indent: &str) {
 /// Hand-rolled to byte-match ruamel's safe dumper: `---`/`...` document
 /// markers, alphabetically sorted top-level keys (addons, arch, location,
 /// name, product), version leaves run through `transform_version_partialy`.
-/// The addon list order is sorted (see [`sorted_addons`]).
+/// The addon list order is sorted (see `sorted_addons`).
 pub fn list_products_yaml<W: Write>(
     out: &mut W,
     hostname: &str,
@@ -242,7 +242,7 @@ fn version_json(v: &Value) -> String {
 /// **to_refhost_dict_partially_normalized(), "name": <hostname>}` — i.e. key
 /// order event, host, location, arch, product, addons, name, byte-matching
 /// `json.dumps` (default separators and `ensure_ascii`). The addon list order
-/// is sorted (see [`sorted_addons`]).
+/// is sorted (see `sorted_addons`).
 pub fn list_products_yaml_json<W: Write>(
     out: &mut W,
     hostname: &str,

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,27 @@
+# Configuration for crate-ci/typos (https://github.com/crate-ci/typos).
+# Allowlist ONLY: every entry is a deliberate, load-bearing spelling or a
+# generated/captured artifact — never a masked real typo.
+
+[files]
+extend-exclude = [
+  # Real refhost fixtures / captured tool output: byte-identical data
+  # snapshots, not prose to spell-check (e.g. "sle-hae", "Unknow version").
+  "tests/vectors/**",
+  # Generated from the clap CLI (see the rust-assets-drift job); the authored
+  # source that produces them is still spell-checked.
+  "crates/repose-cli/completions/**",
+  "crates/repose-cli/man/**",
+]
+
+[default.extend-words]
+# `transform_version_partialy`: spelling deliberately preserved to mirror the
+# Python fn repose.types.refhost.transformations.transform_version_partialy.
+partialy = "partialy"
+# Error string / exception name mirrored verbatim from the Python impl
+# ("Unknow version: ...", Python `UnsuportedProductMessage`).
+unknow = "unknow"
+unsuported = "unsuported"
+# Fragments of "Qualität"/"café" split by \uXXXX escapes in display.rs
+# json.dumps parity tests (e.g. "Qualität", "café").
+qualit = "qualit"
+caf = "caf"


### PR DESCRIPTION
Four self-contained CI hardening workflows, all SHA-pinned with least-privilege `permissions` (matching the existing ci.yml style):

- **dependency-review** — blocks a PR that pulls in a vulnerable or GPLv3-incompatible dependency (complements dependabot, which only alerts post-merge).
- **docs** — `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings` to fail on broken intra-doc links; also fixes the three pre-existing broken links it surfaced.
- **typos** — `crate-ci/typos` with a minimal allowlist (Python-parity identifiers, sanitized refhost fixtures, generated assets); fixes one real README typo.
- **scorecard** — weekly OpenSSF Scorecard, SARIF uploaded to the Security tab.

_AI-assisted._