### PR TITLE
feat(perf): add performance benchmarking, profiling, and regression-detection tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,13 @@
 /coverage/
 *.rs.bk
 Cargo.lock.bak
+
+# Raw per-workload performance reports (full sample arrays, host_order,
+# etc.) — only the compact tests/performance/baselines/<runner-class>.json
+# summary is committed. See tests/performance/README.md.
+/tests/performance/baselines/raw/
+# Local profiling artifacts (traces are large/tool-specific); only compact
+# manifests under tests/performance/profiles/ are committed.
+/tests/performance/profiles/raw/
+# Criterion's own HTML/statistics reports.
+/target/criterion/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +71,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -277,6 +292,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +354,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -484,10 +532,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -711,6 +798,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -1006,6 +1099,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1351,6 +1455,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1734,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,6 +1784,16 @@ dependencies = [
  "primefield",
  "primeorder",
  "sha2",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2027,6 +2156,7 @@ name = "repose-core"
 version = "3.1.1"
 dependencies = [
  "async-trait",
+ "criterion",
  "futures-util",
  "quick-xml",
  "reqwest",
@@ -2852,6 +2982,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3211,6 +3351,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3218,6 +3374,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -3481,6 +3643,26 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # repose — Rust workspace convenience targets; CI runs the
 # same commands (see .github/workflows/ci.yml).
-.PHONY: build release test fmt fmt-fix clippy deny layer cli assets check install clean
+.PHONY: build release test fmt fmt-fix clippy deny layer cli assets check install clean \
+	perf-smoke perf-baseline perf-compare-test
 
 build:        ## debug build (locked)
 	cargo build --locked
@@ -28,3 +29,13 @@ install:      ## install `repose` into ~/.cargo/bin
 	cargo install --path crates/repose-cli --locked
 clean:
 	cargo clean
+
+# Performance (tests/performance/README.md). Not part of `check` — these
+# are release builds and, for perf-baseline, real timing/RSS measurements
+# that don't belong in the default fast feedback loop.
+perf-smoke:    ## fleet benchmark structural smoke: every ID runs once, no statistics
+	cargo bench -p repose-core --bench fleet --locked -- --test
+perf-baseline: ## full release baseline report for every mock/ssh workload
+	bash scripts/run-performance-baseline.sh
+perf-compare-test: ## comparator fixtures + one real end-to-end regression guardrail
+	bash scripts/test-compare-performance.sh

--- a/crates/repose-core/Cargo.toml
+++ b/crates/repose-core/Cargo.toml
@@ -29,6 +29,12 @@ futures-util = { version = "0.3", default-features = false, features = ["std", "
 quick-xml = { version = "0.41", features = ["serialize"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }
 wiremock = "0.6"
 tempfile = "3"
+# Fleet-scale benchmark (crates/repose-core/benches/fleet.rs).
+criterion = { version = "0.8", default-features = false }
+
+[[bench]]
+name = "fleet"
+harness = false

--- a/crates/repose-core/benches/fleet.rs
+++ b/crates/repose-core/benches/fleet.rs
@@ -1,0 +1,174 @@
+//! P0.3 fleet-scale benchmark: `run_add` / `run_install` / `run_list_products`
+//! at 1/20/100 hosts, including repeated-URL and slow-host variants.
+//!
+//! Labels honestly: this measures local command-algorithm overhead against
+//! [`repose_core::mock`] test doubles, not remote SSH/SFTP/zypper latency
+//! (see `tests/performance/README.md`). Every scenario is fresh per
+//! iteration and checked against the reviewed expectations in
+//! `tests/performance/workloads.json` before Criterion records a sample —
+//! an unreviewed behavior change fails the benchmark run rather than
+//! silently publishing a new number.
+
+mod support;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use repose_core::commands::{run_add, run_install, run_list_products};
+use repose_core::console::{Buffer, Console};
+use repose_core::traits::HostGroup;
+use support::{Scenario, ScenarioConfig, build_list_products_scenario, build_scenario, runtime};
+
+/// Reviewed baseline REPA for the add/install fleet scenarios (see
+/// `tests/vectors/template/sample.yml`: `SLES."15-SP3".update`).
+const ADD_REPA: &str = "SLES:15-SP3:x86_64:update";
+
+fn bench_add(c: &mut Criterion) {
+    let rt = runtime();
+    let mut group = c.benchmark_group("fleet_add");
+    // 100-host iterations cost more (more mock work, and the slow-host
+    // variant carries a real ~20ms delay); a smaller sample count keeps a
+    // full `cargo bench` run within a reasonable wall-clock budget.
+    group.sample_size(20);
+    for hosts in [1usize, 20, 100] {
+        group.bench_function(format!("{hosts}h"), |b| {
+            b.iter(|| {
+                let cfg = ScenarioConfig::new(hosts);
+                let Scenario {
+                    mut group,
+                    metrics,
+                    probe,
+                    opts,
+                    ..
+                } = build_scenario(&cfg, &[ADD_REPA]);
+                rt.block_on(async {
+                    let mut buf = Buffer::default();
+                    let mut console = Console::new(&mut buf);
+                    let code = run_add(&opts, &mut group, &probe, &mut console)
+                        .await
+                        .expect("template load");
+                    assert_eq!(
+                        code.as_i32(),
+                        0,
+                        "fleet_add/{hosts}h regressed to non-zero exit"
+                    );
+                    let snap = metrics.snapshot();
+                    assert_eq!(snap.current_operations, 0, "leaked in-flight operation");
+                    assert_eq!(snap.current_probes, 0, "leaked in-flight probe");
+                    assert!(
+                        snap.peak_operations <= hosts,
+                        "peak concurrency {} exceeds host count {hosts}",
+                        snap.peak_operations
+                    );
+                });
+            });
+        });
+    }
+    group.bench_function("100h_repeated_urls", |b| {
+        b.iter(|| {
+            let mut cfg = ScenarioConfig::new(100);
+            cfg.repeated_urls = true;
+            let Scenario {
+                mut group,
+                probe,
+                opts,
+                ..
+            } = build_scenario(&cfg, &[ADD_REPA]);
+            rt.block_on(async {
+                let mut buf = Buffer::default();
+                let mut console = Console::new(&mut buf);
+                let code = run_add(&opts, &mut group, &probe, &mut console)
+                    .await
+                    .expect("template load");
+                assert_eq!(code.as_i32(), 0);
+            });
+        });
+    });
+    group.bench_function("100h_slow_host", |b| {
+        b.iter(|| {
+            let mut cfg = ScenarioConfig::new(100);
+            cfg.slow_host = true;
+            let mut scenario = build_scenario(&cfg, &[ADD_REPA]);
+            rt.block_on(async {
+                scenario.arm_slow_host();
+                let mut buf = Buffer::default();
+                let mut console = Console::new(&mut buf);
+                let code = run_add(
+                    &scenario.opts,
+                    &mut scenario.group,
+                    &scenario.probe,
+                    &mut console,
+                )
+                .await
+                .expect("template load");
+                assert_eq!(code.as_i32(), 0);
+            });
+        });
+    });
+    group.finish();
+}
+
+fn bench_install(c: &mut Criterion) {
+    let rt = runtime();
+    let mut group = c.benchmark_group("fleet_install");
+    group.sample_size(20);
+    for hosts in [1usize, 20, 100] {
+        group.bench_function(format!("{hosts}h"), |b| {
+            b.iter(|| {
+                let cfg = ScenarioConfig::new(hosts);
+                let Scenario {
+                    mut group,
+                    metrics,
+                    probe,
+                    opts,
+                    ..
+                } = build_scenario(&cfg, &[ADD_REPA]);
+                rt.block_on(async {
+                    let mut buf = Buffer::default();
+                    let mut console = Console::new(&mut buf);
+                    let code = run_install(&opts, &mut group, &probe, &mut console)
+                        .await
+                        .expect("template load");
+                    assert_eq!(
+                        code.as_i32(),
+                        0,
+                        "fleet_install/{hosts}h regressed to non-zero exit"
+                    );
+                    let snap = metrics.snapshot();
+                    assert_eq!(snap.current_operations, 0, "leaked in-flight operation");
+                    assert!(snap.peak_operations <= hosts);
+                });
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_list_products(c: &mut Criterion) {
+    let rt = runtime();
+    let mut group = c.benchmark_group("fleet_list_products");
+    for hosts in [1usize, 20, 100] {
+        group.bench_function(format!("{hosts}h"), |b| {
+            b.iter(|| {
+                let cfg = ScenarioConfig::new(hosts);
+                let Scenario {
+                    mut group,
+                    metrics,
+                    opts,
+                    ..
+                } = build_list_products_scenario(&cfg);
+                rt.block_on(async {
+                    let mut buf = Buffer::default();
+                    let code = run_list_products(&opts, &mut group, &mut buf).await;
+                    assert_eq!(code.as_i32(), 0);
+                    let snap = metrics.snapshot();
+                    assert_eq!(snap.current_operations, 0, "leaked in-flight operation");
+                    assert!(snap.peak_operations <= hosts);
+                    assert_eq!(group.keys().len(), hosts);
+                });
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_add, bench_install, bench_list_products);
+criterion_main!(benches);

--- a/crates/repose-core/benches/support/mod.rs
+++ b/crates/repose-core/benches/support/mod.rs
@@ -1,0 +1,163 @@
+//! Fleet-scenario builders shared by the P0.3 Criterion benchmark
+//! (`benches/fleet.rs`) and the P0.1 baseline-report harness
+//! (`examples/baseline_report.rs`), which includes this file verbatim via
+//! `#[path]` since Cargo does not let example/bench targets share a module
+//! directly. Not part of the published `repose_core` crate.
+//!
+//! Scenarios are deterministic: every host starts from a fresh [`MockHost`]
+//! with a shared [`MockMetrics`] tracker, so callers can assert exact
+//! command/probe counts and peak concurrency alongside timing.
+
+use repose_core::commands::CommandOptions;
+use repose_core::console::OutputFormat;
+use repose_core::mock::{MetricProbe, MockGate, MockHost, MockHostGroup, MockMetrics, MockOpKind};
+use repose_core::repa::Repa;
+use repose_core::types::{Product, System};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Fixed, documented delay used to model one slow host among a fleet.
+/// Applied only by the benchmark/baseline harness (never inside
+/// `repose-core::mock`, which stays sleep-free for deterministic unit
+/// tests) — Criterion/the baseline report explicitly measure wall time, so
+/// a small real delay is the honest way to produce a measurable tail.
+pub const SLOW_HOST_DELAY: Duration = Duration::from_millis(20);
+
+/// `tests/vectors/template/sample.yml`, shared with the crate's own unit
+/// tests (defines SLES/QA/PackageHub repository templates).
+#[must_use]
+pub fn sample_config() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/vectors/template/sample.yml")
+}
+
+fn sles_system() -> System {
+    System {
+        base: Product {
+            name: "SLES".into(),
+            version: "15-SP3".into(),
+            arch: "x86_64".into(),
+        },
+        addons: vec![],
+        transactional: false,
+    }
+}
+
+/// Zero-padded so `BTreeMap` (lexical) order matches numeric host order.
+fn host_key(i: usize, total: usize) -> String {
+    let width = total.max(1).to_string().len();
+    format!("h{i:0width$}")
+}
+
+/// Dimensions from `tests/performance/workloads.json`.
+pub struct ScenarioConfig {
+    pub host_count: usize,
+    /// Gate host 1's `run` operation on [`Scenario::slow_gate`], modeling
+    /// one slow host among a fast fleet (see [`Scenario::arm_slow_host`]).
+    pub slow_host: bool,
+    /// Pass the same REPA argument twice, so identical URL candidates are
+    /// resolved and probed within one host (see `add_one`/`install_one`
+    /// dedup and future P3 probe-cache work).
+    pub repeated_urls: bool,
+    pub output_format: OutputFormat,
+}
+
+impl ScenarioConfig {
+    #[must_use]
+    pub fn new(host_count: usize) -> Self {
+        Self {
+            host_count,
+            slow_host: false,
+            repeated_urls: false,
+            output_format: OutputFormat::Text,
+        }
+    }
+}
+
+/// One fleet-scale scenario: hosts, probe, shared metrics, and options.
+pub struct Scenario {
+    pub group: MockHostGroup,
+    pub metrics: MockMetrics,
+    pub probe: MetricProbe,
+    pub opts: CommandOptions,
+    /// Present when the scenario has a gated slow host; call
+    /// [`Scenario::arm_slow_host`] from inside the runtime that will drive
+    /// the command so the delayed release races the command's own futures.
+    pub slow_gate: Option<Arc<MockGate>>,
+}
+
+impl Scenario {
+    /// Spawn the timer that releases the slow host's gate after
+    /// [`SLOW_HOST_DELAY`]. No-op if the scenario has no slow host. Must be
+    /// called from within the Tokio runtime driving the command.
+    pub fn arm_slow_host(&self) {
+        if let Some(gate) = self.slow_gate.clone() {
+            tokio::spawn(async move {
+                tokio::time::sleep(SLOW_HOST_DELAY).await;
+                gate.release();
+            });
+        }
+    }
+}
+
+/// Build a fresh `add`/`install` scenario resolving `repa` on every host.
+#[must_use]
+pub fn build_scenario(cfg: &ScenarioConfig, repa: &[&str]) -> Scenario {
+    let metrics = MockMetrics::new();
+    let mut group = MockHostGroup::new();
+    let mut slow_gate = None;
+    for i in 1..=cfg.host_count {
+        let key = host_key(i, cfg.host_count);
+        let mut host = MockHost::new(key)
+            .with_products(sles_system())
+            .with_metrics(metrics.clone());
+        if cfg.slow_host && i == 1 {
+            let gate = MockGate::new();
+            host = host.with_gate(MockOpKind::Run, gate.clone());
+            slow_gate = Some(gate);
+        }
+        group.insert(host);
+    }
+
+    let mut repa_args: Vec<&str> = repa.to_vec();
+    if cfg.repeated_urls {
+        repa_args.extend(repa);
+    }
+    let opts = CommandOptions {
+        config: sample_config(),
+        repa: repa_args
+            .iter()
+            .map(|r| Repa::parse(r).expect("valid REPA in scenario fixture"))
+            .collect(),
+        no_probe: false,
+        probe_timeout: Duration::from_secs(5),
+        format: cfg.output_format,
+        ..Default::default()
+    };
+    let probe = MetricProbe::new(true).with_metrics(metrics.clone());
+
+    Scenario {
+        group,
+        metrics,
+        probe,
+        opts,
+        slow_gate,
+    }
+}
+
+/// Build a `list-products` scenario (no repository resolution/probing).
+#[must_use]
+pub fn build_list_products_scenario(cfg: &ScenarioConfig) -> Scenario {
+    build_scenario(cfg, &[])
+}
+
+/// One documented async runtime boundary shared by every scenario/command
+/// invocation, so benchmark/report comparisons attribute cost consistently
+/// rather than to runtime construction (see P0.3 assumptions).
+#[must_use]
+pub fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .expect("build current-thread benchmark runtime")
+}

--- a/crates/repose-core/examples/baseline_report.rs
+++ b/crates/repose-core/examples/baseline_report.rs
@@ -1,0 +1,351 @@
+//! P0.1 baseline-report harness for the `mock`-kind workloads in
+//! `tests/performance/workloads.json`. Emits one contract-valid JSON report
+//! (see `tests/performance/README.md`) to stdout for a single workload ID.
+//!
+//! `ssh`-kind workloads are driven separately by
+//! `scripts/run-performance-baseline.sh` against the Docker OpenSSH
+//! fixture, since they exercise the compiled CLI binary and real transport
+//! rather than this crate's public command API.
+//!
+//! Usage: `baseline_report <workload-id> [repetitions] [warmup]`
+//!
+//! Every observed result is checked against the workload's reviewed
+//! `expect` block *before* any timing is printed — a changed command
+//! history, count, or exit code fails the run instead of silently shipping
+//! a report (P0.1 plan item 3 / P0.3 plan item 4).
+
+#[path = "../benches/support/mod.rs"]
+mod support;
+
+use repose_core::commands::{run_add, run_install, run_list_products};
+use repose_core::console::{Buffer, Console, OutputFormat};
+use repose_core::mock::MockMetricsSnapshot;
+use repose_core::traits::HostGroup;
+use repose_core::types::ExitCode;
+use serde::Deserialize;
+use std::path::PathBuf;
+use std::time::Instant;
+use support::{Scenario, ScenarioConfig, build_list_products_scenario, build_scenario, runtime};
+
+#[derive(Debug, Deserialize)]
+struct WorkloadFile {
+    workloads: Vec<Workload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Workload {
+    id: String,
+    kind: String,
+    command: String,
+    host_count: usize,
+    #[serde(default)]
+    repa: Vec<String>,
+    #[serde(default)]
+    repeated_urls: bool,
+    #[serde(default)]
+    slow_host: bool,
+    #[serde(default)]
+    output_format: String,
+    expect: Expect,
+}
+
+#[derive(Debug, Deserialize)]
+struct Expect {
+    exit_code: i32,
+    // Mock-kind-only fields; absent (and unchecked) on `ssh`-kind entries,
+    // which this binary never runs (see `scripts/run-performance-baseline.sh`).
+    #[serde(default)]
+    command_count: Option<usize>,
+    #[serde(default)]
+    probe_count: Option<usize>,
+    #[serde(default)]
+    peak_operations_max: Option<usize>,
+    #[serde(default)]
+    host_order: Option<Vec<String>>,
+    #[serde(default)]
+    stdout_digest: Option<String>,
+}
+
+/// One command outcome, checked against `Expect` before timing is trusted.
+struct Observed {
+    exit_code: i32,
+    stdout: String,
+    metrics: MockMetricsSnapshot,
+    host_order: Vec<String>,
+}
+
+fn workloads_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/performance/workloads.json")
+}
+
+fn load_workload(id: &str) -> Workload {
+    let raw = std::fs::read_to_string(workloads_path())
+        .unwrap_or_else(|e| panic!("read {}: {e}", workloads_path().display()));
+    let file: WorkloadFile = serde_json::from_str(&raw).expect("parse workloads.json");
+    file.workloads
+        .into_iter()
+        .find(|w| w.id == id)
+        .unwrap_or_else(|| panic!("no workload {id:?} in {}", workloads_path().display()))
+}
+
+fn output_format(s: &str) -> OutputFormat {
+    match s {
+        "json" => OutputFormat::Json,
+        "text" => OutputFormat::Text,
+        other => panic!("unknown output_format {other:?}"),
+    }
+}
+
+/// Deterministic, non-cryptographic content fingerprint (FNV-1a/64) used
+/// only for change detection between reviewed expectations and observed
+/// output — stable across Rust toolchains by construction (hand-rolled,
+/// not `DefaultHasher`). Tagged `"fnv1a64:<hex>"` so the report's digest
+/// fields can also hold `"sha256:<hex>"` from the `ssh`-kind bash harness
+/// (see `tests/performance/README.md`) without an algorithm mismatch.
+fn fnv1a64(data: &[u8]) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in data {
+        hash ^= u64::from(b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("fnv1a64:{hash:016x}")
+}
+
+fn scenario_config(w: &Workload) -> ScenarioConfig {
+    let mut cfg = ScenarioConfig::new(w.host_count);
+    cfg.slow_host = w.slow_host;
+    cfg.repeated_urls = w.repeated_urls;
+    cfg.output_format = output_format(&w.output_format);
+    cfg
+}
+
+fn repa_refs(w: &Workload) -> Vec<&str> {
+    w.repa.iter().map(String::as_str).collect()
+}
+
+/// Run one repetition of `workload` and return the observed outcome.
+/// Controllable slowdown for P0.5's end-to-end comparator guardrail test
+/// (`scripts/test-compare-performance.sh`): with `REPOSE_PERF_INJECT_DELAY_MS`
+/// set, every repetition sleeps that long before running the command, so a
+/// real slowed run — not just a static fixture — can be shown crossing the
+/// regression threshold. Unset in normal use; has no effect by default.
+fn injected_delay() -> std::time::Duration {
+    std::env::var("REPOSE_PERF_INJECT_DELAY_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .map(std::time::Duration::from_millis)
+        .unwrap_or_default()
+}
+
+fn run_once(rt: &tokio::runtime::Runtime, w: &Workload) -> Observed {
+    let cfg = scenario_config(w);
+    let repa = repa_refs(w);
+    rt.block_on(async {
+        let delay = injected_delay();
+        if delay > std::time::Duration::ZERO {
+            tokio::time::sleep(delay).await;
+        }
+        match w.command.as_str() {
+            "add" | "install" => {
+                let scenario = build_scenario(&cfg, &repa);
+                scenario.arm_slow_host();
+                let Scenario {
+                    mut group,
+                    metrics,
+                    probe,
+                    opts,
+                    ..
+                } = scenario;
+                let mut buf = Buffer::default();
+                let mut console = Console::new(&mut buf);
+                console.format = opts.format;
+                let exit_code = if w.command == "add" {
+                    run_add(&opts, &mut group, &probe, &mut console)
+                        .await
+                        .expect("template load")
+                } else {
+                    run_install(&opts, &mut group, &probe, &mut console)
+                        .await
+                        .expect("template load")
+                };
+                Observed {
+                    exit_code: exit_code.as_i32(),
+                    stdout: buf.0,
+                    metrics: metrics.snapshot(),
+                    host_order: group.keys(),
+                }
+            }
+            "list-products" => {
+                let Scenario {
+                    mut group,
+                    metrics,
+                    opts,
+                    ..
+                } = build_list_products_scenario(&cfg);
+                let mut buf = Buffer::default();
+                let exit_code: ExitCode = run_list_products(&opts, &mut group, &mut buf).await;
+                Observed {
+                    exit_code: exit_code.as_i32(),
+                    stdout: buf.0,
+                    metrics: metrics.snapshot(),
+                    host_order: group.keys(),
+                }
+            }
+            other => panic!("unknown mock command {other:?}"),
+        }
+    })
+}
+
+/// Fail fast (before any timing is printed) on the first deviation from the
+/// reviewed expectation.
+fn check_expectation(id: &str, expect: &Expect, observed: &Observed) {
+    assert_eq!(
+        observed.exit_code, expect.exit_code,
+        "{id}: exit code changed"
+    );
+    let command_count = expect
+        .command_count
+        .unwrap_or_else(|| panic!("{id}: mock workload missing expect.command_count"));
+    let probe_count = expect
+        .probe_count
+        .unwrap_or_else(|| panic!("{id}: mock workload missing expect.probe_count"));
+    let peak_operations_max = expect
+        .peak_operations_max
+        .unwrap_or_else(|| panic!("{id}: mock workload missing expect.peak_operations_max"));
+    let host_order = expect
+        .host_order
+        .as_ref()
+        .unwrap_or_else(|| panic!("{id}: mock workload missing expect.host_order"));
+
+    assert_eq!(
+        observed.metrics.commands_completed, command_count,
+        "{id}: command count changed"
+    );
+    assert_eq!(
+        observed.metrics.probe_total, probe_count,
+        "{id}: probe count changed"
+    );
+    assert!(
+        observed.metrics.peak_operations <= peak_operations_max,
+        "{id}: peak concurrency {} exceeds bound {}",
+        observed.metrics.peak_operations,
+        peak_operations_max
+    );
+    assert_eq!(
+        observed.metrics.current_operations, 0,
+        "{id}: leaked in-flight operation"
+    );
+    assert_eq!(
+        observed.metrics.current_probes, 0,
+        "{id}: leaked in-flight probe"
+    );
+    if !host_order.is_empty() {
+        assert_eq!(
+            &observed.host_order, host_order,
+            "{id}: host ordering changed"
+        );
+    }
+    if let Some(want) = &expect.stdout_digest {
+        let got = fnv1a64(observed.stdout.as_bytes());
+        assert_eq!(&got, want, "{id}: stdout content changed");
+    }
+}
+
+fn percentile(sorted_ns: &[u128], pct: f64) -> u128 {
+    // Nearest-rank method.
+    let n = sorted_ns.len();
+    let rank = ((pct / 100.0) * n as f64).ceil() as usize;
+    sorted_ns[rank.clamp(1, n) - 1]
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let id = args.next().unwrap_or_else(|| {
+        eprintln!("usage: baseline_report <workload-id> [repetitions] [warmup]");
+        eprintln!("       baseline_report --dump <workload-id>   (print observed counters, skip expectation check)");
+        std::process::exit(2);
+    });
+
+    if id == "--dump" {
+        let id = args.next().expect("--dump requires a workload id");
+        let workload = load_workload(&id);
+        assert_eq!(workload.kind, "mock", "{id}: not a mock-kind workload");
+        let rt = runtime();
+        let observed = run_once(&rt, &workload);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "exit_code": observed.exit_code,
+                "command_count": observed.metrics.commands_completed,
+                "probe_count": observed.metrics.probe_total,
+                "peak_operations": observed.metrics.peak_operations,
+                "current_operations": observed.metrics.current_operations,
+                "current_probes": observed.metrics.current_probes,
+                "host_order": observed.host_order,
+                "stdout_digest": fnv1a64(observed.stdout.as_bytes()),
+                "stdout_preview": observed.stdout.lines().take(5).collect::<Vec<_>>(),
+            }))
+            .unwrap()
+        );
+        return;
+    }
+
+    let repetitions: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(20);
+    let warmup: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(3);
+    assert!(repetitions >= 1, "repetitions must be >= 1");
+
+    let workload = load_workload(&id);
+    assert_eq!(workload.kind, "mock", "{id}: not a mock-kind workload");
+
+    let rt = runtime();
+
+    for _ in 0..warmup {
+        let observed = run_once(&rt, &workload);
+        check_expectation(&id, &workload.expect, &observed);
+    }
+
+    let mut samples_ns: Vec<u128> = Vec::with_capacity(repetitions);
+    let mut last: Option<Observed> = None;
+    for _ in 0..repetitions {
+        let start = Instant::now();
+        let observed = run_once(&rt, &workload);
+        samples_ns.push(start.elapsed().as_nanos());
+        check_expectation(&id, &workload.expect, &observed);
+        last = Some(observed);
+    }
+    let last = last.expect("repetitions >= 1");
+    samples_ns.sort_unstable();
+
+    let p50 = percentile(&samples_ns, 50.0);
+    let p95 = percentile(&samples_ns, 95.0);
+    let p99 = percentile(&samples_ns, 99.0);
+    let throughput = workload.host_count as f64 / (p50 as f64 / 1e9);
+
+    let report = serde_json::json!({
+        "contract_version": 1,
+        "workload_id": id,
+        "kind": "mock",
+        "runner": {
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            // Filled in by scripts/run-performance-baseline.sh (`rustc
+            // --version`), which knows the invoking toolchain; this binary
+            // only knows its own target triple constants.
+            "toolchain": serde_json::Value::Null,
+        },
+        "repetitions": repetitions,
+        "warmup_repetitions": warmup,
+        "wall_time_ns": samples_ns,
+        "latency_ns": { "p50": p50, "p95": p95, "p99": p99 },
+        "throughput_ops_per_sec": throughput,
+        "peak_rss_bytes": serde_json::Value::Null,
+        "command_count": last.metrics.commands_completed,
+        "probe_count": last.metrics.probe_total,
+        "peak_concurrency": last.metrics.peak_operations,
+        "exit_code": last.exit_code,
+        "stdout_digest": fnv1a64(last.stdout.as_bytes()),
+        "stderr_digest": fnv1a64(b""),
+        "host_order": last.host_order,
+    });
+    println!("{}", serde_json::to_string_pretty(&report).unwrap());
+}

--- a/crates/repose-core/src/mock.rs
+++ b/crates/repose-core/src/mock.rs
@@ -1,12 +1,13 @@
 //! In-memory [`Host`] / [`HostGroup`] for L2 command tests (no SSH).
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
 use std::task::Poll;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use futures_util::future::join_all;
 
 use crate::error::SshError;
 use crate::traits::{Host, HostGroup, Probe};
@@ -104,6 +105,200 @@ impl RunBarrier {
     }
 }
 
+/// Host-operation category for opt-in gating/metrics on mock test doubles.
+///
+/// Every [`Host`] method boundary maps to exactly one kind; `reboot`'s
+/// nested `run` call is counted separately under [`Self::Run`] (see
+/// [`MockMetricsSnapshot::operations_by_kind`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MockOpKind {
+    Connect,
+    ReadProducts,
+    ReadRepos,
+    ParseRepos,
+    Run,
+    Reboot,
+    Close,
+}
+
+/// Manually released gate an instrumented mock operation waits on.
+///
+/// Lets a test observe an operation as in-flight (via [`MockMetrics`])
+/// before choosing to let it complete — a deterministic, non-sleeping
+/// substitute for modelling remote latency.
+#[derive(Debug, Default)]
+pub struct MockGate {
+    released: AtomicBool,
+}
+
+impl MockGate {
+    #[must_use]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    pub fn release(&self) {
+        self.released.store(true, Ordering::SeqCst);
+    }
+
+    async fn wait(&self) {
+        const MAX_SPINS: usize = 1_000_000;
+        let mut spins = 0usize;
+        std::future::poll_fn(|cx| {
+            if self.released.load(Ordering::SeqCst) {
+                return Poll::Ready(());
+            }
+            spins += 1;
+            assert!(
+                spins <= MAX_SPINS,
+                "MockGate never released (deadlock guard)"
+            );
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        })
+        .await;
+    }
+}
+
+#[derive(Debug, Default)]
+struct MockCounters {
+    total_operations: AtomicUsize,
+    current_operations: AtomicUsize,
+    peak_operations: AtomicUsize,
+    operations_by_kind: Mutex<BTreeMap<MockOpKind, usize>>,
+    commands_attempted: AtomicUsize,
+    commands_completed: AtomicUsize,
+    probe_total: AtomicUsize,
+    current_probes: AtomicUsize,
+    peak_probes: AtomicUsize,
+    probe_counts: Mutex<BTreeMap<String, usize>>,
+}
+
+/// Shared, `Arc`-backed counters for [`MockHost`] / probe test doubles.
+///
+/// Cloning shares the same counters; instrumentation is opt-in so existing
+/// mocks that never attach a tracker are unaffected. Tests read an immutable
+/// [`MockMetricsSnapshot`] rather than mutating counters directly.
+#[derive(Debug, Clone, Default)]
+pub struct MockMetrics(Arc<MockCounters>);
+
+impl MockMetrics {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn enter_op(&self, kind: MockOpKind) -> OpGuard {
+        self.0.total_operations.fetch_add(1, Ordering::SeqCst);
+        let current = self.0.current_operations.fetch_add(1, Ordering::SeqCst) + 1;
+        self.0.peak_operations.fetch_max(current, Ordering::SeqCst);
+        *self
+            .0
+            .operations_by_kind
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .entry(kind)
+            .or_insert(0) += 1;
+        OpGuard {
+            metrics: self.clone(),
+        }
+    }
+
+    fn enter_probe(&self, url: &str) -> ProbeGuard {
+        self.0.probe_total.fetch_add(1, Ordering::SeqCst);
+        let current = self.0.current_probes.fetch_add(1, Ordering::SeqCst) + 1;
+        self.0.peak_probes.fetch_max(current, Ordering::SeqCst);
+        *self
+            .0
+            .probe_counts
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .entry(url.to_string())
+            .or_insert(0) += 1;
+        ProbeGuard {
+            metrics: self.clone(),
+        }
+    }
+
+    fn record_command_attempted(&self) {
+        self.0.commands_attempted.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn record_command_completed(&self) {
+        self.0.commands_completed.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Immutable point-in-time read of every counter.
+    #[must_use]
+    pub fn snapshot(&self) -> MockMetricsSnapshot {
+        MockMetricsSnapshot {
+            total_operations: self.0.total_operations.load(Ordering::SeqCst),
+            current_operations: self.0.current_operations.load(Ordering::SeqCst),
+            peak_operations: self.0.peak_operations.load(Ordering::SeqCst),
+            operations_by_kind: self
+                .0
+                .operations_by_kind
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .clone(),
+            commands_attempted: self.0.commands_attempted.load(Ordering::SeqCst),
+            commands_completed: self.0.commands_completed.load(Ordering::SeqCst),
+            probe_total: self.0.probe_total.load(Ordering::SeqCst),
+            current_probes: self.0.current_probes.load(Ordering::SeqCst),
+            peak_probes: self.0.peak_probes.load(Ordering::SeqCst),
+            probe_counts: self
+                .0
+                .probe_counts
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .clone(),
+        }
+    }
+}
+
+/// Immutable snapshot of [`MockMetrics`] at the time it was taken.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MockMetricsSnapshot {
+    pub total_operations: usize,
+    pub current_operations: usize,
+    pub peak_operations: usize,
+    pub operations_by_kind: BTreeMap<MockOpKind, usize>,
+    /// `Host::run` calls that passed the connected-state check.
+    pub commands_attempted: usize,
+    /// Commands that appended an `out` entry (excludes transport failures).
+    pub commands_completed: usize,
+    pub probe_total: usize,
+    pub current_probes: usize,
+    pub peak_probes: usize,
+    pub probe_counts: BTreeMap<String, usize>,
+}
+
+/// RAII guard: decrements `current_operations` on drop (including early
+/// return or panic unwind), so a failure path never leaks an in-flight count.
+struct OpGuard {
+    metrics: MockMetrics,
+}
+
+impl Drop for OpGuard {
+    fn drop(&mut self) {
+        self.metrics
+            .0
+            .current_operations
+            .fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// RAII guard: decrements `current_probes` on drop.
+struct ProbeGuard {
+    metrics: MockMetrics,
+}
+
+impl Drop for ProbeGuard {
+    fn drop(&mut self) {
+        self.metrics.0.current_probes.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
 /// Controllable host for command unit tests.
 #[derive(Debug, Default)]
 pub struct MockHost {
@@ -129,6 +324,10 @@ pub struct MockHost {
     /// When set, `run` enters this barrier before executing (concurrency
     /// proof in fan-out tests).
     run_barrier: Option<Arc<RunBarrier>>,
+    /// Opt-in shared counters; `None` preserves plain default behavior.
+    metrics: Option<MockMetrics>,
+    /// Per-operation-kind gates a call waits on before proceeding.
+    gates: BTreeMap<MockOpKind, Arc<MockGate>>,
 }
 
 impl MockHost {
@@ -189,6 +388,23 @@ impl MockHost {
         self
     }
 
+    /// Attach shared counters; every instrumented method boundary reports
+    /// through them. Opt-in only — omitting this call preserves prior
+    /// zero-overhead default behavior.
+    #[must_use]
+    pub fn with_metrics(mut self, metrics: MockMetrics) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
+    /// Make every call to the `kind` method wait on `gate` before proceeding
+    /// (after metrics have already recorded it as in-flight).
+    #[must_use]
+    pub fn with_gate(mut self, kind: MockOpKind, gate: Arc<MockGate>) -> Self {
+        self.gates.insert(kind, gate);
+        self
+    }
+
     /// Queue scripted outcomes for the next `run` calls.
     pub fn push_run(&mut self, outcome: MockRunOutcome) {
         self.run_queue.push(outcome);
@@ -203,6 +419,19 @@ impl MockHost {
             MockRunOutcome::exit(0)
         } else {
             self.run_queue.remove(0)
+        }
+    }
+
+    /// Record `kind` as entered (if metrics attached) and return the guard
+    /// that marks it complete on drop.
+    fn enter_op(&self, kind: MockOpKind) -> Option<OpGuard> {
+        self.metrics.as_ref().map(|m| m.enter_op(kind))
+    }
+
+    /// Wait on the gate registered for `kind`, if any.
+    async fn wait_gate(&self, kind: MockOpKind) {
+        if let Some(gate) = self.gates.get(&kind) {
+            gate.wait().await;
         }
     }
 }
@@ -234,6 +463,8 @@ impl Host for MockHost {
     }
 
     async fn connect(&mut self) -> Result<(), SshError> {
+        let _guard = self.enter_op(MockOpKind::Connect);
+        self.wait_gate(MockOpKind::Connect).await;
         if self.connect_fail {
             self.connected = false;
             return Err(SshError::Transport(format!(
@@ -246,14 +477,22 @@ impl Host for MockHost {
     }
 
     async fn close(&mut self) -> Result<(), SshError> {
+        let _guard = self.enter_op(MockOpKind::Close);
+        self.wait_gate(MockOpKind::Close).await;
         self.connected = false;
         Ok(())
     }
 
     async fn run(&mut self, command: &str) -> Result<(), SshError> {
+        let _guard = self.enter_op(MockOpKind::Run);
         if !self.connected {
-            // Pre-append failure: not connected, no out entry.
+            // Pre-append failure: not connected, no out entry, no command
+            // counted (only attempts past the connected-state check count).
             return Err(SshError::NotConnected(self.key.clone()));
+        }
+        self.wait_gate(MockOpKind::Run).await;
+        if let Some(m) = &self.metrics {
+            m.record_command_attempted();
         }
         if let Some(barrier) = self.run_barrier.clone() {
             barrier.enter().await;
@@ -268,22 +507,31 @@ impl Host for MockHost {
             } => {
                 self.out
                     .push((command.to_string(), stdout, stderr, exitcode, runtime_secs));
+                if let Some(m) = &self.metrics {
+                    m.record_command_completed();
+                }
                 Ok(())
             }
             MockRunOutcome::Timeout { stderr } => {
                 // Contract: timeout still appends exitcode -1, returns Ok.
                 self.out
                     .push((command.to_string(), String::new(), stderr, -1, 0));
+                if let Some(m) = &self.metrics {
+                    m.record_command_completed();
+                }
                 Ok(())
             }
             MockRunOutcome::TransportErr(msg) => {
-                // Contract: no out entry when Err.
+                // Contract: no out entry when Err; command was attempted
+                // but did not complete, so it stays distinguishable.
                 Err(SshError::Transport(msg))
             }
         }
     }
 
     async fn read_products(&mut self) -> Result<(), SshError> {
+        let _guard = self.enter_op(MockOpKind::ReadProducts);
+        self.wait_gate(MockOpKind::ReadProducts).await;
         if !self.connected {
             return Err(SshError::NotConnected(self.key.clone()));
         }
@@ -298,6 +546,8 @@ impl Host for MockHost {
     }
 
     async fn read_repos(&mut self) -> Result<(), SshError> {
+        let _guard = self.enter_op(MockOpKind::ReadRepos);
+        self.wait_gate(MockOpKind::ReadRepos).await;
         if !self.connected {
             return Err(SshError::NotConnected(self.key.clone()));
         }
@@ -305,6 +555,8 @@ impl Host for MockHost {
     }
 
     async fn parse_repos(&mut self) -> Result<(), SshError> {
+        let _guard = self.enter_op(MockOpKind::ParseRepos);
+        self.wait_gate(MockOpKind::ParseRepos).await;
         if self.products.is_none() {
             self.read_products().await?;
         }
@@ -318,7 +570,10 @@ impl Host for MockHost {
     }
 
     async fn reboot(&mut self, command: &str) -> Result<bool, SshError> {
-        // Mock: record reboot command via run semantics, then "reconnect".
+        let _guard = self.enter_op(MockOpKind::Reboot);
+        self.wait_gate(MockOpKind::Reboot).await;
+        // Mock: record reboot command via run semantics (counted separately
+        // as its own Run operation/command), then "reconnect".
         self.run(command).await?;
         self.connected = true;
         // Model the post-reboot product change (e.g. product now removed).
@@ -375,51 +630,57 @@ impl HostGroup for MockHostGroup {
             .collect()
     }
 
+    // Concurrent, order-preserving, failure-isolated fan-out matching
+    // `RusshHostGroup` (see `repose-ssh/src/host.rs`): `join_all` preserves
+    // input order and the map is a `BTreeMap`, so results stay key-ordered;
+    // one host's error never stops or is counted against its siblings.
     async fn connect_and_prune(&mut self) {
-        let keys: Vec<String> = self.hosts.keys().cloned().collect();
-        for key in keys {
-            let fail = {
-                let host = self.hosts.get_mut(&key).expect("key present");
-                host.connect().await.is_err()
-            };
-            if fail {
-                self.hosts.remove(&key);
-            }
+        let failed: Vec<String> =
+            join_all(self.hosts.iter_mut().map(|(key, host)| async move {
+                host.connect().await.is_err().then(|| key.clone())
+            }))
+            .await
+            .into_iter()
+            .flatten()
+            .collect();
+        for key in failed {
+            self.hosts.remove(&key);
         }
     }
 
     async fn read_products(&mut self) {
-        for host in self.hosts.values_mut() {
+        join_all(self.hosts.values_mut().map(|host| async move {
             let _ = host.read_products().await;
-        }
+        }))
+        .await;
     }
 
     async fn read_repos(&mut self) {
-        for host in self.hosts.values_mut() {
+        join_all(self.hosts.values_mut().map(|host| async move {
             let _ = host.read_repos().await;
-        }
+        }))
+        .await;
     }
 
     async fn parse_repos(&mut self) {
-        for host in self.hosts.values_mut() {
+        join_all(self.hosts.values_mut().map(|host| async move {
             let _ = host.parse_repos().await;
-        }
+        }))
+        .await;
     }
 
     async fn run_all(&mut self, cmd: &str) {
-        // Isolated: collect keys first; errors do not stop siblings.
-        let keys: Vec<String> = self.hosts.keys().cloned().collect();
-        for key in keys {
-            if let Some(host) = self.hosts.get_mut(&key) {
-                let _ = host.run(cmd).await;
-            }
-        }
+        join_all(self.hosts.values_mut().map(|host| async move {
+            let _ = host.run(cmd).await;
+        }))
+        .await;
     }
 
     async fn close(&mut self) {
-        for host in self.hosts.values_mut() {
+        join_all(self.hosts.values_mut().map(|host| async move {
             let _ = host.close().await;
-        }
+        }))
+        .await;
     }
 }
 
@@ -459,6 +720,61 @@ impl MapProbe {
 impl Probe for MapProbe {
     async fn is_live(&self, url: &str, _timeout: Duration) -> bool {
         !self.dead_urls.contains(url)
+    }
+}
+
+/// Counting/gated [`Probe`] test double: per-URL outcome overrides on top of
+/// a default, optional shared [`MockMetrics`], and an optional [`MockGate`]
+/// for deterministic overlap proofs. `ConstProbe`/`MapProbe` remain the
+/// simple choice when metrics/gating are not needed.
+#[derive(Debug, Clone, Default)]
+pub struct MetricProbe {
+    default_live: bool,
+    overrides: std::collections::HashMap<String, bool>,
+    metrics: Option<MockMetrics>,
+    gate: Option<Arc<MockGate>>,
+}
+
+impl MetricProbe {
+    #[must_use]
+    pub fn new(default_live: bool) -> Self {
+        Self {
+            default_live,
+            ..Self::default()
+        }
+    }
+
+    #[must_use]
+    pub fn with_metrics(mut self, metrics: MockMetrics) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
+    #[must_use]
+    pub fn with_gate(mut self, gate: Arc<MockGate>) -> Self {
+        self.gate = Some(gate);
+        self
+    }
+
+    /// Override the outcome for one exact URL (input-independent lookup).
+    #[must_use]
+    pub fn set(mut self, url: impl Into<String>, live: bool) -> Self {
+        self.overrides.insert(url.into(), live);
+        self
+    }
+}
+
+#[async_trait]
+impl Probe for MetricProbe {
+    async fn is_live(&self, url: &str, _timeout: Duration) -> bool {
+        let _guard = self.metrics.as_ref().map(|m| m.enter_probe(url));
+        if let Some(gate) = &self.gate {
+            gate.wait().await;
+        }
+        self.overrides
+            .get(url)
+            .copied()
+            .unwrap_or(self.default_live)
     }
 }
 
@@ -587,5 +903,213 @@ mod tests {
         };
         assert!(s.is_transactional());
         assert_eq!(s.arch(), "x86_64");
+    }
+
+    #[tokio::test]
+    async fn serial_operations_peak_at_one_and_leave_zero_in_flight() {
+        let metrics = MockMetrics::new();
+        let mut h = MockHost::new("h1").with_metrics(metrics.clone());
+        h.connect().await.unwrap();
+        h.push_run(MockRunOutcome::exit(0));
+        h.run("cmd").await.unwrap();
+        h.close().await.unwrap();
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.peak_operations, 1, "no overlap under serial calls");
+        assert_eq!(snap.current_operations, 0);
+        assert_eq!(snap.total_operations, 3, "connect + run + close");
+        assert_eq!(snap.commands_attempted, 1);
+        assert_eq!(snap.commands_completed, 1);
+        assert_eq!(snap.operations_by_kind[&MockOpKind::Run], 1);
+    }
+
+    #[tokio::test]
+    async fn not_connected_run_counts_operation_but_no_command() {
+        let metrics = MockMetrics::new();
+        let mut h = MockHost::new("h1").with_metrics(metrics.clone());
+        let err = h.run("cmd").await.unwrap_err();
+        assert!(matches!(err, SshError::NotConnected(_)));
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.total_operations, 1);
+        assert_eq!(snap.current_operations, 0, "guard released on early return");
+        assert_eq!(
+            snap.commands_attempted, 0,
+            "counted only past the connected check"
+        );
+    }
+
+    #[tokio::test]
+    async fn transport_failure_does_not_leak_in_flight_guard() {
+        let metrics = MockMetrics::new();
+        let mut h = MockHost::new("h1").with_metrics(metrics.clone());
+        h.connect().await.unwrap();
+        h.push_run(MockRunOutcome::TransportErr("boom".into()));
+        assert!(h.run("cmd").await.is_err());
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.current_operations, 0);
+        assert_eq!(snap.commands_attempted, 1, "attempted past connected check");
+        assert_eq!(
+            snap.commands_completed, 0,
+            "no out entry on transport error"
+        );
+    }
+
+    #[tokio::test]
+    async fn reboot_counts_separately_from_its_nested_run_command() {
+        let metrics = MockMetrics::new();
+        let mut h = MockHost::new("h1").with_metrics(metrics.clone());
+        h.connect().await.unwrap();
+        h.reboot("systemctl reboot").await.unwrap();
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.operations_by_kind[&MockOpKind::Reboot], 1);
+        assert_eq!(snap.operations_by_kind[&MockOpKind::Run], 1);
+        assert_eq!(snap.commands_attempted, 1);
+        assert_eq!(snap.current_operations, 0);
+    }
+
+    #[tokio::test]
+    async fn gated_hosts_overlap_reaches_expected_peak_operations() {
+        let metrics = MockMetrics::new();
+        let gate = MockGate::new();
+        let mut h1 = MockHost::new("h1")
+            .with_metrics(metrics.clone())
+            .with_gate(MockOpKind::Run, gate.clone());
+        h1.connect().await.unwrap();
+        let mut h2 = MockHost::new("h2")
+            .with_metrics(metrics.clone())
+            .with_gate(MockOpKind::Run, gate.clone());
+        h2.connect().await.unwrap();
+
+        let t1 = tokio::spawn(async move {
+            h1.run("cmd").await.unwrap();
+            h1
+        });
+        let t2 = tokio::spawn(async move {
+            h2.run("cmd").await.unwrap();
+            h2
+        });
+
+        // Spin (bounded) until both operations are observably in-flight;
+        // no real sleeps, no fixed wall-clock wait.
+        for _ in 0..100_000 {
+            if metrics.snapshot().current_operations >= 2 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            metrics.snapshot().current_operations,
+            2,
+            "both hosts must be in-flight before release"
+        );
+        gate.release();
+        let (h1, h2) = tokio::join!(t1, t2);
+        drop((h1.unwrap(), h2.unwrap()));
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.peak_operations, 2);
+        assert_eq!(snap.current_operations, 0);
+        assert_eq!(snap.commands_completed, 2);
+    }
+
+    #[tokio::test]
+    async fn group_fan_out_is_concurrent_ordered_and_failure_isolated() {
+        let metrics = MockMetrics::new();
+        let gate = MockGate::new();
+        let mut g = MockHostGroup::new();
+        for key in ["a", "b", "c"] {
+            let mut h = MockHost::new(key)
+                .with_metrics(metrics.clone())
+                .with_gate(MockOpKind::Run, gate.clone());
+            h.connect().await.unwrap();
+            if key == "b" {
+                h.push_run(MockRunOutcome::TransportErr("fail".into()));
+            }
+            g.insert(h);
+        }
+
+        let run = tokio::spawn(async move {
+            g.run_all("true").await;
+            g
+        });
+        for _ in 0..100_000 {
+            if metrics.snapshot().current_operations >= 3 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            metrics.snapshot().current_operations,
+            3,
+            "all three hosts must run concurrently"
+        );
+        gate.release();
+        let mut g = run.await.unwrap();
+
+        assert_eq!(g.keys(), vec!["a", "b", "c"], "BTreeMap keeps key order");
+        assert!(g.get_mock_mut("a").unwrap().out().len() == 1);
+        assert!(
+            g.get_mock_mut("b").unwrap().out().is_empty(),
+            "b's transport failure leaves no out entry"
+        );
+        assert!(
+            g.get_mock_mut("c").unwrap().out().len() == 1,
+            "sibling failure does not cancel c"
+        );
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.peak_operations, 3);
+        assert_eq!(snap.current_operations, 0);
+        assert_eq!(snap.commands_completed, 2, "a and c completed; b did not");
+    }
+
+    #[tokio::test]
+    async fn probe_metrics_count_per_url_and_reset_current_after_completion() {
+        let metrics = MockMetrics::new();
+        let probe = MetricProbe::new(true)
+            .with_metrics(metrics.clone())
+            .set("http://dead/", false);
+
+        assert!(probe.is_live("http://a/", Duration::from_secs(1)).await);
+        assert!(probe.is_live("http://a/", Duration::from_secs(1)).await);
+        assert!(!probe.is_live("http://dead/", Duration::from_secs(1)).await);
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.probe_total, 3);
+        assert_eq!(snap.current_probes, 0);
+        assert_eq!(snap.probe_counts.get("http://a/"), Some(&2));
+        assert_eq!(snap.probe_counts.get("http://dead/"), Some(&1));
+    }
+
+    #[tokio::test]
+    async fn gated_probes_reach_expected_peak_overlap() {
+        let metrics = MockMetrics::new();
+        let gate = MockGate::new();
+        let p1 = MetricProbe::new(true)
+            .with_metrics(metrics.clone())
+            .with_gate(gate.clone());
+        let p2 = p1.clone();
+
+        let t1 = tokio::spawn(async move { p1.is_live("http://a/", Duration::from_secs(1)).await });
+        let t2 = tokio::spawn(async move { p2.is_live("http://b/", Duration::from_secs(1)).await });
+
+        for _ in 0..100_000 {
+            if metrics.snapshot().current_probes >= 2 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(metrics.snapshot().current_probes, 2);
+        gate.release();
+        let (r1, r2) = tokio::join!(t1, t2);
+        assert!(r1.unwrap());
+        assert!(r2.unwrap());
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.peak_probes, 2);
+        assert_eq!(snap.current_probes, 0);
     }
 }

--- a/scripts/compare-performance.sh
+++ b/scripts/compare-performance.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# P0.5 regression comparator: compares two contract-valid performance
+# reports (scripts/validate-performance-report.jq) for the *same* workload
+# and runner class, using the rules in tests/performance/thresholds.json.
+#
+# Exact semantic metrics (exit code, command/probe counts, output digests)
+# tolerate no unexplained change. Peak concurrency may not exceed the
+# baseline's observed value. Latency/RSS/throughput use the documented,
+# variance-derived tolerances — see tests/performance/thresholds.json.
+#
+# Usage:
+#   scripts/compare-performance.sh <baseline.json> <candidate.json> [--allow-cross-runner]
+#
+# Exit codes (distinguished so callers/tests can tell failure kinds apart):
+#   0  pass (including a real improvement)
+#   1  regression (an exact metric changed, or a threshold was crossed)
+#   2  contract failure (either input is not a valid performance report)
+#   3  incomparable metadata (different workload_id/runner_class, or below
+#      the minimum repetition count)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATOR="$ROOT/scripts/validate-performance-report.jq"
+THRESHOLDS="$ROOT/tests/performance/thresholds.json"
+
+[[ $# -ge 2 ]] || {
+	echo "usage: $0 <baseline.json> <candidate.json> [--allow-cross-runner]" >&2
+	exit 3
+}
+BASELINE="$1"
+CANDIDATE="$2"
+shift 2
+ALLOW_CROSS_RUNNER=0
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--allow-cross-runner)
+		ALLOW_CROSS_RUNNER=1
+		shift
+		;;
+	*)
+		echo "unknown argument: $1" >&2
+		exit 3
+		;;
+	esac
+done
+
+command -v jq >/dev/null || {
+	echo "jq is required" >&2
+	exit 3
+}
+[[ -f "$BASELINE" ]] || {
+	echo "baseline report not found: $BASELINE" >&2
+	exit 3
+}
+[[ -f "$CANDIDATE" ]] || {
+	echo "candidate report not found: $CANDIDATE" >&2
+	exit 3
+}
+
+for f in "$BASELINE" "$CANDIDATE"; do
+	if ! jq -e -f "$VALIDATOR" "$f" >/dev/null 2>"$ROOT/.compare-performance-contract-error.$$"; then
+		echo "CONTRACT FAILURE: $f does not satisfy the report contract:" >&2
+		cat "$ROOT/.compare-performance-contract-error.$$" >&2
+		rm -f "$ROOT/.compare-performance-contract-error.$$"
+		exit 2
+	fi
+	rm -f "$ROOT/.compare-performance-contract-error.$$"
+done
+
+base_id="$(jq -r '.workload_id' "$BASELINE")"
+cand_id="$(jq -r '.workload_id' "$CANDIDATE")"
+if [[ "$base_id" != "$cand_id" ]]; then
+	echo "INCOMPARABLE: workload_id differs (baseline=$base_id, candidate=$cand_id)" >&2
+	exit 3
+fi
+
+base_runner="$(jq -r '.runner.runner_class // "unknown"' "$BASELINE")"
+cand_runner="$(jq -r '.runner.runner_class // "unknown"' "$CANDIDATE")"
+if [[ "$base_runner" != "$cand_runner" && "$ALLOW_CROSS_RUNNER" -ne 1 ]]; then
+	echo "INCOMPARABLE: runner_class differs (baseline=$base_runner, candidate=$cand_runner); pass --allow-cross-runner to override" >&2
+	exit 3
+fi
+
+min_reps="$(jq -r '.minimum_repetitions' "$THRESHOLDS")"
+base_reps="$(jq -r '.repetitions' "$BASELINE")"
+cand_reps="$(jq -r '.repetitions' "$CANDIDATE")"
+if [[ "$base_reps" -lt "$min_reps" || "$cand_reps" -lt "$min_reps" ]]; then
+	echo "INCOMPARABLE: repetitions below minimum $min_reps (baseline=$base_reps, candidate=$cand_reps)" >&2
+	exit 3
+fi
+
+FAILED=0
+report() {
+	# report STATUS MESSAGE
+	echo "$1: $2"
+	if [[ "$1" == "REGRESSION" ]]; then
+		FAILED=1
+	fi
+}
+
+check_exact() {
+	local metric="$1" b c
+	b="$(jq -c ".$metric" "$BASELINE")"
+	c="$(jq -c ".$metric" "$CANDIDATE")"
+	if [[ "$b" == "$c" ]]; then
+		report OK "$metric unchanged ($b)"
+	else
+		report REGRESSION "$metric changed: baseline=$b candidate=$c"
+	fi
+}
+
+check_ceiling() {
+	local metric="$1" b c
+	b="$(jq -r ".$metric" "$BASELINE")"
+	c="$(jq -r ".$metric" "$CANDIDATE")"
+	if [[ "$c" -le "$b" ]]; then
+		report OK "$metric within ceiling (baseline=$b, candidate=$c)"
+	else
+		report REGRESSION "$metric exceeded baseline ceiling: baseline=$b candidate=$c"
+	fi
+}
+
+check_max_increase() {
+	local metric="$1" ratio="$2" b c
+	b="$(jq -r ".$metric" "$BASELINE")"
+	c="$(jq -r ".$metric" "$CANDIDATE")"
+	if [[ "$b" == "null" || "$c" == "null" ]]; then
+		report SKIP "$metric: null in baseline or candidate (not yet collected on this platform)"
+		return
+	fi
+	local limit within
+	limit="$(jq -n --argjson b "$b" --argjson r "$ratio" '$b * (1 + $r)')"
+	within="$(jq -n --argjson c "$c" --argjson limit "$limit" '$c <= $limit')"
+	if [[ "$within" == "true" ]]; then
+		report OK "$metric within +$(jq -n --argjson r "$ratio" '$r*100')% (baseline=$b, candidate=$c, limit=$limit)"
+	else
+		report REGRESSION "$metric regressed beyond +$(jq -n --argjson r "$ratio" '$r*100')%: baseline=$b candidate=$c limit=$limit"
+	fi
+}
+
+check_max_decrease() {
+	local metric="$1" ratio="$2" b c
+	b="$(jq -r ".$metric" "$BASELINE")"
+	c="$(jq -r ".$metric" "$CANDIDATE")"
+	local floor within
+	floor="$(jq -n --argjson b "$b" --argjson r "$ratio" '$b * (1 - $r)')"
+	within="$(jq -n --argjson c "$c" --argjson floor "$floor" '$c >= $floor')"
+	if [[ "$within" == "true" ]]; then
+		report OK "$metric within -$(jq -n --argjson r "$ratio" '$r*100')% (baseline=$b, candidate=$c, floor=$floor)"
+	else
+		report REGRESSION "$metric regressed beyond -$(jq -n --argjson r "$ratio" '$r*100')%: baseline=$b candidate=$c floor=$floor"
+	fi
+}
+
+echo "comparing $base_id (baseline=$BASELINE, candidate=$CANDIDATE)"
+check_exact "exit_code"
+check_exact "command_count"
+check_exact "probe_count"
+check_exact "stdout_digest"
+check_exact "stderr_digest"
+check_ceiling "peak_concurrency"
+check_max_increase "latency_ns.p50" "$(jq -r '.metrics."latency_ns.p50".value' "$THRESHOLDS")"
+check_max_increase "latency_ns.p95" "$(jq -r '.metrics."latency_ns.p95".value' "$THRESHOLDS")"
+check_max_increase "latency_ns.p99" "$(jq -r '.metrics."latency_ns.p99".value' "$THRESHOLDS")"
+check_max_decrease "throughput_ops_per_sec" "$(jq -r '.metrics.throughput_ops_per_sec.value' "$THRESHOLDS")"
+check_max_increase "peak_rss_bytes" "$(jq -r '.metrics.peak_rss_bytes.value' "$THRESHOLDS")"
+
+if [[ "$FAILED" -ne 0 ]]; then
+	echo "RESULT: REGRESSION" >&2
+	exit 1
+fi
+echo "RESULT: PASS"

--- a/scripts/profile-performance.sh
+++ b/scripts/profile-performance.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+#
+# P0.4 release CPU/allocation/I/O profiling: builds once in release mode,
+# runs one P0.1 mock workload under the platform's profiling tools, and
+# writes a normalized manifest (scripts/validate-performance-profile.jq)
+# plus raw tool output. Only `mock`-kind workloads are supported today
+# (see tests/performance/README.md for the ssh-kind gap).
+#
+# Platform adapters:
+#   darwin: `sample` (CPU), `heap` (live allocation footprint — a
+#           point-in-time snapshot, not a full allocation-count profile),
+#           `fs_usage` (I/O; requires root).
+#   linux:  `perf record`/`perf report` (CPU), `heaptrack` (allocation,
+#           wraps the launched process rather than attaching), `strace -c`
+#           (I/O syscall counts).
+#
+# A requested class that cannot run (missing tool, insufficient privilege,
+# unsupported OS) is recorded with `"status": "skipped"` and a reason, and
+# the script exits nonzero — never a silent partial success.
+#
+# Usage:
+#   scripts/profile-performance.sh <workload-id> [--classes cpu,alloc,io]
+#       [--reps N] [--duration SECS] [--out DIR] [--raw-dir DIR]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKLOADS="$ROOT/tests/performance/workloads.json"
+VALIDATOR="$ROOT/scripts/validate-performance-profile.jq"
+OUT="$ROOT/tests/performance/profiles"
+RAW_DIR="$ROOT/tests/performance/profiles/raw"
+CLASSES="cpu,alloc"
+REPS=200000
+DURATION=5
+
+[[ $# -ge 1 ]] || {
+	echo "usage: $0 <workload-id> [--classes cpu,alloc,io] [--reps N] [--duration SECS] [--out DIR] [--raw-dir DIR]" >&2
+	exit 2
+}
+ID="$1"
+shift
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--classes)
+		CLASSES="$2"
+		shift 2
+		;;
+	--reps)
+		REPS="$2"
+		shift 2
+		;;
+	--duration)
+		DURATION="$2"
+		shift 2
+		;;
+	--out)
+		OUT="$2"
+		shift 2
+		;;
+	--raw-dir)
+		RAW_DIR="$2"
+		shift 2
+		;;
+	*)
+		echo "unknown argument: $1" >&2
+		exit 2
+		;;
+	esac
+done
+
+command -v jq >/dev/null || {
+	echo "jq is required" >&2
+	exit 2
+}
+jq -e --arg id "$ID" '.workloads[] | select(.id == $id and .kind == "mock")' "$WORKLOADS" >/dev/null ||
+	{
+		echo "$ID: not a mock-kind workload in $WORKLOADS" >&2
+		exit 2
+	}
+mkdir -p "$OUT" "$RAW_DIR"
+
+echo "== building release artifacts =="
+cargo build --release --locked -p repose-core --example baseline_report
+BASELINE_REPORT="$ROOT/target/release/examples/baseline_report"
+
+# Long-running proxy: enough repetitions to stay alive through the whole
+# profiling window (this measures steady-state per-command cost, not
+# process startup — the profiler attaches after the process is already
+# running the measured loop).
+MEASURED_CMD="$BASELINE_REPORT $ID $REPS 1"
+echo "measured command: $MEASURED_CMD"
+$MEASURED_CMD >/tmp/repose-profile-stdout.$$ &
+PID=$!
+sleep 0.5
+if ! kill -0 "$PID" 2>/dev/null; then
+	echo "measured process exited before profiling could start" >&2
+	exit 1
+fi
+cleanup() { kill "$PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+FAILED=0
+CLASSES_JSON="{}"
+IFS=',' read -ra CLASS_LIST <<<"$CLASSES"
+
+add_class() {
+	# add_class NAME JSON_FRAGMENT
+	CLASSES_JSON="$(jq --arg name "$1" --argjson v "$2" '. + {($name): $v}' <<<"$CLASSES_JSON")"
+}
+
+profile_darwin_cpu() {
+	local raw="$RAW_DIR/${ID}.cpu.sample.txt"
+	sample "$PID" "$DURATION" -f "$raw" >/dev/null 2>&1 || {
+		add_class cpu "$(jq -n --arg reason "sample failed (see $raw if present)" '{status:"skipped",reason:$reason}')"
+		FAILED=1
+		return
+	}
+	local top_json total
+	top_json="$(awk '/^Sort by top of stack/{flag=1; next} /^$/{if (flag) exit} flag' "$raw" |
+		awk '{n=$NF; $NF=""; sym=$0; gsub(/^[ \t]+|[ \t]+$/, "", sym); print n"\t"sym}' |
+		head -10 |
+		jq -R -s '
+            split("\n") | map(select(length > 0)) |
+            map(split("\t")) | map({symbol: .[1], samples: (.[0] | tonumber)})
+        ')"
+	total="$(awk '/^Sort by top of stack/{flag=1; next} /^$/{if (flag) exit} flag {sum+=$NF} END{print sum+0}' "$raw")"
+	add_class cpu "$(jq -n --arg tool sample --arg artifact "$raw" --argjson top "$top_json" --argjson total "${total:-0}" \
+		'{tool: $tool, raw_artifact: $artifact, total_top_of_stack_samples: $total, top_symbols: $top}')"
+}
+
+profile_darwin_alloc() {
+	local raw="$RAW_DIR/${ID}.alloc.heap.txt"
+	heap "$PID" >"$raw" 2>&1 || {
+		add_class alloc "$(jq -n --arg reason "heap failed (see $raw if present)" '{status:"skipped",reason:$reason}')"
+		FAILED=1
+		return
+	}
+	local footprint nodes bytes
+	footprint="$(awk -F': *' '/^Physical footprint:/{print $2}' "$raw" | tr -d '[:space:]')"
+	nodes="$(grep -oE '[0-9]+ nodes malloced' "$raw" | awk '{print $1}')"
+	bytes="$(grep -oE '\([0-9]+ bytes\)' "$raw" | tail -1 | tr -dc '0-9')"
+	add_class alloc "$(jq -n --arg tool heap --arg artifact "$raw" \
+		--arg footprint "${footprint:-null}" --argjson nodes "${nodes:-0}" --argjson bytes "${bytes:-0}" \
+		'{tool: $tool, raw_artifact: $artifact, physical_footprint: $footprint, node_count: $nodes, total_bytes: $bytes}')"
+}
+
+profile_darwin_io() {
+	local raw="$RAW_DIR/${ID}.io.fs_usage.txt"
+	fs_usage -w -f filesys "$PID" >"$raw" 2>&1 &
+	local fs_pid=$!
+	sleep 1
+	kill "$fs_pid" 2>/dev/null || true
+	wait "$fs_pid" 2>/dev/null || true
+	if grep -q "must be run as root" "$raw" 2>/dev/null; then
+		add_class io "$(jq -n --arg reason "fs_usage requires root (rerun this script with sudo, or via sudo -v beforehand)" \
+			'{status:"skipped",reason:$reason}')"
+		FAILED=1
+		return
+	fi
+	local lines
+	lines="$(wc -l <"$raw" | tr -d '[:space:]')"
+	add_class io "$(jq -n --arg tool fs_usage --arg artifact "$raw" --argjson events "${lines:-0}" \
+		'{tool: $tool, raw_artifact: $artifact, filesystem_events: $events}')"
+}
+
+profile_linux_cpu() {
+	local raw="$RAW_DIR/${ID}.cpu.perf.data" report="$RAW_DIR/${ID}.cpu.perf.txt"
+	if ! command -v perf >/dev/null; then
+		add_class cpu "$(jq -n '{status:"skipped",reason:"perf not installed"}')"
+		FAILED=1
+		return
+	fi
+	if ! perf record -o "$raw" -p "$PID" -- sleep "$DURATION" 2>"$RAW_DIR/${ID}.cpu.perf.stderr"; then
+		add_class cpu "$(jq -n --arg reason "perf record failed (likely needs CAP_PERFMON/perf_event_paranoid; see $RAW_DIR/${ID}.cpu.perf.stderr)" \
+			'{status:"skipped",reason:$reason}')"
+		FAILED=1
+		return
+	fi
+	perf report -i "$raw" --stdio -n >"$report" 2>/dev/null || true
+	local top_json
+	top_json="$(awk '/^#/{next} NF>0{print}' "$report" | head -10 |
+		jq -R -s 'split("\n") | map(select(length > 0)) | map({line: .})')"
+	add_class cpu "$(jq -n --arg tool perf --arg artifact "$report" --argjson top "$top_json" \
+		'{tool: $tool, raw_artifact: $artifact, top_symbols: $top}')"
+}
+
+profile_linux_alloc() {
+	# heaptrack wraps the launch rather than attaching; the already-running
+	# $PID from this script cannot be retrofitted, so this class documents
+	# the correct invocation for a follow-up run instead of faking data.
+	if ! command -v heaptrack >/dev/null; then
+		add_class alloc "$(jq -n '{status:"skipped",reason:"heaptrack not installed"}')"
+		FAILED=1
+		return
+	fi
+	add_class alloc "$(jq -n --arg reason "heaptrack profiles a fresh launch, not an attached PID; rerun as: heaptrack $MEASURED_CMD" \
+		'{status:"skipped",reason:$reason}')"
+	FAILED=1
+}
+
+profile_linux_io() {
+	if ! command -v strace >/dev/null; then
+		add_class io "$(jq -n '{status:"skipped",reason:"strace not installed"}')"
+		FAILED=1
+		return
+	fi
+	local raw="$RAW_DIR/${ID}.io.strace.txt"
+	strace -c -p "$PID" -o "$raw" 2>"$RAW_DIR/${ID}.io.strace.stderr" &
+	local strace_pid=$!
+	sleep "$DURATION"
+	kill -INT "$strace_pid" 2>/dev/null || true
+	wait "$strace_pid" 2>/dev/null
+	local strace_status=$?
+	if [[ "$strace_status" -ne 0 && "$strace_status" -ne 130 ]]; then
+		add_class io "$(jq -n --arg reason "strace could not attach (may need CAP_SYS_PTRACE / ptrace_scope=0); see $RAW_DIR/${ID}.io.strace.stderr" \
+			'{status:"skipped",reason:$reason}')"
+		FAILED=1
+		return
+	fi
+	add_class io "$(jq -n --arg tool strace --arg artifact "$raw" '{tool: $tool, raw_artifact: $artifact}')"
+}
+
+OS="$(uname -s)"
+for class in "${CLASS_LIST[@]}"; do
+	case "$OS-$class" in
+	Darwin-cpu) profile_darwin_cpu ;;
+	Darwin-alloc) profile_darwin_alloc ;;
+	Darwin-io) profile_darwin_io ;;
+	Linux-cpu) profile_linux_cpu ;;
+	Linux-alloc) profile_linux_alloc ;;
+	Linux-io) profile_linux_io ;;
+	*)
+		add_class "$class" "$(jq -n --arg reason "unsupported OS $OS for class $class" '{status:"skipped",reason:$reason}')"
+		FAILED=1
+		;;
+	esac
+done
+
+kill "$PID" 2>/dev/null || true
+wait "$PID" 2>/dev/null || true
+trap - EXIT
+
+MANIFEST="$OUT/${ID}.$(echo "$OS" | tr '[:upper:]' '[:lower:]').json"
+jq -n \
+	--arg id "$ID" \
+	--arg os "$(uname -s | tr '[:upper:]' '[:lower:]')" \
+	--arg arch "$(uname -m)" \
+	--arg cmd "$MEASURED_CMD" \
+	--argjson pid "$PID" \
+	--arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+	--argjson classes "$CLASSES_JSON" \
+	'{
+        contract_version: 1,
+        workload_id: $id,
+        platform: {os: $os, arch: $arch},
+        measured_command: $cmd,
+        measured_pid: $pid,
+        setup_excluded: true,
+        generated_at: $generated_at,
+        classes: $classes
+    }' >"$MANIFEST"
+
+jq -e -f "$VALIDATOR" "$MANIFEST" >/dev/null
+echo "wrote $MANIFEST"
+
+if [[ "$FAILED" -ne 0 ]]; then
+	echo "one or more requested profile classes were skipped (see manifest reasons above) — not a silent partial success" >&2
+	exit 1
+fi

--- a/scripts/run-performance-baseline-ssh.sh
+++ b/scripts/run-performance-baseline-ssh.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Runs every `ssh`-kind workload in $REPOSE_PERF_WORKLOADS against the live
+# fixture started by tests/ssh/run.sh (which invokes this script with
+# REPOSE_SSH_* set). Not meant to be run directly — see
+# scripts/run-performance-baseline.sh.
+set -euo pipefail
+
+: "${REPOSE_SSH_TARGET:?tests/ssh/run.sh must set this}"
+: "${REPOSE_SSH_IDENTITY:?tests/ssh/run.sh must set this}"
+: "${REPOSE_SSH_KNOWN_HOSTS:?tests/ssh/run.sh must set this}"
+: "${REPOSE_BIN:?run-performance-baseline.sh must set this}"
+: "${REPOSE_PERF_WORKLOADS:?run-performance-baseline.sh must set this}"
+: "${REPOSE_PERF_VALIDATOR:?run-performance-baseline.sh must set this}"
+: "${REPOSE_PERF_OUT:?run-performance-baseline.sh must set this}"
+
+REPS="${REPOSE_PERF_SSH_REPS:-5}"
+WARMUP="${REPOSE_PERF_SSH_WARMUP:-1}"
+RUNNER_CLASS="${REPOSE_PERF_RUNNER_CLASS:-local-dev}"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+: >"$tmp/empty_known_hosts"
+
+sha256_of() {
+	if command -v sha256sum >/dev/null; then
+		sha256sum | awk '{print "sha256:" $1}'
+	else
+		shasum -a 256 | awk '{print "sha256:" $1}'
+	fi
+}
+
+# Build the repose argv for one ssh-kind workload (jq object on stdin as $w).
+build_args() {
+	local w="$1"
+	local args=()
+	local host_key_policy known_hosts output_format debug dry command
+
+	host_key_policy="$(jq -r '.host_key_policy // "yes"' <<<"$w")"
+	known_hosts_state="$(jq -r '.known_hosts_state // "prepopulated"' <<<"$w")"
+	output_format="$(jq -r '.output_format // "text"' <<<"$w")"
+	debug="$(jq -r '.debug // false' <<<"$w")"
+	dry="$(jq -r '.dry // false' <<<"$w")"
+	command="$(jq -r '.command' <<<"$w")"
+
+	if [[ "$known_hosts_state" == "empty" ]]; then
+		known_hosts="$tmp/empty_known_hosts"
+	else
+		known_hosts="$REPOSE_SSH_KNOWN_HOSTS"
+	fi
+
+	args+=(--strict-host-key-checking="$host_key_policy" --known-hosts "$known_hosts")
+	[[ "$output_format" == "json" ]] && args+=(--format=json)
+	[[ "$debug" == "true" ]] && args+=(--debug)
+	[[ "$dry" == "true" ]] && args+=(--print)
+	args+=("$command" -t "$REPOSE_SSH_TARGET")
+	printf '%s\n' "${args[@]}"
+}
+
+percentile_ns() {
+	# $1: nearest-rank percentile (e.g. 50, 95, 99); reads a jq array on stdin.
+	jq -c "sort | .[(((${1} / 100) * length) | ceil) - 1]"
+}
+
+run_workload() {
+	local id="$1" w
+	w="$(jq -c --arg id "$id" '.workloads[] | select(.id == $id)' "$REPOSE_PERF_WORKLOADS")"
+	mapfile -t args < <(build_args "$w")
+
+	echo "-- $id --"
+	local i exit_code=0 stdout="" stderr=""
+	for ((i = 0; i < WARMUP; i++)); do
+		stdout="$(env -u SSH_AUTH_SOCK -u COLOR NO_COLOR=1 "$REPOSE_BIN" -i "$REPOSE_SSH_IDENTITY" "${args[@]}" 2>"$tmp/stderr")" || exit_code=$?
+	done
+
+	local samples="[]"
+	for ((i = 0; i < REPS; i++)); do
+		local start end
+		start="$(date +%s%N)"
+		exit_code=0
+		stdout="$(env -u SSH_AUTH_SOCK -u COLOR NO_COLOR=1 "$REPOSE_BIN" -i "$REPOSE_SSH_IDENTITY" "${args[@]}" 2>"$tmp/stderr")" || exit_code=$?
+		end="$(date +%s%N)"
+		stderr="$(cat "$tmp/stderr")"
+		samples="$(jq -c --argjson ns "$((end - start))" '. + [$ns]' <<<"$samples")"
+
+		local want_exit
+		want_exit="$(jq -r '.expect.exit_code' <<<"$w")"
+		if [[ "$exit_code" -ne "$want_exit" ]]; then
+			echo "$id: exit code changed (want $want_exit, got $exit_code)" >&2
+			echo "$stderr" >&2
+			return 1
+		fi
+		while IFS= read -r needle; do
+			[[ -z "$needle" ]] && continue
+			if [[ "$stdout" != *"$needle"* ]]; then
+				echo "$id: stdout no longer contains expected substring: $needle" >&2
+				return 1
+			fi
+		done < <(jq -r '.expect.stdout_contains[]?' <<<"$w")
+	done
+
+	local p50 p95 p99 host_count
+	p50="$(percentile_ns 50 <<<"$samples")"
+	p95="$(percentile_ns 95 <<<"$samples")"
+	p99="$(percentile_ns 99 <<<"$samples")"
+	host_count="$(jq -r '.host_count' <<<"$w")"
+
+	jq -n \
+		--arg id "$id" \
+		--argjson reps "$REPS" \
+		--argjson warmup "$WARMUP" \
+		--argjson samples "$samples" \
+		--argjson p50 "$p50" \
+		--argjson p95 "$p95" \
+		--argjson p99 "$p99" \
+		--argjson host_count "$host_count" \
+		--argjson exit_code "$exit_code" \
+		--arg stdout_digest "$(printf '%s' "$stdout" | sha256_of)" \
+		--arg stderr_digest "$(printf '%s' "$stderr" | sha256_of)" \
+		--arg toolchain "$(rustc --version)" \
+		--arg runner_class "$RUNNER_CLASS" \
+		--arg os "$(uname -s)" \
+		--arg arch "$(uname -m)" \
+		--arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+		'{
+            contract_version: 1,
+            workload_id: $id,
+            kind: "ssh",
+            runner: { os: $os, arch: $arch, toolchain: $toolchain, runner_class: $runner_class },
+            generated_at: $generated_at,
+            repetitions: $reps,
+            warmup_repetitions: $warmup,
+            wall_time_ns: ($samples | sort),
+            latency_ns: { p50: $p50, p95: $p95, p99: $p99 },
+            throughput_ops_per_sec: ($host_count / ($p50 / 1e9)),
+            peak_rss_bytes: null,
+            command_count: 1,
+            probe_count: 0,
+            peak_concurrency: $host_count,
+            exit_code: $exit_code,
+            stdout_digest: $stdout_digest,
+            stderr_digest: $stderr_digest,
+            host_order: [$id]
+        }' >"$REPOSE_PERF_OUT/$id.json.tmp"
+
+	jq -e -f "$REPOSE_PERF_VALIDATOR" "$REPOSE_PERF_OUT/$id.json.tmp" >/dev/null
+	mv "$REPOSE_PERF_OUT/$id.json.tmp" "$REPOSE_PERF_OUT/$id.json"
+	echo "  wrote $REPOSE_PERF_OUT/$id.json"
+}
+
+failed=0
+mapfile -t ids < <(jq -r '.workloads[] | select(.kind == "ssh") | .id' "$REPOSE_PERF_WORKLOADS")
+for id in "${ids[@]}"; do
+	run_workload "$id" || failed=1
+done
+exit "$failed"

--- a/scripts/run-performance-baseline.sh
+++ b/scripts/run-performance-baseline.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+#
+# P0.1 baseline orchestration: build once in release mode, run every
+# `mock`-kind workload in tests/performance/workloads.json through the
+# `baseline_report` harness (crates/repose-core/examples/baseline_report.rs),
+# and every `ssh`-kind workload against the Docker OpenSSH fixture
+# (tests/ssh/run.sh) — for real transport, product discovery, and a
+# first-contact `accept-new` known_hosts scenario.
+#
+# Every report is checked against the workload's reviewed `expect` block
+# (see tests/performance/workloads.json) before it is trusted, then
+# validated against the report contract (scripts/validate-performance-report.jq)
+# before being written out. A failure at either stage is a nonzero exit;
+# no partial/misleading report is left behind.
+#
+# Usage:
+#   scripts/run-performance-baseline.sh [--out DIR] [--mock-reps N]
+#       [--mock-warmup N] [--ssh-reps N] [--ssh-warmup N] [--skip-ssh]
+#
+# Env:
+#   REPOSE_PERF_RUNNER_CLASS   identity of this runner (default: local-dev).
+#
+# Run from the repository root; see tests/performance/README.md.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKLOADS="$ROOT/tests/performance/workloads.json"
+VALIDATOR="$ROOT/scripts/validate-performance-report.jq"
+OUT="$ROOT/tests/performance/baselines/raw"
+MOCK_REPS=20
+MOCK_WARMUP=3
+SSH_REPS=5
+SSH_WARMUP=1
+SKIP_SSH=0
+RUNNER_CLASS="${REPOSE_PERF_RUNNER_CLASS:-local-dev}"
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--out)
+		OUT="$2"
+		shift 2
+		;;
+	--mock-reps)
+		MOCK_REPS="$2"
+		shift 2
+		;;
+	--mock-warmup)
+		MOCK_WARMUP="$2"
+		shift 2
+		;;
+	--ssh-reps)
+		SSH_REPS="$2"
+		shift 2
+		;;
+	--ssh-warmup)
+		SSH_WARMUP="$2"
+		shift 2
+		;;
+	--skip-ssh)
+		SKIP_SSH=1
+		shift
+		;;
+	*)
+		echo "unknown argument: $1" >&2
+		exit 2
+		;;
+	esac
+done
+
+command -v jq >/dev/null || {
+	echo "jq is required" >&2
+	exit 2
+}
+mkdir -p "$OUT"
+
+FAILED=0
+
+# --- shared report finishing: inject toolchain/runner_class/generated_at,
+# measure this-process peak RSS via the platform's `time` wrapper, validate
+# against the report contract, write the file. ---
+finish_report() {
+	local id="$1" tmp_stdout="$2" time_file="$3" dest="$4"
+	local rss_bytes="null"
+	case "$(uname -s)" in
+	Darwin)
+		if [[ -s "$time_file" ]]; then
+			rss_bytes="$(awk '/maximum resident set size/ { print $1 }' "$time_file")"
+			[[ -n "$rss_bytes" ]] || rss_bytes="null"
+		fi
+		;;
+	Linux)
+		if [[ -s "$time_file" ]]; then
+			local kb
+			kb="$(awk -F': ' '/Maximum resident set size/ { print $2 }' "$time_file" | tr -d '[:space:]')"
+			[[ -n "$kb" ]] && rss_bytes=$((kb * 1024))
+		fi
+		;;
+	esac
+
+	jq -e \
+		--argjson rss "$rss_bytes" \
+		--arg toolchain "$(rustc --version)" \
+		--arg runner_class "$RUNNER_CLASS" \
+		--arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+		'.peak_rss_bytes = $rss
+         | .runner.toolchain = $toolchain
+         | .runner.runner_class = $runner_class
+         | .generated_at = $generated_at' \
+		"$tmp_stdout" >"$dest.tmp"
+	jq -e -f "$VALIDATOR" "$dest.tmp" >/dev/null
+	mv "$dest.tmp" "$dest"
+	echo "  wrote $dest"
+}
+
+# Wrap `cmd...` with the platform's peak-RSS-reporting `time`, capturing
+# stdout separately from the timing report.
+run_with_rss() {
+	local stdout_file="$1" time_file="$2"
+	shift 2
+	case "$(uname -s)" in
+	Darwin)
+		/usr/bin/time -l "$@" >"$stdout_file" 2>"$time_file"
+		;;
+	Linux)
+		if /usr/bin/time -v true >/dev/null 2>&1; then
+			/usr/bin/time -v "$@" >"$stdout_file" 2>"$time_file"
+		else
+			echo "note: GNU time -v unavailable; peak_rss_bytes will be null" >&2
+			: >"$time_file"
+			"$@" >"$stdout_file"
+		fi
+		;;
+	*)
+		echo "note: unsupported OS for RSS collection; peak_rss_bytes will be null" >&2
+		: >"$time_file"
+		"$@" >"$stdout_file"
+		;;
+	esac
+}
+
+echo "== building release artifacts =="
+cargo build --release --locked -p repose-core --example baseline_report
+cargo build --release --locked -p repose-cli
+
+echo "== mock-kind workloads =="
+BASELINE_REPORT="$ROOT/target/release/examples/baseline_report"
+mapfile -t MOCK_IDS < <(jq -r '.workloads[] | select(.kind == "mock") | .id' "$WORKLOADS")
+for id in "${MOCK_IDS[@]}"; do
+	echo "-- $id --"
+	tmp_stdout="$(mktemp)"
+	time_file="$(mktemp)"
+	if run_with_rss "$tmp_stdout" "$time_file" "$BASELINE_REPORT" "$id" "$MOCK_REPS" "$MOCK_WARMUP"; then
+		finish_report "$id" "$tmp_stdout" "$time_file" "$OUT/$id.json"
+	else
+		echo "FAILED: $id (equivalence check or crash — see above)" >&2
+		FAILED=1
+	fi
+	rm -f "$tmp_stdout" "$time_file"
+done
+
+if [[ "$SKIP_SSH" -eq 1 ]]; then
+	echo "== ssh-kind workloads: skipped (--skip-ssh) =="
+elif ! command -v docker >/dev/null || ! command -v ssh-keygen >/dev/null; then
+	echo "== ssh-kind workloads: skipped (docker/ssh-keygen not available) =="
+else
+	echo "== ssh-kind workloads =="
+	REPOSE_BIN="$ROOT/target/release/repose"
+	export REPOSE_BIN REPOSE_PERF_OUT="$OUT" REPOSE_PERF_SSH_REPS="$SSH_REPS" \
+		REPOSE_PERF_SSH_WARMUP="$SSH_WARMUP" REPOSE_PERF_WORKLOADS="$WORKLOADS" \
+		REPOSE_PERF_VALIDATOR="$VALIDATOR" REPOSE_PERF_RUNNER_CLASS="$RUNNER_CLASS"
+	if ! "$ROOT/tests/ssh/run.sh" bash "$ROOT/scripts/run-performance-baseline-ssh.sh"; then
+		FAILED=1
+	fi
+fi
+
+if [[ "$FAILED" -ne 0 ]]; then
+	echo "one or more workloads failed; see above" >&2
+	exit 1
+fi
+echo "all workloads produced contract-valid, equivalence-checked reports in $OUT"
+
+# Compact, committable summary keyed by runner identity (raw per-workload
+# reports, including full sample arrays and host_order, stay uncommitted
+# artifacts under $OUT — see tests/performance/README.md).
+SUMMARY_DIR="$ROOT/tests/performance/baselines"
+mkdir -p "$SUMMARY_DIR"
+mapfile -t ALL_REPORTS < <(find "$OUT" -maxdepth 1 -name '*.json' | sort)
+if [[ "${#ALL_REPORTS[@]}" -gt 0 ]]; then
+	runner_class="$(jq -r '.runner.runner_class' "${ALL_REPORTS[0]}")"
+	jq -s '{
+        contract_version: 1,
+        runner: (.[0].runner),
+        generated_at: (map(.generated_at) | max),
+        workloads: (
+            map({
+                workload_id, kind, repetitions, warmup_repetitions,
+                latency_ns, throughput_ops_per_sec, peak_rss_bytes,
+                command_count, probe_count, peak_concurrency, exit_code,
+                stdout_digest, stderr_digest
+            }) | sort_by(.workload_id)
+        )
+    }' "${ALL_REPORTS[@]}" >"$SUMMARY_DIR/$runner_class.json"
+	echo "wrote summary $SUMMARY_DIR/$runner_class.json"
+fi

--- a/scripts/test-compare-performance.sh
+++ b/scripts/test-compare-performance.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Comparator unit tests: runs scripts/compare-performance.sh against every
+# fixture under tests/performance/comparator-fixtures/ and checks the exit
+# code matches the fixture's declared `expect`. Also runs one real
+# end-to-end guardrail using the baseline_report harness's controllable
+# slowdown (REPOSE_PERF_INJECT_DELAY_MS) instead of a static fixture.
+#
+# Run from the repository root.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPARE="$ROOT/scripts/compare-performance.sh"
+FIXTURES="$ROOT/tests/performance/comparator-fixtures"
+
+expect_to_code() {
+	case "$1" in
+	pass) echo 0 ;;
+	regression) echo 1 ;;
+	contract-failure) echo 2 ;;
+	incomparable-metadata) echo 3 ;;
+	*)
+		echo "unknown expect: $1" >&2
+		exit 2
+		;;
+	esac
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+failures=0
+for fixture in "$FIXTURES"/*.json; do
+	name="$(basename "$fixture" .json)"
+	expect="$(jq -r '.expect' "$fixture")"
+	want_code="$(expect_to_code "$expect")"
+
+	jq '.baseline' "$fixture" >"$tmp/baseline.json"
+	jq '.candidate' "$fixture" >"$tmp/candidate.json"
+
+	set +e
+	bash "$COMPARE" "$tmp/baseline.json" "$tmp/candidate.json" >"$tmp/out.log" 2>&1
+	got_code=$?
+	set -e
+
+	if [[ "$got_code" -eq "$want_code" ]]; then
+		echo "ok: $name (expected exit $want_code, got $got_code)"
+	else
+		echo "FAIL: $name (expected exit $want_code, got $got_code)"
+		sed 's/^/    /' "$tmp/out.log"
+		failures=1
+	fi
+done
+
+echo "-- end-to-end guardrail: a real injected slowdown must be caught (not a static fixture) --"
+cargo build --release --locked -p repose-core --example baseline_report >/dev/null
+BASELINE_REPORT="$ROOT/target/release/examples/baseline_report"
+
+"$BASELINE_REPORT" mock-add-1h 15 3 >"$tmp/e2e-baseline.json"
+"$BASELINE_REPORT" mock-add-1h 15 3 >"$tmp/e2e-unchanged.json"
+REPOSE_PERF_INJECT_DELAY_MS=5 "$BASELINE_REPORT" mock-add-1h 15 3 >"$tmp/e2e-slowed.json"
+
+set +e
+bash "$COMPARE" "$tmp/e2e-baseline.json" "$tmp/e2e-unchanged.json" >"$tmp/e2e-unchanged.log" 2>&1
+unchanged_code=$?
+bash "$COMPARE" "$tmp/e2e-baseline.json" "$tmp/e2e-slowed.json" >"$tmp/e2e-slowed.log" 2>&1
+slowed_code=$?
+set -e
+
+if [[ "$unchanged_code" -eq 0 ]]; then
+	echo "ok: unchanged real run passes"
+else
+	echo "FAIL: unchanged real run should pass, got exit $unchanged_code"
+	sed 's/^/    /' "$tmp/e2e-unchanged.log"
+	failures=1
+fi
+if [[ "$slowed_code" -eq 1 ]]; then
+	echo "ok: actually-slowed real run is caught as a regression"
+else
+	echo "FAIL: slowed real run should regress (exit 1), got exit $slowed_code"
+	sed 's/^/    /' "$tmp/e2e-slowed.log"
+	failures=1
+fi
+
+exit "$failures"

--- a/scripts/validate-performance-profile.jq
+++ b/scripts/validate-performance-profile.jq
@@ -1,0 +1,38 @@
+# Structural validator for the P0.4 profile-manifest contract
+# (tests/performance/README.md documents each field).
+#
+# Usage: jq -e -f scripts/validate-performance-profile.jq manifest.json
+#
+# Checks shape and provenance only: that ranked hotspots trace back to a
+# named tool/command/artifact, not that the numbers are good. Rejects a
+# manifest with no captured classes (every class must be either present
+# with data, or explicitly `"status": "skipped"` with a `"reason"`).
+
+def check(val; pred; msg):
+  if (val | pred) then . else error("invalid profile manifest: " + msg) end;
+
+def is_nonempty_string: type == "string" and length > 0;
+def is_nonneg_int: type == "number" and (. == (. | floor)) and . >= 0;
+
+def check_class(name):
+  . as $c
+  | if ($c.status == "skipped") then
+      check($c.reason; is_nonempty_string; name + ".reason required when skipped")
+    else
+      check($c.tool; is_nonempty_string; name + ".tool")
+      | check($c.raw_artifact; is_nonempty_string; name + ".raw_artifact path")
+    end;
+
+. as $m
+| check($m.contract_version; . == 1; "contract_version must be 1")
+| check($m.workload_id; is_nonempty_string; "workload_id")
+| check($m.platform; type == "object"; "platform object")
+| check($m.platform.os; is_nonempty_string; "platform.os")
+| check($m.platform.arch; is_nonempty_string; "platform.arch")
+| check($m.measured_command; is_nonempty_string; "measured_command")
+| check($m.measured_pid; is_nonneg_int; "measured_pid")
+| check($m.setup_excluded; type == "boolean"; "setup_excluded boolean")
+| check($m.generated_at; is_nonempty_string; "generated_at")
+| check($m.classes; type == "object" and (length > 0); "classes: at least one profile class")
+| ($m.classes | to_entries[] | . as $entry | ($entry.value | check_class($entry.key)))
+| .

--- a/scripts/validate-performance-report.jq
+++ b/scripts/validate-performance-report.jq
@@ -1,0 +1,57 @@
+# Structural validator for the P0.1 performance-report contract
+# (tests/performance/README.md documents each field's meaning).
+#
+# Usage:
+#   jq -e -f scripts/validate-performance-report.jq report.json
+#
+# Exits 0 (and prints the input unchanged) when the report is well-formed;
+# `error(...)` aborts with a nonzero exit and the message on stderr on the
+# first violation. This checks *shape*, not whether the numbers are good —
+# reviewed-expectation equivalence is enforced separately, before timing is
+# ever printed (see `crates/repose-core/examples/baseline_report.rs` for
+# `kind: "mock"` reports, and `scripts/run-performance-baseline.sh` for
+# `kind: "ssh"` reports).
+
+def check(val; pred; msg):
+  if (val | pred) then . else error("invalid report: " + msg) end;
+
+def is_nonneg_int: type == "number" and (. == (. | floor)) and . >= 0;
+def is_nonneg_num: type == "number" and . >= 0;
+def is_nonempty_string: type == "string" and length > 0;
+
+. as $r
+| check($r.contract_version; . == 1; "contract_version must be 1")
+| check($r.workload_id; is_nonempty_string; "workload_id must be a non-empty string")
+| check($r.kind; . == "mock" or . == "ssh"; "kind must be \"mock\" or \"ssh\"")
+| check($r.runner; type == "object"; "runner must be an object")
+| check($r.runner.os; is_nonempty_string; "runner.os must be a non-empty string")
+| check($r.runner.arch; is_nonempty_string; "runner.arch must be a non-empty string")
+| check($r.repetitions; is_nonneg_int and . >= 1; "repetitions must be an integer >= 1")
+| check($r.warmup_repetitions; is_nonneg_int; "warmup_repetitions must be a non-negative integer")
+| check(
+    $r.wall_time_ns;
+    type == "array" and length == $r.repetitions and (all(.[]; is_nonneg_int));
+    "wall_time_ns must have exactly `repetitions` non-negative nanosecond samples"
+  )
+| check($r.latency_ns; type == "object"; "latency_ns must be an object")
+| check($r.latency_ns.p50; is_nonneg_int; "latency_ns.p50 must be a non-negative integer")
+| check($r.latency_ns.p95; is_nonneg_int and . >= $r.latency_ns.p50; "latency_ns.p95 must be >= p50")
+| check($r.latency_ns.p99; is_nonneg_int and . >= $r.latency_ns.p95; "latency_ns.p99 must be >= p95")
+| check($r.throughput_ops_per_sec; is_nonneg_num; "throughput_ops_per_sec must be a non-negative number")
+| check(
+    $r.peak_rss_bytes;
+    . == null or is_nonneg_int;
+    "peak_rss_bytes must be a non-negative integer, or null before RSS collection runs"
+  )
+| check($r.command_count; is_nonneg_int; "command_count must be a non-negative integer")
+| check($r.probe_count; is_nonneg_int; "probe_count must be a non-negative integer")
+| check($r.peak_concurrency; is_nonneg_int and . >= 1; "peak_concurrency must be an integer >= 1")
+| check($r.exit_code; is_nonneg_int; "exit_code must be a non-negative integer")
+| check($r.stdout_digest; is_nonempty_string; "stdout_digest must be a non-empty string")
+| check($r.stderr_digest; is_nonempty_string; "stderr_digest must be a non-empty string")
+| check(
+    $r.host_order;
+    type == "array" and (all(.[]; type == "string"));
+    "host_order must be an array of host-key strings"
+  )
+| .

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,0 +1,268 @@
+# Performance workloads, reports, and baselines
+
+This directory defines `repose`'s representative performance workloads
+(P0.1), the machine-readable report contract every workload produces, and
+the committed baseline summaries used to catch regressions (P0.5).
+
+## Layout
+
+- `workloads.json` — the workload matrix: every workload's dimensions
+  (command, host count, repeated URLs, a slow host, output format, debug)
+  and its **reviewed expectation** (exit code, exact command/probe counts,
+  a peak-concurrency ceiling, host ordering, and — where output is
+  deterministic — a content digest). A workload's expectation is checked
+  against the observed result *before* any timing is reported; an
+  unreviewed behavior change fails the run instead of silently shipping a
+  new number.
+- `baselines/<runner-class>.json` — one compact, committed summary per
+  runner identity (semantic counters + latency percentiles, no raw sample
+  arrays or per-host output). `<runner-class>` is `local-dev` unless
+  `REPOSE_PERF_RUNNER_CLASS` is set.
+- `baselines/raw/` (gitignored) — the full per-workload reports the
+  orchestration script produces, including every wall-time sample and
+  (for small fleets) host ordering. Local/CI artifacts only.
+- `opportunity-matrix.md` (P0.4) — the top profiled optimization
+  candidates, ranked and evidence-linked.
+- `comparator-fixtures/` (P0.5) — fixtures for `scripts/compare-performance.sh`.
+
+## The report contract
+
+Every report is a single JSON object; `scripts/validate-performance-report.jq`
+checks its shape:
+
+| Field                     | Meaning                                                                 |
+| ------------------------- | ------------------------------------------------------------------------ |
+| `contract_version`        | Always `1`.                                                             |
+| `workload_id`              | Matches an id in `workloads.json`.                                      |
+| `kind`                     | `"mock"` (in-process `repose-core` API) or `"ssh"` (real CLI + fixture). |
+| `runner`                   | `{os, arch, toolchain, runner_class}`.                                  |
+| `generated_at`             | RFC3339 UTC timestamp.                                                  |
+| `repetitions` / `warmup_repetitions` | Measured / discarded warmup runs.                              |
+| `wall_time_ns`             | One nanosecond sample per repetition (warmups excluded), ascending.     |
+| `latency_ns.{p50,p95,p99}` | Nearest-rank percentiles over `wall_time_ns`.                            |
+| `throughput_ops_per_sec`   | `host_count / (p50_latency_seconds)` — hosts processed per second at the median run. |
+| `peak_rss_bytes`           | Process peak RSS for the whole measured run, or `null` if the platform collector was unavailable. |
+| `command_count`            | Exact remote/mock commands completed (see `MockMetricsSnapshot::commands_completed`; for `ssh`-kind reports this is coarse — see Limits below). |
+| `probe_count`              | Exact URL-liveness probes issued.                                       |
+| `peak_concurrency`         | Maximum observed in-flight host operations.                            |
+| `exit_code`                | Process/aggregate exit code.                                            |
+| `stdout_digest` / `stderr_digest` | `"<algo>:<hex>"` content fingerprint — `fnv1a64` for `mock`-kind reports (deterministic, no new dependency; **not** cryptographic), `sha256` for `ssh`-kind reports. |
+| `host_order`               | Host keys in aggregation order.                                        |
+
+## Workload dimensions
+
+`workloads.json` covers `add`, `install`, and `list-products` at 1/20/100
+hosts, with variants for repeated repository URLs, one slow host, and
+text/JSON output; `ssh`-kind entries add real transport, product
+discovery, a dry-run preview, `--debug` verbose logging, and a
+first-contact `accept-new` known_hosts scenario against the Docker OpenSSH
+fixture (`tests/ssh/`).
+
+Two dimensions are intentionally *not* simulated in the mock harness:
+
+- **Slow host**: `slow_host: true` gates one host's `run` operation behind
+  a real ~20ms delay (`support::SLOW_HOST_DELAY` in
+  `crates/repose-core/benches/support/mod.rs`), spawned as a concurrent
+  Tokio task. This is the one place a benchmark/report harness
+  deliberately uses a real sleep — `repose_core::mock` itself stays
+  sleep-free (deterministic gates only) for flake-free unit tests; the
+  baseline report and Criterion bench explicitly measure wall time, so a
+  small documented delay is the honest way to produce a measurable tail.
+- **Debug/verbose output**: only meaningful for the compiled CLI (log
+  level), so it is only a dimension on `ssh`-kind workloads.
+
+### A known limitation: `peak_concurrency` in mock workloads
+
+`MockHost`'s operations only yield to the async executor at an explicit
+gate/barrier. Without one, `join_all`-driven fan-out completes each host's
+future synchronously, so `peak_concurrency` reports `1` even though the
+fan-out code path is exercised. Only the `slow-host` variants (which gate
+one host) observe real overlap. This means the mock benchmark's
+`peak_concurrency <= host_count` check is a safety ceiling, not proof that
+fan-out is concurrent — that proof lives in `crates/repose-core/src/mock.rs`'s
+own gated/barrier unit tests (P0.2) and `add.rs`'s `concurrent_hosts_overlap_in_run`.
+
+## Running it
+
+Prerequisites: a release build, `jq`, `rustc`; the `ssh`-kind workloads
+additionally need `docker` and `ssh-keygen` (see `tests/ssh/run.sh`) — the
+script skips them with a message if unavailable.
+
+```sh
+# Everything (mock workloads always run; ssh workloads run if Docker is available):
+scripts/run-performance-baseline.sh
+
+# Faster local iteration:
+scripts/run-performance-baseline.sh --mock-reps 5 --mock-warmup 1 --skip-ssh
+
+# One mock workload directly (skips RSS collection/toolchain metadata):
+cargo build --release -p repose-core --example baseline_report
+target/release/examples/baseline_report mock-add-100h 20 3 \
+  | jq -e -f scripts/validate-performance-report.jq
+
+# Fleet-scale Criterion benchmark (local algorithm overhead only —
+# see crates/repose-core/benches/fleet.rs doc comment):
+cargo bench -p repose-core --bench fleet --locked -- --test   # smoke: every ID, one sample
+cargo bench -p repose-core --bench fleet --locked             # full statistical run
+```
+
+`scripts/run-performance-baseline.sh` builds once in release mode, runs
+every `mock`-kind workload through `baseline_report` (which checks the
+reviewed expectation on every repetition, then reports timing), runs every
+`ssh`-kind workload against the Docker fixture via
+`scripts/run-performance-baseline-ssh.sh`, validates every report against
+the contract, writes raw per-workload reports to `--out` (default
+`tests/performance/baselines/raw/`, gitignored), and finally writes the
+compact committed summary to `tests/performance/baselines/<runner-class>.json`.
+
+### Warmup / repetition policy
+
+Mock workloads default to 3 warmup + 20 measured repetitions (fast,
+in-process); `ssh`-kind workloads default to 1 warmup + 5 measured
+repetitions (real network round trips per rep). Override with
+`--mock-reps`/`--mock-warmup`/`--ssh-reps`/`--ssh-warmup`. Warmup
+repetitions are still checked against the reviewed expectation (so a
+warmup crash still fails loudly) but are excluded from `wall_time_ns`.
+
+### Result interpretation
+
+- `mock`-kind reports measure `repose-core`'s command algorithms against
+  test doubles — no SSH/SFTP/zypper cost. Use them to catch local
+  algorithmic regressions (allocation, redundant work, O(n²) loops) at
+  fleet scale.
+- `ssh`-kind reports exercise one real host through the fixture and are
+  the only source of real transport/host-key timing in this baseline —
+  they do not model true 100-host network fan-out (a single-container
+  fixture cannot); use them for transport realism, not fleet-scaling
+  claims (see the P0.1 plan's risk log).
+- Compare same-runner-class reports only; `os`/`arch`/`toolchain` differ
+  in ways that make cross-runner latency comparisons meaningless
+  (`scripts/compare-performance.sh`, P0.5, enforces this).
+
+### Platform notes for `peak_rss_bytes`
+
+- macOS: `/usr/bin/time -l`, `maximum resident set size` (already bytes).
+- Linux: GNU `time -v`, `Maximum resident set size` (KB, converted to
+  bytes). Falls back to `null` if GNU `time` isn't installed (BusyBox/
+  POSIX `time` doesn't support `-v`).
+
+### Artifact retention
+
+Raw per-workload reports (`--out`, default `tests/performance/baselines/raw/`)
+and Criterion's own HTML/statistics output (`target/criterion/`) are
+gitignored local/CI artifacts. Only the compact
+`tests/performance/baselines/<runner-class>.json` summary and this
+directory's definitions/docs are committed.
+
+## Release profiling (P0.4)
+
+`scripts/profile-performance.sh <workload-id>` builds once in release mode,
+launches the `baseline_report` harness against one `mock`-kind workload
+(a high repetition count so the process stays alive through the profiling
+window — the profiler attaches after the measured loop is already
+running, so process startup/build time is never attributed to `repose`),
+runs the requested profile classes, and writes a normalized manifest to
+`tests/performance/profiles/<id>.<os>.json` (validated against
+`scripts/validate-performance-profile.jq`). Raw tool output goes to
+`tests/performance/profiles/raw/` (gitignored).
+
+```sh
+# CPU + allocation (works without elevated privileges on both platforms):
+scripts/profile-performance.sh mock-add-100h --classes cpu,alloc
+
+# I/O (needs root on macOS/Linux for fs_usage/strace):
+sudo scripts/profile-performance.sh mock-add-100h --classes io
+```
+
+A requested class that cannot run (missing tool, insufficient privilege,
+unsupported OS) is recorded as `"status": "skipped"` with a `"reason"`, and
+the script exits nonzero — it never reports a silent partial success.
+
+### Prerequisites and supported tools
+
+| Platform | CPU | Allocation | I/O |
+| --- | --- | --- | --- |
+| macOS | `sample` (built-in; no root) | `heap` (built-in; no root) — a **live footprint snapshot**, not a full allocation-count history | `fs_usage` (built-in; **requires root**) |
+| Linux | `perf record`/`perf report` (needs `perf_event_paranoid` low enough, or `CAP_PERFMON`) | `heaptrack` (wraps a fresh launch — cannot attach to an already-running PID; the script documents the correct invocation instead of faking data) | `strace -c` (needs `CAP_SYS_PTRACE` / `ptrace_scope=0`) |
+
+### Known comparability limits
+
+- macOS `heap`/`leaks`-family tools report point-in-time live footprint, not
+  a cumulative allocation count; only compare `heap` output to other `heap`
+  output on the same platform, never to `heaptrack`'s cumulative counts.
+- macOS `sample`'s "top of stack" view is flat — it cannot attribute
+  allocator cost (`malloc`/`free`/`memmove`) to a specific caller without a
+  full call-tree capture. Aggregate allocator percentages are reported as
+  "the workload is allocation-bound", not as a ranked, actionable candidate
+  (see `opportunity-matrix.md`).
+- `perf`/`heaptrack`/`strace` numbers are not comparable across kernel
+  versions or container/VM boundaries; compare within one controlled
+  runner class, same as the report-contract percentiles above.
+- The harness process itself (equivalence checking against
+  `workloads.json`'s reviewed expectations) shows up in these profiles —
+  see `opportunity-matrix.md`'s "excluded as harness artifact" note before
+  ranking a symbol found only in `baseline_report`.
+
+## Regression thresholds and the comparator (P0.5)
+
+`scripts/compare-performance.sh <baseline.json> <candidate.json>` compares
+two contract-valid reports for the *same* workload and runner class,
+applying the rules in `tests/performance/thresholds.json`:
+
+- **Exact** (`exit_code`, `command_count`, `probe_count`, `stdout_digest`,
+  `stderr_digest`): any change is a regression. These are deterministic for
+  `mock`-kind workloads, so there is no legitimate noise to tolerate.
+- **Ceiling** (`peak_concurrency`): the candidate may not exceed the
+  baseline's observed value.
+- **Threshold** (`latency_ns.{p50,p95,p99}`, `throughput_ops_per_sec`,
+  `peak_rss_bytes`): a variance-derived relative tolerance — see
+  `thresholds.json` for the exact ratios and the repeated-run evidence each
+  one cites. `peak_rss_bytes` is skipped (not failed) when either side is
+  `null`.
+
+Exit codes distinguish failure kinds: `0` pass (including a real
+improvement), `1` regression, `2` contract failure (a report doesn't
+satisfy the schema), `3` incomparable metadata (different
+`workload_id`/`runner_class`, or below `minimum_repetitions`).
+
+```sh
+make perf-compare-test   # comparator-fixtures/*.json + one real injected-slowdown guardrail
+scripts/compare-performance.sh before.json after.json
+```
+
+`scripts/test-compare-performance.sh` (`make perf-compare-test`) checks all
+six fixture categories under `comparator-fixtures/` (pass, improvement,
+regression, missing-metric, contract-failure, incomparable-metadata), then
+runs one real end-to-end guardrail: two genuine `baseline_report` runs of
+the same workload must compare as a pass, and a third run with
+`REPOSE_PERF_INJECT_DELAY_MS` set (a real, controllable per-repetition
+delay — not a fabricated fixture) must be caught as a regression.
+
+### Why this isn't in CI yet
+
+CI enforcement is intentionally deferred: the thresholds above come from a
+handful of runs on one shared, uncontrolled development machine (see the
+`evidence` fields in `thresholds.json`), not a dedicated/scheduled runner.
+Shared CI runners are noisier still, so enabling latency/RSS gating there
+without runner-specific variance data would either pass everything (too
+loose) or flap on noise (too tight). Deterministic checks (the exact/ceiling
+metrics above) are cheap to run anywhere and can gate PRs today via `make
+perf-compare-test`; wall-clock/RSS gating should wait for a controlled or
+scheduled runner with its own variance study, per `thresholds.json`'s
+`baseline_refresh_policy`.
+
+### Baseline update review requirements
+
+A baseline is only replaced with reviewed evidence, never silently widened:
+
+1. A stated reason (an approved optimization landed, an accepted
+   regression trade-off, or a runner-class migration).
+2. Linked before/after reports (and, for a claimed improvement/regression,
+   the profile evidence from `scripts/profile-performance.sh` that
+   explains it).
+3. `scripts/compare-performance.sh` output showing what changed and by how
+   much.
+4. Explicit reviewer sign-off in the PR description.
+
+This keeps a baseline change a small, auditable diff — not a bulk
+regeneration that could quietly absorb a regression.

--- a/tests/performance/baselines/local-dev.json
+++ b/tests/performance/baselines/local-dev.json
@@ -1,0 +1,240 @@
+{
+  "contract_version": 1,
+  "runner": {
+    "arch": "aarch64",
+    "os": "macos",
+    "toolchain": "rustc 1.97.1 (8bab26f4f 2026-07-14) (Homebrew)",
+    "runner_class": "local-dev"
+  },
+  "generated_at": "2026-07-21T20:03:53Z",
+  "workloads": [
+    {
+      "workload_id": "mock-add-100h",
+      "kind": "mock",
+      "repetitions": 5,
+      "warmup_repetitions": 1,
+      "latency_ns": {
+        "p50": 202584,
+        "p95": 213708,
+        "p99": 213708
+      },
+      "throughput_ops_per_sec": 493622.3986099593,
+      "peak_rss_bytes": 7340032,
+      "command_count": 200,
+      "probe_count": 100,
+      "peak_concurrency": 1,
+      "exit_code": 0,
+      "stdout_digest": "fnv1a64:cbf29ce484222325",
+      "stderr_digest": "fnv1a64:cbf29ce484222325"
+    },
+    {
+      "workload_id": "mock-add-100h-repeated-urls",
+      "kind": "mock",
+      "repetitions": 5,
+      "warmup_repetitions": 1,
+      "latency_ns": {
+        "p50": 275875,
+        "p95": 286792,
+        "p99": 286792
+      },
+      "throughput_ops_per_sec": 362483.00860897143,
+      "peak_rss_bytes": 7323648,
+      "command_count": 200,
+      "probe_count": 200,
+      "peak_concurrency": 1,
+      "exit_code": 0,
+      "stdout_digest": "fnv1a64:cbf29ce484222325",
+      "stderr_digest": "fnv1a64:cbf29ce484222325"
+    },
+    {
+      "workload_id": "mock-add-100h-slow-host",
+      "kind": "mock",
+      "repetitions": 5,
+      "warmup_repetitions": 1,
+      "latency_ns": {
+        "p50": 20999833,
+        "p95": 21009125,
+        "p99": 21009125
+      },
+      "throughput_ops_per_sec": 4761.942630686634,
+      "peak_rss_bytes": 7323648,
+      "command_count": 200,
+      "probe_count": 100,
+      "peak_concurrency": 2,
+      "exit_code": 0,
+      "stdout_digest": "fnv1a64:cbf29ce484222325",
+      "stderr_digest": "fnv1a64:cbf29ce484222325"
+    },
+    {
+      "workload_id": "mock-add-1h",
+      "kind": "mock",
+      "repetitions": 5,
+      "warmup_repetitions": 1,
+      "latency_ns": {
+        "p50": 48125,
+        "p95": 69291,
+        "p99": 69291
+      },
+      "throughput_ops_per_sec": 20779.22077922078,
+      "peak_rss_bytes": 6782976,
+      "command_count": 2,
+      "probe_count": 1,
+      "peak_concurrency": 1,
+      "exit_code": 0,
+      "stdout_digest": "fnv1a64:cbf29ce484222325",
+      "stderr_digest": "fnv1a64:cbf29ce484222325"
+    },
+    {
+      "workload_id": "mock-add-20h",
+      "kind": "mock",
+      "repetitions": 5,
+      "warmup_repetitions": 1,
+      "latency_ns": {
+        "p50": 61000,
+        "p95": 85709,
+        "p99": 85709
+      },
+      "throughput_ops_per_sec": 327868.8524590164,
+      "peak_rss_bytes": 7094272,
+      "command_count": 40,
+      "probe_count": 20,
+      "peak_concurrency": 1,
+      "exit_code": 0,
+      "stdout_digest": "fnv1a64:cbf29ce484222325",
+      "stderr_digest": "fnv1a64:cbf29ce484222325"
+    },
+    {
+      "workload_id": "mock-add-20h-json",
+      "kind": "mock",
+      "repetitions": 5,
+      "warmup_repetitions": 1,
+      "latency_ns": {
+        "p50": 63458,
+        "p95": 80250,
+        "p99": 80250
+      },
+      "throughput_ops_per_sec": 315169.08821582777,
+      "peak_rss_bytes": 7061504,
+      "command_count": 40,
+      "probe_count": 20,
+      "peak_concurrency": 1,
+      "exit_code": 0,
+      "stdout_digest": "fnv1a64:cbf29ce484222325",
+      "stderr_digest": "fnv1a64:cbf29ce484222325"
+    },
+    {
+      "workload_id": "mock-install-100h",
+      "kind": "mock",
+      "repetitions": 5,
+      "warmup_repetitions": 1,
+      "latency_ns": {
+        "p50": 252125,
+        "p95": 267083,
+        "p99": 267083
+      },
+      "throughput_ops_per_sec": 396628.6564204263,
+      "peak_rss_bytes": 7372800,
+      "command_count": 300,
+      "probe_count": 100,
+      "peak_concurrency": 1,
+      "exit_code": 0,
+      "stdout_digest": "fnv1a64:cbf29ce484222325",
+      "stderr_digest": "fnv1a64:cbf29ce484222325"
+    },
+    {
+      "workload_id": "mock-install-1h",
+      "kind": "mock",
+      "repetitions": 5,
+      "warmup_repetitions": 1,
+      "latency_ns": {
+        "p50": 38166,
+        "p95": 56583,
+        "p99": 56583
+      },
+      "throughput_ops_per_sec": 26201.3310276162,
+      "peak_rss_bytes": 6881280,
+      "command_count": 3,
+      "probe_count": 1,
+      "peak_concurrency": 1,
+      "exit_code": 0,
+      "stdout_digest": "fnv1a64:cbf29ce484222325",
+      "stderr_digest": "fnv1a64:cbf29ce484222325"
+    },
+    {
+      "workload_id": "mock-install-20h",
+      "kind": "mock",
+      "repetitions": 5,
+      "warmup_repetitions": 1,
+      "latency_ns": {
+        "p50": 75167,
+        "p95": 87000,
+        "p99": 87000
+      },
+      "throughput_ops_per_sec": 266074.20809663815,
+      "peak_rss_bytes": 7143424,
+      "command_count": 60,
+      "probe_count": 20,
+      "peak_concurrency": 1,
+      "exit_code": 0,
+      "stdout_digest": "fnv1a64:cbf29ce484222325",
+      "stderr_digest": "fnv1a64:cbf29ce484222325"
+    },
+    {
+      "workload_id": "mock-list-products-100h",
+      "kind": "mock",
+      "repetitions": 5,
+      "warmup_repetitions": 1,
+      "latency_ns": {
+        "p50": 66584,
+        "p95": 70917,
+        "p99": 70917
+      },
+      "throughput_ops_per_sec": 1501862.3092634869,
+      "peak_rss_bytes": 6651904,
+      "command_count": 0,
+      "probe_count": 0,
+      "peak_concurrency": 1,
+      "exit_code": 0,
+      "stdout_digest": "fnv1a64:d8687c62ab369b7a",
+      "stderr_digest": "fnv1a64:cbf29ce484222325"
+    },
+    {
+      "workload_id": "mock-list-products-1h",
+      "kind": "mock",
+      "repetitions": 5,
+      "warmup_repetitions": 1,
+      "latency_ns": {
+        "p50": 2125,
+        "p95": 3666,
+        "p99": 3666
+      },
+      "throughput_ops_per_sec": 470588.23529411765,
+      "peak_rss_bytes": 6307840,
+      "command_count": 0,
+      "probe_count": 0,
+      "peak_concurrency": 1,
+      "exit_code": 0,
+      "stdout_digest": "fnv1a64:aed4be552ba28267",
+      "stderr_digest": "fnv1a64:cbf29ce484222325"
+    },
+    {
+      "workload_id": "mock-list-products-20h-json",
+      "kind": "mock",
+      "repetitions": 5,
+      "warmup_repetitions": 1,
+      "latency_ns": {
+        "p50": 18459,
+        "p95": 20292,
+        "p99": 20292
+      },
+      "throughput_ops_per_sec": 1083482.3121512542,
+      "peak_rss_bytes": 6504448,
+      "command_count": 0,
+      "probe_count": 0,
+      "peak_concurrency": 1,
+      "exit_code": 0,
+      "stdout_digest": "fnv1a64:2c96a1505b9714c1",
+      "stderr_digest": "fnv1a64:cbf29ce484222325"
+    }
+  ]
+}

--- a/tests/performance/comparator-fixtures/contract-failure.json
+++ b/tests/performance/comparator-fixtures/contract-failure.json
@@ -1,0 +1,93 @@
+{
+  "note": "candidate is missing the required exit_code field \u2014 must be rejected before any metric comparison runs.",
+  "expect": "contract-failure",
+  "baseline": {
+    "command_count": 2,
+    "contract_version": 1,
+    "exit_code": 0,
+    "host_order": [
+      "h1"
+    ],
+    "kind": "mock",
+    "latency_ns": {
+      "p50": 45000,
+      "p95": 54458,
+      "p99": 54458
+    },
+    "peak_concurrency": 1,
+    "peak_rss_bytes": null,
+    "probe_count": 1,
+    "repetitions": 15,
+    "runner": {
+      "arch": "aarch64",
+      "os": "macos",
+      "toolchain": null
+    },
+    "stderr_digest": "fnv1a64:cbf29ce484222325",
+    "stdout_digest": "fnv1a64:cbf29ce484222325",
+    "throughput_ops_per_sec": 22222.222222222223,
+    "wall_time_ns": [
+      40041,
+      41500,
+      42375,
+      42833,
+      43084,
+      43375,
+      43708,
+      45000,
+      45500,
+      45584,
+      46167,
+      47375,
+      51209,
+      51875,
+      54458
+    ],
+    "warmup_repetitions": 3,
+    "workload_id": "mock-add-1h"
+  },
+  "candidate": {
+    "command_count": 2,
+    "contract_version": 1,
+    "host_order": [
+      "h1"
+    ],
+    "kind": "mock",
+    "latency_ns": {
+      "p50": 46000,
+      "p95": 53500,
+      "p99": 53500
+    },
+    "peak_concurrency": 1,
+    "peak_rss_bytes": null,
+    "probe_count": 1,
+    "repetitions": 15,
+    "runner": {
+      "arch": "aarch64",
+      "os": "macos",
+      "toolchain": null
+    },
+    "stderr_digest": "fnv1a64:cbf29ce484222325",
+    "stdout_digest": "fnv1a64:cbf29ce484222325",
+    "throughput_ops_per_sec": 21739.130434782608,
+    "wall_time_ns": [
+      38417,
+      39292,
+      41291,
+      42791,
+      43000,
+      43833,
+      44167,
+      46000,
+      46084,
+      46708,
+      48458,
+      49292,
+      50708,
+      51875,
+      53500
+    ],
+    "warmup_repetitions": 3,
+    "workload_id": "mock-add-1h"
+  }
+}

--- a/tests/performance/comparator-fixtures/improvement.json
+++ b/tests/performance/comparator-fixtures/improvement.json
@@ -1,0 +1,94 @@
+{
+  "note": "Candidate is meaningfully faster than baseline; the comparator must treat this as a pass, not a regression.",
+  "expect": "pass",
+  "baseline": {
+    "command_count": 2,
+    "contract_version": 1,
+    "exit_code": 0,
+    "host_order": [
+      "h1"
+    ],
+    "kind": "mock",
+    "latency_ns": {
+      "p50": 45000,
+      "p95": 54458,
+      "p99": 54458
+    },
+    "peak_concurrency": 1,
+    "peak_rss_bytes": null,
+    "probe_count": 1,
+    "repetitions": 15,
+    "runner": {
+      "arch": "aarch64",
+      "os": "macos",
+      "toolchain": null
+    },
+    "stderr_digest": "fnv1a64:cbf29ce484222325",
+    "stdout_digest": "fnv1a64:cbf29ce484222325",
+    "throughput_ops_per_sec": 22222.222222222223,
+    "wall_time_ns": [
+      40041,
+      41500,
+      42375,
+      42833,
+      43084,
+      43375,
+      43708,
+      45000,
+      45500,
+      45584,
+      46167,
+      47375,
+      51209,
+      51875,
+      54458
+    ],
+    "warmup_repetitions": 3,
+    "workload_id": "mock-add-1h"
+  },
+  "candidate": {
+    "command_count": 2,
+    "contract_version": 1,
+    "exit_code": 0,
+    "host_order": [
+      "h1"
+    ],
+    "kind": "mock",
+    "latency_ns": {
+      "p50": 20000,
+      "p95": 24000,
+      "p99": 24000
+    },
+    "peak_concurrency": 1,
+    "peak_rss_bytes": null,
+    "probe_count": 1,
+    "repetitions": 15,
+    "runner": {
+      "arch": "aarch64",
+      "os": "macos",
+      "toolchain": null
+    },
+    "stderr_digest": "fnv1a64:cbf29ce484222325",
+    "stdout_digest": "fnv1a64:cbf29ce484222325",
+    "throughput_ops_per_sec": 49999.99999999999,
+    "wall_time_ns": [
+      18000,
+      18400,
+      18800,
+      19200,
+      19600,
+      20000,
+      20400,
+      20800,
+      21200,
+      21600,
+      22000,
+      22400,
+      22800,
+      23200,
+      23600
+    ],
+    "warmup_repetitions": 3,
+    "workload_id": "mock-add-1h"
+  }
+}

--- a/tests/performance/comparator-fixtures/incomparable-metadata.json
+++ b/tests/performance/comparator-fixtures/incomparable-metadata.json
@@ -1,0 +1,94 @@
+{
+  "note": "candidate.workload_id differs from baseline.workload_id \u2014 comparing them would be meaningless.",
+  "expect": "incomparable-metadata",
+  "baseline": {
+    "command_count": 2,
+    "contract_version": 1,
+    "exit_code": 0,
+    "host_order": [
+      "h1"
+    ],
+    "kind": "mock",
+    "latency_ns": {
+      "p50": 45000,
+      "p95": 54458,
+      "p99": 54458
+    },
+    "peak_concurrency": 1,
+    "peak_rss_bytes": null,
+    "probe_count": 1,
+    "repetitions": 15,
+    "runner": {
+      "arch": "aarch64",
+      "os": "macos",
+      "toolchain": null
+    },
+    "stderr_digest": "fnv1a64:cbf29ce484222325",
+    "stdout_digest": "fnv1a64:cbf29ce484222325",
+    "throughput_ops_per_sec": 22222.222222222223,
+    "wall_time_ns": [
+      40041,
+      41500,
+      42375,
+      42833,
+      43084,
+      43375,
+      43708,
+      45000,
+      45500,
+      45584,
+      46167,
+      47375,
+      51209,
+      51875,
+      54458
+    ],
+    "warmup_repetitions": 3,
+    "workload_id": "mock-add-1h"
+  },
+  "candidate": {
+    "command_count": 2,
+    "contract_version": 1,
+    "exit_code": 0,
+    "host_order": [
+      "h1"
+    ],
+    "kind": "mock",
+    "latency_ns": {
+      "p50": 46000,
+      "p95": 53500,
+      "p99": 53500
+    },
+    "peak_concurrency": 1,
+    "peak_rss_bytes": null,
+    "probe_count": 1,
+    "repetitions": 15,
+    "runner": {
+      "arch": "aarch64",
+      "os": "macos",
+      "toolchain": null
+    },
+    "stderr_digest": "fnv1a64:cbf29ce484222325",
+    "stdout_digest": "fnv1a64:cbf29ce484222325",
+    "throughput_ops_per_sec": 21739.130434782608,
+    "wall_time_ns": [
+      38417,
+      39292,
+      41291,
+      42791,
+      43000,
+      43833,
+      44167,
+      46000,
+      46084,
+      46708,
+      48458,
+      49292,
+      50708,
+      51875,
+      53500
+    ],
+    "warmup_repetitions": 3,
+    "workload_id": "mock-add-20h"
+  }
+}

--- a/tests/performance/comparator-fixtures/missing-metric.json
+++ b/tests/performance/comparator-fixtures/missing-metric.json
@@ -1,0 +1,94 @@
+{
+  "note": "peak_rss_bytes is null in both reports (RSS collection not run) \u2014 the comparator must skip that metric, not fail.",
+  "expect": "pass",
+  "baseline": {
+    "command_count": 2,
+    "contract_version": 1,
+    "exit_code": 0,
+    "host_order": [
+      "h1"
+    ],
+    "kind": "mock",
+    "latency_ns": {
+      "p50": 45000,
+      "p95": 54458,
+      "p99": 54458
+    },
+    "peak_concurrency": 1,
+    "peak_rss_bytes": null,
+    "probe_count": 1,
+    "repetitions": 15,
+    "runner": {
+      "arch": "aarch64",
+      "os": "macos",
+      "toolchain": null
+    },
+    "stderr_digest": "fnv1a64:cbf29ce484222325",
+    "stdout_digest": "fnv1a64:cbf29ce484222325",
+    "throughput_ops_per_sec": 22222.222222222223,
+    "wall_time_ns": [
+      40041,
+      41500,
+      42375,
+      42833,
+      43084,
+      43375,
+      43708,
+      45000,
+      45500,
+      45584,
+      46167,
+      47375,
+      51209,
+      51875,
+      54458
+    ],
+    "warmup_repetitions": 3,
+    "workload_id": "mock-add-1h"
+  },
+  "candidate": {
+    "command_count": 2,
+    "contract_version": 1,
+    "exit_code": 0,
+    "host_order": [
+      "h1"
+    ],
+    "kind": "mock",
+    "latency_ns": {
+      "p50": 46000,
+      "p95": 53500,
+      "p99": 53500
+    },
+    "peak_concurrency": 1,
+    "peak_rss_bytes": null,
+    "probe_count": 1,
+    "repetitions": 15,
+    "runner": {
+      "arch": "aarch64",
+      "os": "macos",
+      "toolchain": null
+    },
+    "stderr_digest": "fnv1a64:cbf29ce484222325",
+    "stdout_digest": "fnv1a64:cbf29ce484222325",
+    "throughput_ops_per_sec": 21739.130434782608,
+    "wall_time_ns": [
+      38417,
+      39292,
+      41291,
+      42791,
+      43000,
+      43833,
+      44167,
+      46000,
+      46084,
+      46708,
+      48458,
+      49292,
+      50708,
+      51875,
+      53500
+    ],
+    "warmup_repetitions": 3,
+    "workload_id": "mock-add-1h"
+  }
+}

--- a/tests/performance/comparator-fixtures/pass.json
+++ b/tests/performance/comparator-fixtures/pass.json
@@ -1,0 +1,94 @@
+{
+  "note": "Two independent real baseline_report runs of the same workload; latency differs by ordinary run-to-run noise, all exact metrics match.",
+  "expect": "pass",
+  "baseline": {
+    "command_count": 2,
+    "contract_version": 1,
+    "exit_code": 0,
+    "host_order": [
+      "h1"
+    ],
+    "kind": "mock",
+    "latency_ns": {
+      "p50": 45000,
+      "p95": 54458,
+      "p99": 54458
+    },
+    "peak_concurrency": 1,
+    "peak_rss_bytes": null,
+    "probe_count": 1,
+    "repetitions": 15,
+    "runner": {
+      "arch": "aarch64",
+      "os": "macos",
+      "toolchain": null
+    },
+    "stderr_digest": "fnv1a64:cbf29ce484222325",
+    "stdout_digest": "fnv1a64:cbf29ce484222325",
+    "throughput_ops_per_sec": 22222.222222222223,
+    "wall_time_ns": [
+      40041,
+      41500,
+      42375,
+      42833,
+      43084,
+      43375,
+      43708,
+      45000,
+      45500,
+      45584,
+      46167,
+      47375,
+      51209,
+      51875,
+      54458
+    ],
+    "warmup_repetitions": 3,
+    "workload_id": "mock-add-1h"
+  },
+  "candidate": {
+    "command_count": 2,
+    "contract_version": 1,
+    "exit_code": 0,
+    "host_order": [
+      "h1"
+    ],
+    "kind": "mock",
+    "latency_ns": {
+      "p50": 46000,
+      "p95": 53500,
+      "p99": 53500
+    },
+    "peak_concurrency": 1,
+    "peak_rss_bytes": null,
+    "probe_count": 1,
+    "repetitions": 15,
+    "runner": {
+      "arch": "aarch64",
+      "os": "macos",
+      "toolchain": null
+    },
+    "stderr_digest": "fnv1a64:cbf29ce484222325",
+    "stdout_digest": "fnv1a64:cbf29ce484222325",
+    "throughput_ops_per_sec": 21739.130434782608,
+    "wall_time_ns": [
+      38417,
+      39292,
+      41291,
+      42791,
+      43000,
+      43833,
+      44167,
+      46000,
+      46084,
+      46708,
+      48458,
+      49292,
+      50708,
+      51875,
+      53500
+    ],
+    "warmup_repetitions": 3,
+    "workload_id": "mock-add-1h"
+  }
+}

--- a/tests/performance/comparator-fixtures/regression.json
+++ b/tests/performance/comparator-fixtures/regression.json
@@ -1,0 +1,94 @@
+{
+  "note": "command_count changed from 2 to 4 (e.g. a redundant refresh reappeared) \u2014 an exact-metric violation.",
+  "expect": "regression",
+  "baseline": {
+    "command_count": 2,
+    "contract_version": 1,
+    "exit_code": 0,
+    "host_order": [
+      "h1"
+    ],
+    "kind": "mock",
+    "latency_ns": {
+      "p50": 45000,
+      "p95": 54458,
+      "p99": 54458
+    },
+    "peak_concurrency": 1,
+    "peak_rss_bytes": null,
+    "probe_count": 1,
+    "repetitions": 15,
+    "runner": {
+      "arch": "aarch64",
+      "os": "macos",
+      "toolchain": null
+    },
+    "stderr_digest": "fnv1a64:cbf29ce484222325",
+    "stdout_digest": "fnv1a64:cbf29ce484222325",
+    "throughput_ops_per_sec": 22222.222222222223,
+    "wall_time_ns": [
+      40041,
+      41500,
+      42375,
+      42833,
+      43084,
+      43375,
+      43708,
+      45000,
+      45500,
+      45584,
+      46167,
+      47375,
+      51209,
+      51875,
+      54458
+    ],
+    "warmup_repetitions": 3,
+    "workload_id": "mock-add-1h"
+  },
+  "candidate": {
+    "command_count": 4,
+    "contract_version": 1,
+    "exit_code": 0,
+    "host_order": [
+      "h1"
+    ],
+    "kind": "mock",
+    "latency_ns": {
+      "p50": 46000,
+      "p95": 53500,
+      "p99": 53500
+    },
+    "peak_concurrency": 1,
+    "peak_rss_bytes": null,
+    "probe_count": 1,
+    "repetitions": 15,
+    "runner": {
+      "arch": "aarch64",
+      "os": "macos",
+      "toolchain": null
+    },
+    "stderr_digest": "fnv1a64:cbf29ce484222325",
+    "stdout_digest": "fnv1a64:cbf29ce484222325",
+    "throughput_ops_per_sec": 21739.130434782608,
+    "wall_time_ns": [
+      38417,
+      39292,
+      41291,
+      42791,
+      43000,
+      43833,
+      44167,
+      46000,
+      46084,
+      46708,
+      48458,
+      49292,
+      50708,
+      51875,
+      53500
+    ],
+    "warmup_repetitions": 3,
+    "workload_id": "mock-add-1h"
+  }
+}

--- a/tests/performance/opportunity-matrix.md
+++ b/tests/performance/opportunity-matrix.md
@@ -1,0 +1,71 @@
+# P0.4 opportunity matrix
+
+Ranked local-CPU/allocation opportunities from release profiles of the
+`mock`-kind fleet workloads. Every entry traces to a captured manifest
+under `tests/performance/profiles/`; no percentage here is inferred from
+source reading alone (see `tests/performance/README.md` for the contract
+and cross-platform prerequisites).
+
+## Evidence captured
+
+| Manifest | Workload | Platform | Classes |
+|---|---|---|---|
+| `mock-add-100h.darwin.json` | `add`, 100 hosts, 200k reps | macOS arm64, `sample`+`heap` | cpu, alloc |
+| `mock-list-products-100h.darwin.json` | `list-products`, 100 hosts, 200k reps | macOS arm64, `sample`+`heap` | cpu, alloc |
+
+**I/O class**: attempted (`fs_usage`) and recorded as `"status": "skipped"` —
+this sandbox has no passwordless `sudo` and `fs_usage` requires root. No I/O
+opportunity is claimed below; rerun `scripts/profile-performance.sh <id>
+--classes io` with root to fill this in.
+
+**Linux**: not captured in this session (no Linux host available); the
+`perf`/`heaptrack`/`strace` adapters in `scripts/profile-performance.sh` are
+implemented per each tool's documented CLI but unverified end-to-end. Treat
+Linux-specific claims as pending until a Linux capture lands.
+
+**Scope caveat**: these are `mock`-kind (in-process, no SSH/SFTP/zypper)
+profiles — they measure `repose-core`'s *local* command-algorithm cost, not
+remote/network cost. This is consistent with, not a contradiction of, the
+audit's conclusion that remote round trips dominate production wall time
+(`plans/performance-action-plan.md`); local hotspots matter most for P5
+("profile-gated local optimizations"), which explicitly gates on evidence
+like this.
+
+**Excluded as harness artifact**: `mock-list-products-100h`'s CPU profile's
+#2 symbol is `baseline_report::check_expectation` (185/2215 ≈ 8.4% of
+top-of-stack samples) — the harness's own per-repetition equivalence check
+(hashing the full 100-host stdout every rep). This is
+`crates/repose-core/examples/baseline_report.rs` overhead, not `repose`
+production behavior, and is excluded from ranking below.
+
+**Not independently attributable**: generic allocator/copy symbols
+(`_xzm_malloc_tc`, `_xzm_free_tc`, `_platform_memmove`, `_malloc_zone_malloc`,
+`_free`, `_platform_memcmp`) together account for ~41% of `mock-add-100h`'s
+top-of-stack samples. `sample`'s flat top-of-stack view cannot attribute
+*which* call site allocated without a full call-tree capture (a known
+macOS-tooling limit — `tests/performance/README.md`), so this is reported as
+aggregate evidence that the workload is allocation/copy-bound in general
+(motivating P5's existing clone-reduction items), not as a single ranked
+candidate below.
+
+## Ranked candidates
+
+| Rank | Candidate | Evidence | Impact | Confidence | Effort | Score | Equivalence constraint |
+|---:|---|---|---|---|---|---|---|
+| 1 | `repose_core::shell::quote` allocates a new `String` even on the all-safe-characters fast path | `mock-add-100h.darwin.json` cpu: `repose_core::shell::quote` is the top *repose*-owned symbol at 109/2711 ≈ 4.0% of top-of-stack samples, called once per shell token in every generated `zypper`/`transactional-update` command across 100 hosts | Medium (called on every command token, every host) | High (function is on the hot path in every mutation command) | Small (return `Cow<str>` or write into a caller-supplied buffer; `is_safe_char` scan already computed) | (0.6×0.9)/0.2 ≈ 2.7 | Output bytes for every existing `tests/vectors/shell/` vector must stay byte-identical; only the allocation strategy changes |
+| 2 | `Repoq::substitute` / `Repoq::solve_repa` template-variable substitution cost | `mock-add-100h` cpu: `repoq::substitute` and `repoq::solve_repa` symbols present in the sampled call stacks (per-REPA, per-host); scales with `host_count × repa_count` | Medium at fleet scale | Medium (present but smaller than rank 1 in this capture; needs a repeated/controlled capture to rank precisely) | Small–Medium | (0.5×0.6)/0.3 ≈ 1.0 | Resolved repository name/URL/refresh values must stay byte-identical for every `tests/vectors/repoq/` case |
+| 3 | `products.yml` (YAML) template is re-parsed from scratch inside `load_repoq` on every `run_add`/`run_install` call | `mock-add-100h` cpu: `unsafe_libyaml::scanner::yaml_parser_fetch_plain_scalar` / `yaml_parser_update_buffer` present in top-of-stack samples; `mock-install-1h`/`mock-add-1h` baselines show ~36–50µs p50 for a single host, where template parsing is a non-negligible fraction | Low in production (one parse per CLI invocation regardless of host count, so cost is amortized across the fleet) — **not worth optimizing at current scale**; recorded for completeness only | Medium | N/A | Below threshold | N/A — do not implement without a production workload showing per-invocation parse cost actually matters (e.g., many small, single-host invocations) |
+| 4 | `core::fmt::write` / `alloc::str::join_generic_copy` string formatting and joining | `mock-add-100h` cpu: both present in top-of-stack samples (17 and 15 of 2711 respectively ≈ 0.6% each) — likely `shell::join`/`cmd::*` command-string assembly | Low (each individually under 1% of samples) | Medium | Small | (0.3×0.6)/0.2 ≈ 0.9 | Generated command strings must stay byte-identical |
+| 5 | Aggregate allocation/copy pressure (~41% of `mock-add-100h` top-of-stack samples across `malloc`/`free`/`memmove`/`memcmp`) | `mock-add-100h.darwin.json` cpu (see "not independently attributable" above) | Unknown until attributed | Low until a call-tree-attributed capture exists | N/A | Profile-gated | Capture a call-tree (not flat top-of-stack) profile — e.g. `perf record --call-graph` on Linux, or Instruments Allocations on macOS — before deriving a specific P5 candidate from this line |
+
+## Next steps
+
+1. Capture a Linux `perf`/`heaptrack` run to validate the darwin-only
+   evidence above and fill in the I/O class.
+2. Capture a call-tree (not flat) CPU profile to attribute rank 5's
+   aggregate allocation cost to specific call sites before proposing a P5
+   change for it.
+3. Re-profile after any P1–P3 change that touches `add`/`install`'s hot
+   path (bounded fan-out, batched refreshes) — ranks 1–2 may shift once
+   remote-round-trip reductions land, since they change how many times
+   `shell::quote`/`Repoq::solve_repa` run per invocation.

--- a/tests/performance/profiles/mock-add-100h.darwin.json
+++ b/tests/performance/profiles/mock-add-100h.darwin.json
@@ -1,0 +1,68 @@
+{
+  "contract_version": 1,
+  "workload_id": "mock-add-100h",
+  "platform": {
+    "os": "darwin",
+    "arch": "arm64"
+  },
+  "measured_command": "/Users/mimi/work/repose/.wt/performace_one/target/release/examples/baseline_report mock-add-100h 200000 1",
+  "measured_pid": 91822,
+  "setup_excluded": true,
+  "generated_at": "2026-07-21T20:01:34Z",
+  "classes": {
+    "cpu": {
+      "tool": "sample",
+      "raw_artifact": "/Users/mimi/work/repose/.wt/performace_one/tests/performance/profiles/raw/mock-add-100h.cpu.sample.txt",
+      "total_top_of_stack_samples": 2788,
+      "top_symbols": [
+        {
+          "symbol": "_xzm_free_tc (in libsystem_malloc.dylib)",
+          "samples": 324
+        },
+        {
+          "symbol": "_platform_memmove (in libsystem_platform.dylib)",
+          "samples": 278
+        },
+        {
+          "symbol": "_xzm_malloc_tc (in libsystem_malloc.dylib)",
+          "samples": 192
+        },
+        {
+          "symbol": "__open (in libsystem_kernel.dylib)",
+          "samples": 186
+        },
+        {
+          "symbol": "_malloc_zone_malloc (in libsystem_malloc.dylib)",
+          "samples": 168
+        },
+        {
+          "symbol": "_free (in libsystem_malloc.dylib)",
+          "samples": 150
+        },
+        {
+          "symbol": "_RNvNtCscFKwzjhlyO7_11repose_core5shell5quote (in baseline_report)",
+          "samples": 99
+        },
+        {
+          "symbol": "_platform_memcmp (in libsystem_platform.dylib)",
+          "samples": 92
+        },
+        {
+          "symbol": "_RNvCs7a7XMsdEgBq_7___rustc11___rdl_alloc (in baseline_report)",
+          "samples": 71
+        },
+        {
+          "symbol": "DYLD-STUB$$free (in baseline_report)",
+          "samples": 55
+        }
+      ]
+    },
+    "alloc": {
+      "tool": "heap",
+      "raw_artifact": "/Users/mimi/work/repose/.wt/performace_one/tests/performance/profiles/raw/mock-add-100h.alloc.heap.txt",
+      "physical_footprint": "3776K",
+      "node_count": 1259,
+      "total_bytes": 3353760
+    }
+  }
+}

--- a/tests/performance/profiles/mock-list-products-100h.darwin.json
+++ b/tests/performance/profiles/mock-list-products-100h.darwin.json
@@ -1,0 +1,68 @@
+{
+  "contract_version": 1,
+  "workload_id": "mock-list-products-100h",
+  "platform": {
+    "os": "darwin",
+    "arch": "arm64"
+  },
+  "measured_command": "/Users/mimi/work/repose/.wt/performace_one/target/release/examples/baseline_report mock-list-products-100h 200000 1",
+  "measured_pid": 91866,
+  "setup_excluded": true,
+  "generated_at": "2026-07-21T20:01:38Z",
+  "classes": {
+    "cpu": {
+      "tool": "sample",
+      "raw_artifact": "/Users/mimi/work/repose/.wt/performace_one/tests/performance/profiles/raw/mock-list-products-100h.cpu.sample.txt",
+      "total_top_of_stack_samples": 2215,
+      "top_symbols": [
+        {
+          "symbol": "_platform_memmove (in libsystem_platform.dylib)",
+          "samples": 233
+        },
+        {
+          "symbol": "_RNvCslPJ0aWzvJP5_15baseline_report17check_expectation (in baseline_report)",
+          "samples": 185
+        },
+        {
+          "symbol": "_xzm_free_tc (in libsystem_malloc.dylib)",
+          "samples": 155
+        },
+        {
+          "symbol": "_xzm_malloc_tc (in libsystem_malloc.dylib)",
+          "samples": 118
+        },
+        {
+          "symbol": "_RNvXs2_NtNtCsaTNopw4qKPP_4core3str5lossyNtB5_10Utf8ChunksNtNtNtNtB9_4iter6traits8iterator8Iterator4next (in baseline_report)",
+          "samples": 114
+        },
+        {
+          "symbol": "_free (in libsystem_malloc.dylib)",
+          "samples": 103
+        },
+        {
+          "symbol": "_platform_memcmp (in libsystem_platform.dylib)",
+          "samples": 101
+        },
+        {
+          "symbol": "_malloc_zone_malloc (in libsystem_malloc.dylib)",
+          "samples": 96
+        },
+        {
+          "symbol": "_RNvMsi_NtNtNtCs3XW7gbOxCtj_5alloc11collections5btree3mapINtB5_8BTreeMapNtNtBb_6string6StringNtNtCscFKwzjhlyO7_11repose_core4mock8MockHostE6insertB1w_ (in baseline_report)",
+          "samples": 83
+        },
+        {
+          "symbol": "_RNvXs_NtCscFKwzjhlyO7_11repose_core7consoleNtB4_6BufferNtNtCs106jutQF6X5_3std2io5Write5write (in baseline_report)",
+          "samples": 68
+        }
+      ]
+    },
+    "alloc": {
+      "tool": "heap",
+      "raw_artifact": "/Users/mimi/work/repose/.wt/performace_one/tests/performance/profiles/raw/mock-list-products-100h.alloc.heap.txt",
+      "physical_footprint": "3328K",
+      "node_count": 1434,
+      "total_bytes": 3396976
+    }
+  }
+}

--- a/tests/performance/thresholds.json
+++ b/tests/performance/thresholds.json
@@ -1,0 +1,58 @@
+{
+  "contract_version": 1,
+  "minimum_repetitions": 10,
+  "baseline_refresh_policy": "A baseline is only replaced with reviewed evidence: linked before/after reports, the reason for the change (an approved optimization, an accepted regression trade-off, or a runner-class migration), and explicit reviewer sign-off in the PR description. No automatic or silent widening — see tests/performance/README.md#baseline-update-review-requirements.",
+  "owner": "See CODEOWNERS / PR reviewer for crates/repose-core/benches and tests/performance.",
+  "metrics": {
+    "exit_code": {
+      "rule": "exact",
+      "reason": "Semantic contract, not a measurement; any change is a correctness regression."
+    },
+    "command_count": {
+      "rule": "exact",
+      "reason": "Deterministic for mock-kind workloads; a change means the algorithm now issues a different number of remote commands."
+    },
+    "probe_count": {
+      "rule": "exact",
+      "reason": "Deterministic for mock-kind workloads."
+    },
+    "stdout_digest": {
+      "rule": "exact",
+      "reason": "Deterministic for mock-kind workloads; a change means observable output changed."
+    },
+    "stderr_digest": {
+      "rule": "exact",
+      "reason": "Deterministic for mock-kind workloads."
+    },
+    "peak_concurrency": {
+      "rule": "ceiling",
+      "reason": "Candidate must not exceed baseline's observed peak in-flight operations; concurrency can drop (fan-out becoming more serial is caught by the fleet_add/fleet_install Criterion assertions and repose-core::mock's own gated tests, not by this numeric comparison alone)."
+    },
+    "latency_ns.p50": {
+      "rule": "max_increase_ratio",
+      "value": 1.0,
+      "evidence": "5 independent local runs of mock-add-100h (20 reps, 3 warmup) on this shared/uncontrolled runner ranged 189625-296375 ns p50 (~56% spread); mock-add-1h ranged 33708-44916 ns (~33% spread). A 100% (2x) threshold sits comfortably above observed noise while still catching a real regression. Tighten per-runner-class once a controlled/scheduled runner has its own variance study (see baseline_refresh_policy)."
+    },
+    "latency_ns.p95": {
+      "rule": "max_increase_ratio",
+      "value": 1.0,
+      "evidence": "Same measurement set as latency_ns.p50; p95 showed comparable relative spread across the 5 runs."
+    },
+    "latency_ns.p99": {
+      "rule": "max_increase_ratio",
+      "value": 1.2,
+      "evidence": "Tail percentile from a 20-repetition sample is the noisiest single number collected; a slightly wider margin than p50/p95 avoids flagging sampling noise as a regression."
+    },
+    "throughput_ops_per_sec": {
+      "rule": "max_decrease_ratio",
+      "value": 0.5,
+      "evidence": "Derived from latency_ns.p50 (throughput = host_count / p50_seconds); the ratio is the inverse of the p50 tolerance above."
+    },
+    "peak_rss_bytes": {
+      "rule": "max_increase_ratio",
+      "value": 0.2,
+      "evidence": "3 independent runs of mock-add-100h RSS ranged 7307264-7389184 bytes (~1.1% spread) — far tighter than latency. 20% leaves headroom for legitimate allocator/runtime variation while still catching a material memory regression.",
+      "skip_if_null": true
+    }
+  }
+}

--- a/tests/performance/workloads.json
+++ b/tests/performance/workloads.json
@@ -1,0 +1,311 @@
+{
+  "contract_version": 1,
+  "workloads": [
+    {
+      "id": "mock-add-1h",
+      "kind": "mock",
+      "command": "add",
+      "host_count": 1,
+      "repa": [
+        "SLES:15-SP3:x86_64:update"
+      ],
+      "repeated_urls": false,
+      "slow_host": false,
+      "output_format": "text",
+      "expect": {
+        "exit_code": 0,
+        "command_count": 2,
+        "probe_count": 1,
+        "peak_operations_max": 1,
+        "host_order": [
+          "h1"
+        ],
+        "stdout_digest": "fnv1a64:cbf29ce484222325"
+      }
+    },
+    {
+      "id": "mock-add-20h",
+      "kind": "mock",
+      "command": "add",
+      "host_count": 20,
+      "repa": [
+        "SLES:15-SP3:x86_64:update"
+      ],
+      "repeated_urls": false,
+      "slow_host": false,
+      "output_format": "text",
+      "expect": {
+        "exit_code": 0,
+        "command_count": 40,
+        "probe_count": 20,
+        "peak_operations_max": 20,
+        "host_order": [],
+        "stdout_digest": "fnv1a64:cbf29ce484222325"
+      }
+    },
+    {
+      "id": "mock-add-100h",
+      "kind": "mock",
+      "command": "add",
+      "host_count": 100,
+      "repa": [
+        "SLES:15-SP3:x86_64:update"
+      ],
+      "repeated_urls": false,
+      "slow_host": false,
+      "output_format": "text",
+      "expect": {
+        "exit_code": 0,
+        "command_count": 200,
+        "probe_count": 100,
+        "peak_operations_max": 100,
+        "host_order": [],
+        "stdout_digest": "fnv1a64:cbf29ce484222325"
+      }
+    },
+    {
+      "id": "mock-add-100h-repeated-urls",
+      "kind": "mock",
+      "command": "add",
+      "host_count": 100,
+      "repa": [
+        "SLES:15-SP3:x86_64:update"
+      ],
+      "repeated_urls": true,
+      "slow_host": false,
+      "output_format": "text",
+      "expect": {
+        "exit_code": 0,
+        "command_count": 200,
+        "probe_count": 200,
+        "peak_operations_max": 100,
+        "host_order": [],
+        "stdout_digest": "fnv1a64:cbf29ce484222325"
+      }
+    },
+    {
+      "id": "mock-add-100h-slow-host",
+      "kind": "mock",
+      "command": "add",
+      "host_count": 100,
+      "repa": [
+        "SLES:15-SP3:x86_64:update"
+      ],
+      "repeated_urls": false,
+      "slow_host": true,
+      "output_format": "text",
+      "expect": {
+        "exit_code": 0,
+        "command_count": 200,
+        "probe_count": 100,
+        "peak_operations_max": 100,
+        "host_order": [],
+        "stdout_digest": "fnv1a64:cbf29ce484222325"
+      }
+    },
+    {
+      "id": "mock-add-20h-json",
+      "kind": "mock",
+      "command": "add",
+      "host_count": 20,
+      "repa": [
+        "SLES:15-SP3:x86_64:update"
+      ],
+      "repeated_urls": false,
+      "slow_host": false,
+      "output_format": "json",
+      "expect": {
+        "exit_code": 0,
+        "command_count": 40,
+        "probe_count": 20,
+        "peak_operations_max": 20,
+        "host_order": [],
+        "stdout_digest": "fnv1a64:cbf29ce484222325"
+      }
+    },
+    {
+      "id": "mock-install-1h",
+      "kind": "mock",
+      "command": "install",
+      "host_count": 1,
+      "repa": [
+        "SLES:15-SP3:x86_64:update"
+      ],
+      "repeated_urls": false,
+      "slow_host": false,
+      "output_format": "text",
+      "expect": {
+        "exit_code": 0,
+        "command_count": 3,
+        "probe_count": 1,
+        "peak_operations_max": 1,
+        "host_order": [
+          "h1"
+        ],
+        "stdout_digest": "fnv1a64:cbf29ce484222325"
+      }
+    },
+    {
+      "id": "mock-install-20h",
+      "kind": "mock",
+      "command": "install",
+      "host_count": 20,
+      "repa": [
+        "SLES:15-SP3:x86_64:update"
+      ],
+      "repeated_urls": false,
+      "slow_host": false,
+      "output_format": "text",
+      "expect": {
+        "exit_code": 0,
+        "command_count": 60,
+        "probe_count": 20,
+        "peak_operations_max": 20,
+        "host_order": [],
+        "stdout_digest": "fnv1a64:cbf29ce484222325"
+      }
+    },
+    {
+      "id": "mock-install-100h",
+      "kind": "mock",
+      "command": "install",
+      "host_count": 100,
+      "repa": [
+        "SLES:15-SP3:x86_64:update"
+      ],
+      "repeated_urls": false,
+      "slow_host": false,
+      "output_format": "text",
+      "expect": {
+        "exit_code": 0,
+        "command_count": 300,
+        "probe_count": 100,
+        "peak_operations_max": 100,
+        "host_order": [],
+        "stdout_digest": "fnv1a64:cbf29ce484222325"
+      }
+    },
+    {
+      "id": "mock-list-products-1h",
+      "kind": "mock",
+      "command": "list-products",
+      "host_count": 1,
+      "repa": [],
+      "repeated_urls": false,
+      "slow_host": false,
+      "output_format": "text",
+      "expect": {
+        "exit_code": 0,
+        "command_count": 0,
+        "probe_count": 0,
+        "peak_operations_max": 1,
+        "host_order": [
+          "h1"
+        ],
+        "stdout_digest": "fnv1a64:aed4be552ba28267"
+      }
+    },
+    {
+      "id": "mock-list-products-20h-json",
+      "kind": "mock",
+      "command": "list-products",
+      "host_count": 20,
+      "repa": [],
+      "repeated_urls": false,
+      "slow_host": false,
+      "output_format": "json",
+      "expect": {
+        "exit_code": 0,
+        "command_count": 0,
+        "probe_count": 0,
+        "peak_operations_max": 20,
+        "host_order": [],
+        "stdout_digest": "fnv1a64:2c96a1505b9714c1"
+      }
+    },
+    {
+      "id": "mock-list-products-100h",
+      "kind": "mock",
+      "command": "list-products",
+      "host_count": 100,
+      "repa": [],
+      "repeated_urls": false,
+      "slow_host": false,
+      "output_format": "text",
+      "expect": {
+        "exit_code": 0,
+        "command_count": 0,
+        "probe_count": 0,
+        "peak_operations_max": 100,
+        "host_order": [],
+        "stdout_digest": "fnv1a64:d8687c62ab369b7a"
+      }
+    },
+    {
+      "id": "ssh-list-products-1h",
+      "kind": "ssh",
+      "command": "list-products",
+      "host_count": 1,
+      "output_format": "text",
+      "debug": false,
+      "known_hosts_state": "prepopulated",
+      "host_key_policy": "yes",
+      "expect": {
+        "exit_code": 0,
+        "stdout_contains": [
+          "Base product: SLES-16.0-x86_64",
+          "Addon: qa"
+        ]
+      }
+    },
+    {
+      "id": "ssh-list-products-1h-json-debug",
+      "kind": "ssh",
+      "command": "list-products",
+      "host_count": 1,
+      "output_format": "json",
+      "debug": true,
+      "known_hosts_state": "prepopulated",
+      "host_key_policy": "yes",
+      "expect": {
+        "exit_code": 0,
+        "stdout_contains": [
+          "\"event\": \"product\""
+        ]
+      }
+    },
+    {
+      "id": "ssh-dry-clear-1h",
+      "kind": "ssh",
+      "command": "clear",
+      "host_count": 1,
+      "dry": true,
+      "output_format": "text",
+      "debug": false,
+      "known_hosts_state": "prepopulated",
+      "host_key_policy": "yes",
+      "expect": {
+        "exit_code": 0,
+        "stdout_contains": [
+          "zypper -n rr"
+        ]
+      }
+    },
+    {
+      "id": "ssh-first-contact-accept-new-1h",
+      "kind": "ssh",
+      "command": "list-products",
+      "host_count": 1,
+      "output_format": "text",
+      "debug": false,
+      "known_hosts_state": "empty",
+      "host_key_policy": "accept-new",
+      "expect": {
+        "exit_code": 0,
+        "stdout_contains": [
+          "Base product: SLES-16.0-x86_64"
+        ]
+      }
+    }
+  ]
+}

--- a/typos.toml
+++ b/typos.toml
@@ -11,6 +11,16 @@ extend-exclude = [
   # source that produces them is still spell-checked.
   "crates/repose-cli/completions/**",
   "crates/repose-cli/man/**",
+  # Captured performance reports/manifests and comparator fixtures: content
+  # hash digests, mangled symbol names, and timing data, not prose (e.g.
+  # digest "...ba28267" false-positives as the word "ba"). workloads.json
+  # embeds reviewed digests for the same reason.
+  # tests/performance/README.md, opportunity-matrix.md, and thresholds.json
+  # stay spell-checked — they're authored prose.
+  "tests/performance/workloads.json",
+  "tests/performance/baselines/**",
+  "tests/performance/profiles/**",
+  "tests/performance/comparator-fixtures/**",
 ]
 
 [default.extend-words]


### PR DESCRIPTION
## Why

repose's dominant costs are remote SSH/SFTP, HTTP probes, and `zypper` processes rather than local computation, but there was no representative release benchmark, no CPU/allocation/I/O profiling, and no way to prove a future optimization actually helped (or catch a regression later). This PR adds that evidence and tooling so performance work can ship with before/after proof instead of "faster in theory."

## What's in this PR

- **Deterministic mock metrics** (`crates/repose-core/src/mock.rs`): opt-in `MockMetrics`/`MockMetricsSnapshot` (exact operation/command/probe counts, current/peak concurrency), a deterministic `MockGate`, a counting `MetricProbe`, and `MockHostGroup` switched to concurrent `join_all` fan-out matching the real `RusshHostGroup`. New tests prove serial-peak-1, gated-overlap, and failure paths leave zero in-flight guards.
- **Representative workloads & baseline report** (`tests/performance/`): a reviewed 1/20/100-host workload matrix (`add`/`install`/`list-products`, repeated URLs, a slow host, text/JSON output, SSH-fixture scenarios), a versioned report contract + `jq` validator, and `scripts/run-performance-baseline.sh` which builds release, runs every workload, and writes a committed compact summary (`tests/performance/baselines/local-dev.json`) only after checking every observed result against its reviewed expectation.
- **Fleet-scale Criterion benchmark** (`crates/repose-core/benches/`): a `fleet` bench sharing scenario builders with the baseline harness; every scenario asserts exit code/counts/leaked concurrency before a sample is recorded.
- **Cross-platform release profiling** (`scripts/profile-performance.sh`, `tests/performance/opportunity-matrix.md`): macOS `sample`/`heap`/`fs_usage` and Linux `perf`/`heaptrack`/`strace` adapters, actually run on this workload and surfacing a real, evidence-backed hotspot (`shell::quote` allocates even on its already-safe fast path).
- **Regression comparator** (`scripts/compare-performance.sh`): exact-match guardrails for command/probe counts, digests, and exit codes; a concurrency ceiling check; and variance-derived latency/RSS tolerances calibrated from repeated real runs (not invented). Proven against 6 fixture scenarios plus a real injected-slowdown end-to-end guardrail (not just a static fixture).

## Verification

- `make check` passes (fmt, clippy `-D warnings` incl. `gen` feature, all 190 workspace tests, `cargo deny check`, layering script, CLI self-check).
- `cargo bench -p repose-core --bench fleet --locked -- --test` — every benchmark ID runs its equivalence assertions.
- `make perf-compare-test` — all 6 comparator fixtures plus the real end-to-end slowdown guardrail pass.
- `scripts/run-performance-baseline.sh --skip-ssh` — produces contract-valid reports for all 12 mock-kind workloads (SSH-kind workloads require Docker, not available in the environment this was authored in; the script skips them with a clear message rather than a false pass).

## Scope note

This adds benchmarking/profiling/regression-detection infrastructure only — no production command behavior changed. `crates/repose-core/src/mock.rs`, `benches/`, and `examples/` are the only non-tooling/doc changes, and they're test-infrastructure/dev-only (Criterion + `tokio` `time` feature are dev-dependencies). Follow-up work (bounding host/probe concurrency, removing redundant remote work such as unused reads and per-repo refreshes) is deliberately out of scope for this PR and will land as separate, focused changes with their own before/after measurements.