### PR TITLE
ci: code coverage via cargo-llvm-cov + Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,40 @@
+---
+name: coverage
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: . -> target
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b  # v2.83.4
+        with:
+          tool: cargo-llvm-cov
+      - name: Collect coverage
+        run: cargo llvm-cov --workspace --locked --lcov --output-path lcov.info
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5.5.5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+# Codecov configuration. Coverage is informational (reported, not merge-blocking)
+# to start; tighten to blocking once a baseline settles.
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+# Non-code / generated / fixture trees excluded from coverage accounting.
+ignore:
+  - "crates/repose-cli/man/**"
+  - "crates/repose-cli/completions/**"
+  - "tests/vectors/**"


### PR DESCRIPTION
Adds a `coverage` workflow (cargo-llvm-cov → lcov → `codecov/codecov-action`, SHA-pinned) and a `codecov.yml`. Coverage is **informational** to start (reports on PRs, does not block merges) with man pages / completions / `tests/vectors` fixtures ignored.

Requires a `CODECOV_TOKEN` repository secret (Codecov new-repo setup) — until it's added the upload step is a no-op with `fail_ci_if_error: false`, so this PR is safe to merge first.

_AI-assisted._