### PR TITLE
feat(display): restore Python 2.1.0 color output in list-* commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,7 +2010,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "repose-cli"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "repose-core"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "repose-ssh"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ members = [
 ]
 
 [workspace.package]
-version = "3.0.0"
-edition = "2021"
+version = "3.1.0"
+edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/openSUSE/repose"
 rust-version = "1.96"

--- a/crates/README.md
+++ b/crates/README.md
@@ -48,7 +48,7 @@ Run these commands from the repository root.
 
 - **Layering:** `repose-core` must never depend on `repose-ssh` or `russh` (enforced more strictly in PR0.5).
 - **Single SSH backend:** `deny.toml` bans `ssh2` / `libssh2-sys` / async-ssh2-* crates.
-- **Path deps** pin the workspace version (`version = "3.0.0"`) so `cargo-deny` `wildcards = "deny"` accepts them.
+- **Path deps** pin the workspace version (`version = "3.1.0"`) so `cargo-deny` `wildcards = "deny"` accepts them.
 - **Binary name:** `repose` (replace strategy; no `repose-rs`).
 
 The Python implementation was removed at cutover; behavior is pinned by the

--- a/crates/repose-cli/man/repose-add.1
+++ b/crates/repose-cli/man/repose-add.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-add 1  "repose-add 3.0.0" 
+.TH repose-add 1  "repose-add 3.1.0" 
 .SH NAME
 repose\-add \- add specified repository to target
 .SH SYNOPSIS
@@ -90,4 +90,4 @@ Print help
 <\fIREPA\fR>
 REPA pattern specification for needed repository
 .SH VERSION
-v3.0.0
+v3.1.0

--- a/crates/repose-cli/man/repose-clear.1
+++ b/crates/repose-cli/man/repose-clear.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-clear 1  "repose-clear 3.0.0" 
+.TH repose-clear 1  "repose-clear 3.1.0" 
 .SH NAME
 repose\-clear \- clear all repositories from target
 .SH SYNOPSIS
@@ -81,4 +81,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.0.0
+v3.1.0

--- a/crates/repose-cli/man/repose-install.1
+++ b/crates/repose-cli/man/repose-install.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-install 1  "repose-install 3.0.0" 
+.TH repose-install 1  "repose-install 3.1.0" 
 .SH NAME
 repose\-install \- add specified repository to target and install product
 .SH SYNOPSIS
@@ -93,4 +93,4 @@ Print help
 <\fIREPA\fR>
 REPA pattern specification for needed repository
 .SH VERSION
-v3.0.0
+v3.1.0

--- a/crates/repose-cli/man/repose-known-products.1
+++ b/crates/repose-cli/man/repose-known-products.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-known-products 1  "repose-known-products 3.0.0" 
+.TH repose-known-products 1  "repose-known-products 3.1.0" 
 .SH NAME
 repose\-known\-products \- list known products by \*(Aqrepose\*(Aq
 .SH SYNOPSIS
@@ -78,4 +78,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.0.0
+v3.1.0

--- a/crates/repose-cli/man/repose-list-products.1
+++ b/crates/repose-cli/man/repose-list-products.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-list-products 1  "repose-list-products 3.0.0" 
+.TH repose-list-products 1  "repose-list-products 3.1.0" 
 .SH NAME
 repose\-list\-products \- list products on target
 .SH SYNOPSIS
@@ -84,4 +84,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.0.0
+v3.1.0

--- a/crates/repose-cli/man/repose-list-repos.1
+++ b/crates/repose-cli/man/repose-list-repos.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-list-repos 1  "repose-list-repos 3.0.0" 
+.TH repose-list-repos 1  "repose-list-repos 3.1.0" 
 .SH NAME
 repose\-list\-repos \- list repositories on target
 .SH SYNOPSIS
@@ -81,4 +81,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.0.0
+v3.1.0

--- a/crates/repose-cli/man/repose-remove.1
+++ b/crates/repose-cli/man/repose-remove.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-remove 1  "repose-remove 3.0.0" 
+.TH repose-remove 1  "repose-remove 3.1.0" 
 .SH NAME
 repose\-remove \- remove repository from target
 .SH SYNOPSIS
@@ -84,4 +84,4 @@ Print help
 <\fIREPA\fR>
 REPA pattern specification for needed repository
 .SH VERSION
-v3.0.0
+v3.1.0

--- a/crates/repose-cli/man/repose-reset.1
+++ b/crates/repose-cli/man/repose-reset.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-reset 1  "repose-reset 3.0.0" 
+.TH repose-reset 1  "repose-reset 3.1.0" 
 .SH NAME
 repose\-reset \- reset target repositories to only installed products repositories
 .SH SYNOPSIS
@@ -87,4 +87,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.0.0
+v3.1.0

--- a/crates/repose-cli/man/repose-uninstall.1
+++ b/crates/repose-cli/man/repose-uninstall.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-uninstall 1  "repose-uninstall 3.0.0" 
+.TH repose-uninstall 1  "repose-uninstall 3.1.0" 
 .SH NAME
 repose\-uninstall \- remove specified repository from target and uninstall product
 .SH SYNOPSIS
@@ -87,4 +87,4 @@ Print help
 <\fIREPA\fR>
 REPA pattern specification for needed repository
 .SH VERSION
-v3.0.0
+v3.1.0

--- a/crates/repose-cli/man/repose.1
+++ b/crates/repose-cli/man/repose.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose 1  "repose 3.0.0" 
+.TH repose 1  "repose 3.1.0" 
 .SH NAME
 repose \- Repository manipulation tool for QAM
 .SH SYNOPSIS
@@ -109,4 +109,4 @@ list known products by \*(Aqrepose\*(Aq
 repose\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v3.0.0
+v3.1.0

--- a/crates/repose-cli/src/lib.rs
+++ b/crates/repose-cli/src/lib.rs
@@ -284,7 +284,8 @@ async fn async_main() -> ExitCode {
             return ExitCode::SUCCESS;
         }
         Some(Commands::KnownProducts) => {
-            return known_products(&cli.config, cli.format.into());
+            let color = resolve_color(cli.no_color, cli.color, std::io::stdout().is_terminal());
+            return known_products(&cli.config, cli.format.into(), color);
         }
         Some(other) => other,
     };
@@ -326,8 +327,36 @@ fn init_logging(debug: bool, quiet: bool, no_color: bool) {
         .try_init();
 }
 
-fn known_products(config: &Path, format: CoreFormat) -> ExitCode {
-    match run_known_products(config, format, &mut std::io::stdout()) {
+/// Resolve the effective color decision for stdout `list-*` output, mirroring
+/// `repose_core::console::Console::use_color`: `--no-color`/`--color=never`
+/// force off, `--color=always` forces on, and `auto` honors `NO_COLOR`, then
+/// `COLOR`, then `is_tty`.
+fn resolve_color(no_color: bool, color: Color, is_tty: bool) -> bool {
+    if no_color {
+        return false;
+    }
+    match color {
+        Color::Always => true,
+        Color::Never => false,
+        Color::Auto => {
+            if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+                return false;
+            }
+            if let Ok(c) = std::env::var("COLOR") {
+                if c.eq_ignore_ascii_case("never") {
+                    return false;
+                }
+                if c.eq_ignore_ascii_case("always") {
+                    return true;
+                }
+            }
+            is_tty
+        }
+    }
+}
+
+fn known_products(config: &Path, format: CoreFormat, color: bool) -> ExitCode {
+    match run_known_products(config, format, color, &mut std::io::stdout()) {
         Ok(c) => exit_from(c),
         Err(e) => {
             eprintln!("error: {e}");
@@ -412,6 +441,7 @@ async fn dispatch(cli: Cli, conn: ConnectionConfig, cmd: Commands) -> ExitCode {
         no_reboot,
         format: cli.format.into(),
         yaml: matches!(&cmd, Commands::ListProducts { yaml: true, .. }),
+        color: resolve_color(cli.no_color, cli.color, std::io::stdout().is_terminal()),
     };
 
     let mut group = RusshHostGroup::from_targets(specs, conn);

--- a/crates/repose-cli/src/lib.rs
+++ b/crates/repose-cli/src/lib.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use repose_core::commands::{
-    default_probe, run_add, run_clear, run_install, run_known_products, run_list_products,
-    run_list_repos, run_remove, run_reset, run_uninstall, CommandOptions,
+    CommandOptions, default_probe, run_add, run_clear, run_install, run_known_products,
+    run_list_products, run_list_repos, run_remove, run_reset, run_uninstall,
 };
 use repose_core::console::{ColorMode as CoreColorMode, Console, OutputFormat as CoreFormat};
 use repose_core::host_parse::parse_host;

--- a/crates/repose-cli/tests/cli.rs
+++ b/crates/repose-cli/tests/cli.rs
@@ -132,6 +132,26 @@ fn color_never_flag_contains_no_ansi_escape() {
 }
 
 #[test]
+fn color_always_flag_colorizes_known_products_label() {
+    // Python 2.1.0 colors the `Products known by 'repose':` label green
+    // (utils.green): `\x1b[1;32m…\x1b[1;m\x1b[0m`.
+    let config = vector("template/sample.yml");
+    let output = repose(&[
+        "--color=always",
+        "--config",
+        path(&config),
+        "known-products",
+    ]);
+
+    assert!(output.status.success());
+    assert!(
+        stdout(&output).contains("\x1b[1;32mProducts known by 'repose':\x1b[1;m\x1b[0m"),
+        "{}",
+        stdout(&output)
+    );
+}
+
+#[test]
 fn no_color_env_var_contains_no_ansi_escape() {
     // NO_COLOR is process-global; each subprocess gets an isolated env, so this
     // is the safe place to exercise the env-var force-off precedence.

--- a/crates/repose-core/src/commands/add.rs
+++ b/crates/repose-core/src/commands/add.rs
@@ -1,7 +1,7 @@
 //! `repose add` — resolve REPA, probe, zypper ar, cohort refresh.
 
 use crate::commands::{
-    aggregate, filter_live, load_repoq, run_reported_shared, CommandOptions, SharedConsole,
+    CommandOptions, SharedConsole, aggregate, filter_live, load_repoq, run_reported_shared,
 };
 use crate::console::Console;
 use crate::shell::cmd;

--- a/crates/repose-core/src/commands/clear.rs
+++ b/crates/repose-core/src/commands/clear.rs
@@ -1,6 +1,6 @@
 //! `repose clear` — `zypper rr` every raw alias; never `_report_target`.
 
-use crate::commands::{aggregate, CommandOptions, SharedConsole};
+use crate::commands::{CommandOptions, SharedConsole, aggregate};
 use crate::console::Console;
 use crate::shell::cmd;
 use crate::traits::{Host, HostGroup};

--- a/crates/repose-core/src/commands/install.rs
+++ b/crates/repose-core/src/commands/install.rs
@@ -1,8 +1,8 @@
 //! `repose install` — ar + ref + product install; transactional path.
 
 use crate::commands::{
-    aggregate, filter_live, load_repoq, reboot_and_verify_shared, run_reported_shared,
-    CommandOptions, SharedConsole,
+    CommandOptions, SharedConsole, aggregate, filter_live, load_repoq, reboot_and_verify_shared,
+    run_reported_shared,
 };
 use crate::console::Console;
 use crate::repoq::Repos;

--- a/crates/repose-core/src/commands/list_cmd.rs
+++ b/crates/repose-core/src/commands/list_cmd.rs
@@ -107,10 +107,10 @@ pub fn run_known_products(
 }
 
 fn split_key(key: &str) -> (&str, u16) {
-    if let Some((h, p)) = key.rsplit_once(':') {
-        if let Ok(port) = p.parse() {
-            return (h, port);
-        }
+    if let Some((h, p)) = key.rsplit_once(':')
+        && let Ok(port) = p.parse()
+    {
+        return (h, port);
     }
     (key, 22)
 }

--- a/crates/repose-core/src/commands/list_cmd.rs
+++ b/crates/repose-core/src/commands/list_cmd.rs
@@ -41,7 +41,10 @@ pub async fn run_list_products<W: Write>(
                             let _ = d.list_products(hostname, port, sys);
                         }
                         crate::console::OutputFormat::Text => {
-                            let mut d = TextDisplay { output: &mut *out };
+                            let mut d = TextDisplay {
+                                output: &mut *out,
+                                color: opts.color,
+                            };
                             let _ = d.list_products(hostname, port, sys);
                         }
                     }
@@ -72,7 +75,10 @@ pub async fn run_list_repos<W: Write>(
                     let _ = d.list_repos(hostname, port, repos);
                 }
                 crate::console::OutputFormat::Text => {
-                    let mut d = TextDisplay { output: &mut *out };
+                    let mut d = TextDisplay {
+                        output: &mut *out,
+                        color: opts.color,
+                    };
                     let _ = d.list_repos(hostname, port, repos);
                 }
             }
@@ -85,6 +91,7 @@ pub async fn run_list_repos<W: Write>(
 pub fn run_known_products(
     config: &Path,
     format: crate::console::OutputFormat,
+    color: bool,
     out: &mut impl Write,
 ) -> Result<ExitCode, crate::template::TemplateError> {
     let tpl = load_template(config)?;
@@ -99,7 +106,7 @@ pub fn run_known_products(
             let _ = d.list_known_products(&names);
         }
         crate::console::OutputFormat::Text => {
-            let mut d = TextDisplay { output: out };
+            let mut d = TextDisplay { output: out, color };
             let _ = d.list_known_products(&names);
         }
     }
@@ -125,7 +132,7 @@ mod tests {
         let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("../../tests/vectors/template/sample.yml");
         let mut buf = Buffer::default();
-        run_known_products(&path, crate::console::OutputFormat::Text, &mut buf).unwrap();
+        run_known_products(&path, crate::console::OutputFormat::Text, false, &mut buf).unwrap();
         assert!(buf.0.contains("QA") && buf.0.contains("SLES"));
     }
 

--- a/crates/repose-core/src/commands/mod.rs
+++ b/crates/repose-core/src/commands/mod.rs
@@ -41,6 +41,9 @@ pub struct CommandOptions {
     pub format: OutputFormat,
     /// `list-products --yaml`: emit a YAML refhost spec instead of text/json.
     pub yaml: bool,
+    /// Emit ANSI color in `list-*` text output (resolved from `--color` /
+    /// `--no-color` / `NO_COLOR` / TTY by the CLI).
+    pub color: bool,
 }
 
 impl Default for CommandOptions {
@@ -54,6 +57,7 @@ impl Default for CommandOptions {
             no_reboot: false,
             format: OutputFormat::Text,
             yaml: false,
+            color: false,
         }
     }
 }

--- a/crates/repose-core/src/commands/mod.rs
+++ b/crates/repose-core/src/commands/mod.rs
@@ -26,7 +26,7 @@ use crate::probe::HttpProbe;
 use crate::repa::Repa;
 use crate::repoq::Repoq;
 use crate::shell::cmd;
-use crate::template::{load_template, TemplateError};
+use crate::template::{TemplateError, load_template};
 use crate::traits::{Host, Probe};
 use crate::types::ExitCode;
 

--- a/crates/repose-core/src/commands/remove.rs
+++ b/crates/repose-core/src/commands/remove.rs
@@ -1,6 +1,6 @@
 //! `repose remove` — pattern match aliases, zypper rr.
 
-use crate::commands::{aggregate, run_reported_shared, CommandOptions, SharedConsole};
+use crate::commands::{CommandOptions, SharedConsole, aggregate, run_reported_shared};
 use crate::console::Console;
 use crate::repa::Repa;
 use crate::shell::cmd;

--- a/crates/repose-core/src/commands/reset.rs
+++ b/crates/repose-core/src/commands/reset.rs
@@ -1,7 +1,7 @@
 //! `repose reset` — rr then ar only if full live replacement set.
 
 use crate::commands::{
-    aggregate, load_repoq, partition_live, run_reported_shared, CommandOptions, SharedConsole,
+    CommandOptions, SharedConsole, aggregate, load_repoq, partition_live, run_reported_shared,
 };
 use crate::console::Console;
 use crate::shell::cmd;

--- a/crates/repose-core/src/commands/uninstall.rs
+++ b/crates/repose-core/src/commands/uninstall.rs
@@ -2,7 +2,7 @@
 
 use crate::commands::remove::{calculate_patterns, calculate_repolist};
 use crate::commands::{
-    aggregate, reboot_and_verify_shared, run_reported_shared, CommandOptions, SharedConsole,
+    CommandOptions, SharedConsole, aggregate, reboot_and_verify_shared, run_reported_shared,
 };
 use crate::console::Console;
 use crate::repa::Repa;

--- a/crates/repose-core/src/console.rs
+++ b/crates/repose-core/src/console.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, Write};
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum OutputFormat {
@@ -117,11 +117,11 @@ impl<W: Write> Console<W> {
     fn emit(&mut self, event: &str, level: Level, fields: Value) -> io::Result<()> {
         if self.format == OutputFormat::Json {
             let mut payload = json!({"event": event, "level": level.as_str()});
-            if let Some(obj) = payload.as_object_mut() {
-                if let Some(map) = fields.as_object() {
-                    for (k, v) in map {
-                        obj.insert(k.clone(), v.clone());
-                    }
+            if let Some(obj) = payload.as_object_mut()
+                && let Some(map) = fields.as_object()
+            {
+                for (k, v) in map {
+                    obj.insert(k.clone(), v.clone());
                 }
             }
             writeln!(self.stream, "{payload}")?;

--- a/crates/repose-core/src/display.rs
+++ b/crates/repose-core/src/display.rs
@@ -20,6 +20,31 @@ fn sorted_addons(system: &System) -> Vec<&Product> {
     addons
 }
 
+/// ANSI color helpers ported from Python `repose.utils` (`green`/`yellow`/
+/// `blue`), used by [`TextDisplay`] to color `list-*` / `known-products`
+/// labels and values. The sequences (`\x1b[1;3Nm{s}\x1b[1;m\x1b[0m`, double
+/// reset) are byte-identical to the Python 2.1.0 helpers. Returns `s`
+/// unchanged when `enabled` is false.
+fn green(enabled: bool, s: &str) -> String {
+    wrap(enabled, "\x1b[1;32m", s)
+}
+
+fn yellow(enabled: bool, s: &str) -> String {
+    wrap(enabled, "\x1b[1;33m", s)
+}
+
+fn blue(enabled: bool, s: &str) -> String {
+    wrap(enabled, "\x1b[1;34m", s)
+}
+
+fn wrap(enabled: bool, seq: &str, s: &str) -> String {
+    if enabled {
+        format!("{seq}{s}\x1b[1;m\x1b[0m")
+    } else {
+        s.to_string()
+    }
+}
+
 /// One JSON scalar, matching Python `json.dumps` with its default
 /// `ensure_ascii=True`: serde_json already escapes ASCII controls, `"` and
 /// `\` identically (verified: `json.dumps('tab\tq"b\\s\x01')` ==
@@ -282,14 +307,22 @@ pub trait CommandDisplay {
 
 pub struct TextDisplay<W: Write> {
     pub output: W,
+    /// Emit ANSI color (Python `CommandDisplay` via `utils` color helpers).
+    pub color: bool,
 }
 
 impl<W: Write> CommandDisplay for TextDisplay<W> {
     fn list_products(&mut self, hostname: &str, port: u16, system: &System) -> io::Result<()> {
-        // Mirrors Python `CommandDisplay.list_products` + `System.pretty`
-        // (color disabled when stdout is not a TTY, as here).
+        // Mirrors Python `CommandDisplay.list_products` + `System.pretty`:
+        // `Host` green, hostname/port yellow; the `pretty()` lines stay plain.
         let base = &system.base;
-        writeln!(self.output, "Host: {hostname}:{port}")?;
+        writeln!(
+            self.output,
+            "{}: {}:{}",
+            green(self.color, "Host"),
+            yellow(self.color, hostname),
+            yellow(self.color, &port.to_string()),
+        )?;
         writeln!(
             self.output,
             "  Base product: {}-{}-{}",
@@ -312,17 +345,35 @@ impl<W: Write> CommandDisplay for TextDisplay<W> {
     }
 
     fn list_repos(&mut self, hostname: &str, port: u16, repos: &[Repository]) -> io::Result<()> {
-        writeln!(self.output, "Repositories on {hostname}:{port}")?;
+        // Python `list_update_repos`: `Repositories` green, host/port blue;
+        // per repo the `REPO name`/`REPO URL` labels green, values plain.
+        writeln!(
+            self.output,
+            "{} on {}:{}",
+            green(self.color, "Repositories"),
+            blue(self.color, hostname),
+            blue(self.color, &port.to_string()),
+        )?;
         for r in repos {
-            writeln!(self.output, "REPO name: {}", r.name)?;
-            writeln!(self.output, "REPO URL: {}", r.url)?;
+            writeln!(
+                self.output,
+                "{}: {}",
+                green(self.color, "REPO name"),
+                r.name
+            )?;
+            writeln!(self.output, "{}: {}", green(self.color, "REPO URL"), r.url)?;
         }
         writeln!(self.output)?;
         Ok(())
     }
 
     fn list_known_products(&mut self, products: &[String]) -> io::Result<()> {
-        writeln!(self.output, "Products known by 'repose':")?;
+        // Python `list_known_products`: label green, names line plain.
+        writeln!(
+            self.output,
+            "{}",
+            green(self.color, "Products known by 'repose':")
+        )?;
         writeln!(self.output, "{}", products.join(" "))?;
         writeln!(self.output)?;
         Ok(())
@@ -447,7 +498,10 @@ mod tests {
     #[test]
     fn list_products_text_matches_python_pretty() {
         let mut buf = Buffer::default();
-        let mut d = TextDisplay { output: &mut buf };
+        let mut d = TextDisplay {
+            output: &mut buf,
+            color: false,
+        };
         d.list_products("ulysse.qam.suse.cz", 22, &sample_system())
             .unwrap();
         // Python `f"      Addon: {x.name:<53} - version: {x.version}"`: name is
@@ -458,6 +512,78 @@ mod tests {
              Base product: SL-Micro-6.1-x86_64\n  \
              Installed Extensions and Modules:\n      \
              Addon: SL-Micro-Extras{pad} - version: 6.1\n\n"
+        );
+        assert_eq!(buf.0, expected);
+    }
+
+    #[test]
+    fn color_helpers_match_python_utils_sequences() {
+        // Byte-parity with Python 2.1.0 `utils.green/yellow/blue`
+        // (`\033[1;3Nm{x}\033[1;m\033[0m`); plain passthrough when disabled.
+        assert_eq!(green(true, "Host"), "\x1b[1;32mHost\x1b[1;m\x1b[0m");
+        assert_eq!(yellow(true, "h1"), "\x1b[1;33mh1\x1b[1;m\x1b[0m");
+        assert_eq!(blue(true, "h1"), "\x1b[1;34mh1\x1b[1;m\x1b[0m");
+        assert_eq!(green(false, "Host"), "Host");
+        assert_eq!(yellow(false, "h1"), "h1");
+        assert_eq!(blue(false, "h1"), "h1");
+    }
+
+    #[test]
+    fn list_products_text_colorized_header_matches_python() {
+        let mut buf = Buffer::default();
+        let mut d = TextDisplay {
+            output: &mut buf,
+            color: true,
+        };
+        d.list_products("ulysse.qam.suse.cz", 22, &sample_system())
+            .unwrap();
+        // Header: green `Host`, yellow hostname/port; pretty() lines plain.
+        assert!(buf.0.starts_with(&format!(
+            "{}: {}:{}\n",
+            green(true, "Host"),
+            yellow(true, "ulysse.qam.suse.cz"),
+            yellow(true, "22"),
+        )));
+        assert!(buf.0.contains("  Base product: SL-Micro-6.1-x86_64\n"));
+    }
+
+    #[test]
+    fn list_repos_text_colorized_matches_python() {
+        let mut buf = Buffer::default();
+        let mut d = TextDisplay {
+            output: &mut buf,
+            color: true,
+        };
+        let r = crate::types::Repository {
+            alias: "a".into(),
+            name: "SLES:pool".into(),
+            url: "http://x/".into(),
+            state: true,
+        };
+        d.list_repos("dubai", 22, std::slice::from_ref(&r)).unwrap();
+        let expected = format!(
+            "{} on {}:{}\n{}: SLES:pool\n{}: http://x/\n\n",
+            green(true, "Repositories"),
+            blue(true, "dubai"),
+            blue(true, "22"),
+            green(true, "REPO name"),
+            green(true, "REPO URL"),
+        );
+        assert_eq!(buf.0, expected);
+    }
+
+    #[test]
+    fn known_products_text_colorized_label_matches_python() {
+        let mut buf = Buffer::default();
+        let mut d = TextDisplay {
+            output: &mut buf,
+            color: true,
+        };
+        d.list_known_products(&["SLES".into(), "QA".into()])
+            .unwrap();
+        let expected = format!(
+            "{}\nSLES QA\n\n",
+            green(true, "Products known by 'repose':")
         );
         assert_eq!(buf.0, expected);
     }

--- a/crates/repose-core/src/lib.rs
+++ b/crates/repose-core/src/lib.rs
@@ -27,13 +27,13 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub use config::{ConnectionConfig, HostKeyPolicy};
 pub use error::SshError;
-pub use host_parse::{parse_host, HostParseError, HostSpec};
+pub use host_parse::{HostParseError, HostSpec, parse_host};
 pub use repa::{Repa, RepaError};
 pub use shell::{join as shell_join, quote as shell_quote};
-pub use traits::{last_out_succeeded, Host, HostGroup, Probe, SshSession};
+pub use traits::{Host, HostGroup, Probe, SshSession, last_out_succeeded};
 pub use types::{
-    zypper_exit_ok, ExitCode, OutEntry, Product, Repositories, Repository, System,
-    ZYPPER_SUCCESS_EXIT_CODES,
+    ExitCode, OutEntry, Product, Repositories, Repository, System, ZYPPER_SUCCESS_EXIT_CODES,
+    zypper_exit_ok,
 };
 
 #[cfg(test)]

--- a/crates/repose-core/src/mock.rs
+++ b/crates/repose-core/src/mock.rs
@@ -1,8 +1,8 @@
 //! In-memory [`Host`] / [`HostGroup`] for L2 command tests (no SSH).
 
 use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::task::Poll;
 use std::time::Duration;
 
@@ -466,7 +466,7 @@ impl Probe for MapProbe {
 mod tests {
     use super::*;
     use crate::traits::last_out_succeeded;
-    use crate::types::{zypper_exit_ok, Product};
+    use crate::types::{Product, zypper_exit_ok};
 
     #[tokio::test]
     async fn run_appends_success_exit() {

--- a/crates/repose-core/src/probe.rs
+++ b/crates/repose-core/src/probe.rs
@@ -48,10 +48,10 @@ impl HttpProbe {
                 Ok(resp) if resp.status().as_u16() < 400 => return true,
                 Ok(_) => {
                     // Non-success HEAD *status* (>=400) retries with GET.
-                    if let Ok(resp) = client.get(&target).timeout(timeout).send().await {
-                        if resp.status().as_u16() < 400 {
-                            return true;
-                        }
+                    if let Ok(resp) = client.get(&target).timeout(timeout).send().await
+                        && resp.status().as_u16() < 400
+                    {
+                        return true;
                     }
                 }
                 Err(_) => {

--- a/crates/repose-core/src/product_parse.rs
+++ b/crates/repose-core/src/product_parse.rs
@@ -1,7 +1,7 @@
 //! Pure parsers for `.prod` XML and os-release text (no SFTP).
 
-use quick_xml::events::{BytesRef, Event};
 use quick_xml::Reader;
+use quick_xml::events::{BytesRef, Event};
 
 use crate::types::{Product, System};
 
@@ -66,15 +66,14 @@ pub fn parse_prod_xml(xml: &str, _filename: &str) -> Option<Product> {
             Ok(Event::Start(e)) => {
                 if active.is_some() {
                     text_done = true;
-                } else if depth == 1 {
-                    if let Some(idx) = field_index(e.name().as_ref()) {
-                        if !seen[idx] {
-                            seen[idx] = true;
-                            active = Some(idx);
-                            acc.clear();
-                            text_done = false;
-                        }
-                    }
+                } else if depth == 1
+                    && let Some(idx) = field_index(e.name().as_ref())
+                    && !seen[idx]
+                {
+                    seen[idx] = true;
+                    active = Some(idx);
+                    acc.clear();
+                    text_done = false;
                 }
                 depth += 1;
             }
@@ -84,13 +83,12 @@ pub fn parse_prod_xml(xml: &str, _filename: &str) -> Option<Product> {
                 // "current": tail text after it belongs to no field.
                 if active.is_some() {
                     text_done = true;
-                } else if depth == 1 {
-                    if let Some(idx) = field_index(e.name().as_ref()) {
-                        if !seen[idx] {
-                            seen[idx] = true;
-                            texts[idx] = Some(String::new());
-                        }
-                    }
+                } else if depth == 1
+                    && let Some(idx) = field_index(e.name().as_ref())
+                    && !seen[idx]
+                {
+                    seen[idx] = true;
+                    texts[idx] = Some(String::new());
                 }
             }
             // Character data is fragmented across Text / GeneralRef / CData
@@ -113,12 +111,12 @@ pub fn parse_prod_xml(xml: &str, _filename: &str) -> Option<Product> {
             }
             Ok(Event::End(_)) => {
                 depth -= 1;
-                if depth == 1 {
-                    if let Some(idx) = active.take() {
-                        // Whitespace trim is a documented delta (Python keeps
-                        // `.text` verbatim); real `.prod` files are unpadded.
-                        texts[idx] = Some(acc.trim().to_string());
-                    }
+                if depth == 1
+                    && let Some(idx) = active.take()
+                {
+                    // Whitespace trim is a documented delta (Python keeps
+                    // `.text` verbatim); real `.prod` files are unpadded.
+                    texts[idx] = Some(acc.trim().to_string());
                 }
             }
             Ok(Event::Eof) => break,
@@ -138,10 +136,11 @@ pub fn parse_prod_xml(xml: &str, _filename: &str) -> Option<Product> {
     // only differs on malformed input (excluded from the golden vectors).
     let mut ver = if let Some(bv) = baseversion.filter(|s| !s.is_empty()) {
         let mut v = bv;
-        if let Some(sp) = patchlevel {
-            if sp != "0" && !sp.is_empty() {
-                v = format!("{v}-SP{sp}");
-            }
+        if let Some(sp) = patchlevel
+            && sp != "0"
+            && !sp.is_empty()
+        {
+            v = format!("{v}-SP{sp}");
         }
         v
     } else {
@@ -403,8 +402,7 @@ mod tests {
         let xml =
             "<product><name></name><name>SLES</name><version>1</version><arch>a</arch></product>";
         assert_eq!(parse_prod_xml(xml, "t.prod"), None);
-        let xml =
-            "<product><name>FIRST</name><name>SECOND</name><version>1</version><arch>a</arch></product>";
+        let xml = "<product><name>FIRST</name><name>SECOND</name><version>1</version><arch>a</arch></product>";
         let p = parse_prod_xml(xml, "t.prod").unwrap();
         assert_eq!(p.name, "FIRST");
     }

--- a/crates/repose-core/src/transform.rs
+++ b/crates/repose-core/src/transform.rs
@@ -1,6 +1,6 @@
 //! Version transforms for refhost YAML (`transform_version_partialy` spelling preserved).
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Normalise a version string into major/minor or pass through unchanged.
 ///

--- a/crates/repose-core/tests/refhost_vectors.rs
+++ b/crates/repose-core/tests/refhost_vectors.rs
@@ -33,8 +33,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use repose_core::display::{list_products_yaml, CommandDisplay, JsonDisplay, TextDisplay};
-use repose_core::product_parse::{parse_system, ProdFile};
+use repose_core::display::{CommandDisplay, JsonDisplay, TextDisplay, list_products_yaml};
+use repose_core::product_parse::{ProdFile, parse_system};
 use repose_core::repo_parse::parse_repositories;
 use repose_core::types::{Repository, System};
 
@@ -70,10 +70,10 @@ fn golden(dir: &Path, label: &str, file: &str, rendered: &str) -> String {
 
 /// Replicates `commands::list_cmd::split_key`: `host:port`, defaulting to 22.
 fn split_key(key: &str) -> (&str, u16) {
-    if let Some((h, p)) = key.rsplit_once(':') {
-        if let Ok(port) = p.parse() {
-            return (h, port);
-        }
+    if let Some((h, p)) = key.rsplit_once(':')
+        && let Ok(port) = p.parse()
+    {
+        return (h, port);
     }
     (key, 22)
 }

--- a/crates/repose-core/tests/refhost_vectors.rs
+++ b/crates/repose-core/tests/refhost_vectors.rs
@@ -122,9 +122,12 @@ fn replay(dir: &Path) -> System {
 
 fn render_text(hostname: &str, port: u16, sys: &System) -> String {
     let mut out = Vec::new();
-    TextDisplay { output: &mut out }
-        .list_products(hostname, port, sys)
-        .unwrap();
+    TextDisplay {
+        output: &mut out,
+        color: false,
+    }
+    .list_products(hostname, port, sys)
+    .unwrap();
     String::from_utf8(out).unwrap()
 }
 
@@ -144,9 +147,12 @@ fn render_yaml(hostname: &str, sys: &System) -> String {
 
 fn render_repos_text(hostname: &str, port: u16, repos: &[Repository]) -> String {
     let mut out = Vec::new();
-    TextDisplay { output: &mut out }
-        .list_repos(hostname, port, repos)
-        .unwrap();
+    TextDisplay {
+        output: &mut out,
+        color: false,
+    }
+    .list_repos(hostname, port, repos)
+    .unwrap();
     String::from_utf8(out).unwrap()
 }
 

--- a/crates/repose-ssh/src/host.rs
+++ b/crates/repose-ssh/src/host.rs
@@ -8,10 +8,10 @@ use futures_util::future::join_all;
 use repose_core::config::ConnectionConfig;
 use repose_core::error::SshError;
 use repose_core::host_parse::HostSpec;
-use repose_core::product_parse::{parse_system, ProdFile, TRANSACTIONAL_CONF_PATHS};
+use repose_core::product_parse::{ProdFile, TRANSACTIONAL_CONF_PATHS, parse_system};
 use repose_core::repo_parse::parse_repositories;
 use repose_core::traits::{Host, HostGroup, SshSession};
-use repose_core::types::{repositories_from_raw, OutEntry, Repositories, Repository, System};
+use repose_core::types::{OutEntry, Repositories, Repository, System, repositories_from_raw};
 
 use crate::session::RusshSession;
 
@@ -169,7 +169,7 @@ impl Host for RusshHost {
             None => {
                 return Err(SshError::Other(
                     "no output recorded for zypper -x lr".into(),
-                ))
+                ));
             }
         };
         if matches!(exitcode, 0 | 106 | 6) {

--- a/crates/repose-ssh/src/lib.rs
+++ b/crates/repose-ssh/src/lib.rs
@@ -11,9 +11,9 @@ pub mod session;
 pub use host::{RusshHost, RusshHostGroup};
 pub use session::RusshSession;
 
+pub use repose_core::VERSION as CORE_VERSION;
 pub use repose_core::error::SshError;
 pub use repose_core::traits::{Host, HostGroup, Probe, SshSession};
-pub use repose_core::VERSION as CORE_VERSION;
 
 /// Confirms the workspace link to `repose-core` at compile time.
 #[must_use]

--- a/crates/repose-ssh/src/session.rs
+++ b/crates/repose-ssh/src/session.rs
@@ -15,7 +15,7 @@ use repose_core::error::SshError;
 use repose_core::traits::SshSession;
 use russh::client::{self, Handler};
 use russh::keys::agent::client::AgentClient;
-use russh::keys::{load_secret_key, Algorithm, PrivateKeyWithHashAlg};
+use russh::keys::{Algorithm, PrivateKeyWithHashAlg, load_secret_key};
 use russh::{ChannelMsg, Disconnect, Preferred};
 use russh_sftp::client::SftpSession;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};

--- a/crates/repose-ssh/tests/ssh_integration.rs
+++ b/crates/repose-ssh/tests/ssh_integration.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use repose_core::host_parse::{parse_host, HostSpec};
+use repose_core::host_parse::{HostSpec, parse_host};
 use repose_core::{ConnectionConfig, HostKeyPolicy};
 use repose_ssh::{Host, HostGroup, RusshHost, RusshHostGroup, RusshSession, SshSession};
 use tempfile::tempdir;
@@ -112,16 +112,20 @@ async fn live_session_covers_auth_host_keys_commands_sftp_and_reconnect() {
         .read_file("/etc/products.d/SLES.prod")
         .await
         .expect("base product should be readable");
-    assert!(product
-        .windows(b"<name>SLES</name>".len())
-        .any(|window| window == b"<name>SLES</name>"));
+    assert!(
+        product
+            .windows(b"<name>SLES</name>".len())
+            .any(|window| window == b"<name>SLES</name>")
+    );
     let second_read = strict
         .read_file("/etc/products.d/qa.prod")
         .await
         .expect("cached SFTP session should remain usable");
-    assert!(second_read
-        .windows(b"<name>qa</name>".len())
-        .any(|window| window == b"<name>qa</name>"));
+    assert!(
+        second_read
+            .windows(b"<name>qa</name>".len())
+            .any(|window| window == b"<name>qa</name>")
+    );
 
     strict.close().await.expect("session should close");
     assert!(!strict.is_active());


### PR DESCRIPTION
## Summary

The Rust port of `CommandDisplay` dropped all ANSI coloring that Python 2.1.0 emitted for `list-products`, `list-repos`, and `known-products` text output. The `console.rs` host-prefix coloring was ported, but the `display.rs` label/value coloring was not, so most user-facing strings rendered plain compared to the Python version.

This restores that coloring, matching Python 2.1.0 byte-for-byte.

## What changed

- Added `green`/`yellow`/`blue` helpers in `display.rs` reproducing `utils.py`'s exact sequences (`\x1b[1;3Nm…\x1b[1;m\x1b[0m`, including the double reset).
- Added a `color: bool` toggle to `TextDisplay`, threaded from the CLI through `CommandOptions`.
- Colorized the three commands as Python did:
  - `list-products`: `Host` green, hostname/port yellow (the `pretty()` Base product / Addon lines stay plain, as in Python).
  - `list-repos`: `Repositories` green, host/port blue, `REPO name`/`REPO URL` labels green.
  - `known-products`: `Products known by 'repose':` label green.
- Color is resolved by the same `--color`/`--no-color`/`NO_COLOR`/`COLOR`/TTY logic the `Console` already uses, so the flags apply consistently to list output.

## Behavior / compatibility

- Color-off path is unchanged: the committed `tests/vectors/refhosts/**/*.text` golden vectors still match (generated non-TTY / color-off).
- `--no-color`, `--color=never`, and `NO_COLOR` emit zero ESC bytes in all three commands.

## Tests

- New unit tests in `display.rs`: helper byte-parity + each colorized method.
- New CLI subprocess test asserting `--color=always known-products` colors the label; existing no-color/never/NO_COLOR tests continue to verify no ESC bytes.
- Full gate green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --all-targets --locked`, plus the crate-layering check.