### PR TITLE
chore(release): 3.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,7 +2010,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "repose-cli"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "repose-core"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "repose-ssh"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.1.0"
+version = "3.1.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/openSUSE/repose"

--- a/crates/README.md
+++ b/crates/README.md
@@ -48,7 +48,7 @@ Run these commands from the repository root.
 
 - **Layering:** `repose-core` must never depend on `repose-ssh` or `russh` (enforced more strictly in PR0.5).
 - **Single SSH backend:** `deny.toml` bans `ssh2` / `libssh2-sys` / async-ssh2-* crates.
-- **Path deps** pin the workspace version (`version = "3.1.0"`) so `cargo-deny` `wildcards = "deny"` accepts them.
+- **Path deps** pin the workspace version (`version = "3.1.1"`) so `cargo-deny` `wildcards = "deny"` accepts them.
 - **Binary name:** `repose` (replace strategy; no `repose-rs`).
 
 The Python implementation was removed at cutover; behavior is pinned by the

--- a/crates/repose-cli/man/repose-add.1
+++ b/crates/repose-cli/man/repose-add.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-add 1  "repose-add 3.1.0" 
+.TH repose-add 1  "repose-add 3.1.1" 
 .SH NAME
 repose\-add \- add specified repository to target
 .SH SYNOPSIS
@@ -90,4 +90,4 @@ Print help
 <\fIREPA\fR>
 REPA pattern specification for needed repository
 .SH VERSION
-v3.1.0
+v3.1.1

--- a/crates/repose-cli/man/repose-clear.1
+++ b/crates/repose-cli/man/repose-clear.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-clear 1  "repose-clear 3.1.0" 
+.TH repose-clear 1  "repose-clear 3.1.1" 
 .SH NAME
 repose\-clear \- clear all repositories from target
 .SH SYNOPSIS
@@ -81,4 +81,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.1.0
+v3.1.1

--- a/crates/repose-cli/man/repose-install.1
+++ b/crates/repose-cli/man/repose-install.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-install 1  "repose-install 3.1.0" 
+.TH repose-install 1  "repose-install 3.1.1" 
 .SH NAME
 repose\-install \- add specified repository to target and install product
 .SH SYNOPSIS
@@ -93,4 +93,4 @@ Print help
 <\fIREPA\fR>
 REPA pattern specification for needed repository
 .SH VERSION
-v3.1.0
+v3.1.1

--- a/crates/repose-cli/man/repose-known-products.1
+++ b/crates/repose-cli/man/repose-known-products.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-known-products 1  "repose-known-products 3.1.0" 
+.TH repose-known-products 1  "repose-known-products 3.1.1" 
 .SH NAME
 repose\-known\-products \- list known products by \*(Aqrepose\*(Aq
 .SH SYNOPSIS
@@ -78,4 +78,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.1.0
+v3.1.1

--- a/crates/repose-cli/man/repose-list-products.1
+++ b/crates/repose-cli/man/repose-list-products.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-list-products 1  "repose-list-products 3.1.0" 
+.TH repose-list-products 1  "repose-list-products 3.1.1" 
 .SH NAME
 repose\-list\-products \- list products on target
 .SH SYNOPSIS
@@ -84,4 +84,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.1.0
+v3.1.1

--- a/crates/repose-cli/man/repose-list-repos.1
+++ b/crates/repose-cli/man/repose-list-repos.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-list-repos 1  "repose-list-repos 3.1.0" 
+.TH repose-list-repos 1  "repose-list-repos 3.1.1" 
 .SH NAME
 repose\-list\-repos \- list repositories on target
 .SH SYNOPSIS
@@ -81,4 +81,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.1.0
+v3.1.1

--- a/crates/repose-cli/man/repose-remove.1
+++ b/crates/repose-cli/man/repose-remove.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-remove 1  "repose-remove 3.1.0" 
+.TH repose-remove 1  "repose-remove 3.1.1" 
 .SH NAME
 repose\-remove \- remove repository from target
 .SH SYNOPSIS
@@ -84,4 +84,4 @@ Print help
 <\fIREPA\fR>
 REPA pattern specification for needed repository
 .SH VERSION
-v3.1.0
+v3.1.1

--- a/crates/repose-cli/man/repose-reset.1
+++ b/crates/repose-cli/man/repose-reset.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-reset 1  "repose-reset 3.1.0" 
+.TH repose-reset 1  "repose-reset 3.1.1" 
 .SH NAME
 repose\-reset \- reset target repositories to only installed products repositories
 .SH SYNOPSIS
@@ -87,4 +87,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.1.0
+v3.1.1

--- a/crates/repose-cli/man/repose-uninstall.1
+++ b/crates/repose-cli/man/repose-uninstall.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-uninstall 1  "repose-uninstall 3.1.0" 
+.TH repose-uninstall 1  "repose-uninstall 3.1.1" 
 .SH NAME
 repose\-uninstall \- remove specified repository from target and uninstall product
 .SH SYNOPSIS
@@ -87,4 +87,4 @@ Print help
 <\fIREPA\fR>
 REPA pattern specification for needed repository
 .SH VERSION
-v3.1.0
+v3.1.1

--- a/crates/repose-cli/man/repose.1
+++ b/crates/repose-cli/man/repose.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose 1  "repose 3.1.0" 
+.TH repose 1  "repose 3.1.1" 
 .SH NAME
 repose \- Repository manipulation tool for QAM
 .SH SYNOPSIS
@@ -109,4 +109,4 @@ list known products by \*(Aqrepose\*(Aq
 repose\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v3.1.0
+v3.1.1


### PR DESCRIPTION
Bumps the workspace version from 3.1.0 to 3.1.1.

- `Cargo.toml`: workspace version bump
- `Cargo.lock`: relocked workspace member entries
- Regenerated committed man pages (`crates/repose-cli/man/*.1`) so the embedded version tracks 3.1.1
- `crates/README.md`: updated the example version in the path-deps policy note

Verified locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --all-targets --locked`, and `cargo deny check` all pass.