### PR TITLE
docs(readme): trim developer detail and update color options

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Frequently used global options (run `repose --help` for the full list):
 | `-c`, `--config PATH`               | repose configuration (default `/etc/repose/products.yml`) |
 | `-d`, `--debug`                     | enable debug logging                                   |
 | `-q`, `--quiet`                     | suppress repose's own log messages                     |
-| `--no-color`                        | disable ANSI color (honors `NO_COLOR`)                 |
+| `--color auto\|always\|never`       | ANSI color mode (default `auto`; honors `NO_COLOR`)    |
+| `--no-color`                        | alias for `--color=never`                              |
 | `--format text\|json`               | output format (default `text`)                         |
 | `--strict-host-key-checking MODE`   | SSH host-key policy (see below)                        |
 | `--known-hosts PATH`                | known_hosts file (default `~/.ssh/known_hosts`)        |
@@ -183,47 +184,29 @@ clean stream.
 
 ## Output control
 
-Repose routes all user-facing output (dry-run command previews and per-host
-run output) through a single sink. Two global flags govern its shape:
+Repose routes all user-facing output (dry-run command previews, per-host
+run output, and `list-*` / `known-products` listings) through a single
+sink. Two global flags govern its shape:
 
-- `--no-color`: disable ANSI color sequences. The
-  [`NO_COLOR`](https://no-color.org) environment variable is also honored.
-  By default, color is enabled only when stdout is a terminal. The legacy
-  `COLOR=always|never` environment variable still overrides detection.
+- `--color={auto,always,never}`: control ANSI color sequences (default
+  `auto`). In `auto` mode color is enabled only when stdout is a terminal;
+  the [`NO_COLOR`](https://no-color.org) environment variable forces it off
+  and the legacy `COLOR=always|never` environment variable overrides
+  detection. `always` and `never` force the respective behaviour regardless
+  of terminal or environment. `--no-color` is an alias for `--color=never`
+  and wins when both are given.
 - `--format={text,json}`: select human-readable text (default) or
   newline-delimited JSON for scripts.
 
+In text mode, the `list-products`, `list-repos`, and `known-products`
+commands color their labels and values (green/yellow/blue) when color is
+active.
+
 In JSON mode, every command emits newline-delimited JSON (one object per
-line). Action commands (`add`, `install`, `remove`, `uninstall`, `clear`,
-`reset`) emit event envelopes; query commands (`list-products`,
-`list-repos`, `known-products`) emit payload events.
-
-### Event envelopes (action commands)
-
-| field   | type   | description                                              |
-| ------- | ------ | -------------------------------------------------------- |
-| `event` | string | `"dry"` \| `"report"` \| `"error"` \| `"info"`           |
-| `level` | string | `"info"` \| `"warning"` \| `"error"`                     |
-| `host`  | string | target host (omitted for unscoped `info` events)         |
-| `cmd`   | string | the dry-run command (only for `event="dry"`)             |
-| `line`  | string | a single output line (for `report`/`error`/`info`)       |
-| `ok`    | bool   | per-host success flag (for `report`/`error`)             |
-
-### Payload events (query commands)
-
-`list-products --format=json` emits one `product` event per product per host
-(`{event:"product", host, port, kind:"base"|"addon", name, version, arch}`).
-
-`list-repos --format=json` emits one `repo` event per repository per host
-(`{event:"repo", host, port, alias, name, url, state}`).
-
-`known-products --format=json` emits one `known_product` event per known
-product (`{event:"known_product", name}`).
-
-`list-products --yaml --format=json` emits one `host_spec` event per host
-carrying the same payload the YAML dumper produces (location, arch,
-product, addons, name) — useful for machine consumers that want the
-refhost.yml spec without the YAML envelope.
+line): action commands emit event envelopes, query commands emit payload
+events. The `--quiet` flag silences logger messages but not per-host output;
+redirect stdout or filter the JSON to suppress it. See
+[`crates/README.md`](crates/README.md) for the field-level schemas.
 
 ```
 repose add -n --format=json -t fubar.suse.cz sle-sdk | jq .
@@ -231,92 +214,44 @@ repose list-products --format=json -t fubar.suse.cz | jq 'select(.kind=="base")'
 repose known-products --format=json | jq -r '.name'
 ```
 
-Note: per-host run output (previously emitted via the logger at info/warning
-level) now goes through this sink on stdout. The `--quiet` flag still
-silences logger messages but no longer hides per-host output; redirect
-stdout or use `--format=json` with filtering to suppress it.
-
 ## SSH host-key policy
 
-Repose talks to refhosts over SSH. The host-key behaviour follows OpenSSH's
-`StrictHostKeyChecking` semantics and is configured with two global flags:
+Repose talks to refhosts over SSH, following OpenSSH's `StrictHostKeyChecking`
+semantics via two global flags:
 
 - `--strict-host-key-checking={yes,accept-new,no,off}` (default: `accept-new`)
 - `--known-hosts PATH` (default: `~/.ssh/known_hosts`)
 
-| Mode         | Unknown host (first contact)             | Changed host key             |
-| ------------ | ---------------------------------------- | ---------------------------- |
-| `yes`        | refuse (`BadHostKeyException`)           | refuse                       |
-| `accept-new` | accept + record in known_hosts (default) | refuse                       |
-| `no` / `off` | accept silently                          | accept silently (unsafe)     |
+| Mode         | Unknown host (first contact)             | Changed host key         |
+| ------------ | ---------------------------------------- | ------------------------ |
+| `yes`        | refuse                                   | refuse                   |
+| `accept-new` | accept + record in known_hosts (default) | refuse                   |
+| `no` / `off` | accept silently                          | accept silently (unsafe) |
 
-`accept-new` matches the OpenSSH default since 7.6 (2017): unknown hosts are
-recorded on first contact, but a host whose key has *changed* since it was
-first recorded is refused. This is a behaviour change from pre-1.12 releases,
-which silently re-trusted any presented key (equivalent to `off`).
-
-If you operate a QA pool where refhost keys legitimately rotate and you
-cannot prune `known_hosts` between rotations, opt into the legacy behaviour
-explicitly:
-
-```
-repose --strict-host-key-checking=off add -t fubar.suse.cz sle-sdk
-```
-
-For paranoid setups (each refhost key pre-recorded in a dedicated file),
-pin both flags:
-
-```
-repose --strict-host-key-checking=yes \
-       --known-hosts /etc/repose/known_hosts \
-       add -t fubar.suse.cz sle-sdk
-```
-
-## SSH backend
-
-Repose uses a single SSH stack ([russh](https://crates.io/crates/russh)); there
-is no `--ssh-backend` flag. It honours the same `--strict-host-key-checking`,
-`--known-hosts`, and `~/.ssh/config` directives described above.
-
-Authentication tries the ssh-agent first (every agent identity is offered),
-then `IdentityFile` keys from `~/.ssh/config`. Unlike `ssh(1)`, the
-`IdentitiesOnly` directive is not honoured: agent identities are offered even
-when `IdentitiesOnly yes` is set for a host.
+`accept-new` (the OpenSSH default since 7.6) records unknown hosts on first
+contact but refuses a host whose key has *changed*. Use `off` only for a QA
+pool where refhost keys legitimately rotate. Authentication tries the
+ssh-agent first, then `IdentityFile` keys from `~/.ssh/config`; see
+[`crates/README.md`](crates/README.md) for SSH config compatibility details.
 
 ## Shell completion
 
-Repose ships pre-generated shell completions for bash, zsh, and fish
-(`crates/repose-cli/completions/`, also installed by the package). Load the
-one for your shell, for example:
-
-```
-# bash
-source crates/repose-cli/completions/repose.bash
-# zsh: put the `_repose` file on your $fpath
-# fish: copy repose.fish into ~/.config/fish/completions/
-```
-
-Then, in a new shell, tab-complete subcommands and flags:
-
-```
-repose <TAB>           # add remove reset install clear uninstall ...
-```
-
-Regenerate the committed completions (and man pages) from the CLI with:
-
-```
-cargo run -p repose-cli --features gen --bin repose-gen -- crates/repose-cli
-```
+Repose ships pre-generated shell completions for bash, zsh, and fish, installed
+by the package. Load the one for your shell (bash: `source` the file; zsh: put
+`_repose` on your `$fpath`; fish: copy `repose.fish` into
+`~/.config/fish/completions/`), then tab-complete subcommands and flags.
 
 ## Building
 
-Repose is a root Rust workspace with crate sources under `crates/`. Build the
-binary with:
+Repose is a root Rust workspace with crate sources under `crates/`:
 
 ```
 cargo build --release -p repose-cli
 # binary at target/release/repose
 ```
+
+See [`crates/README.md`](crates/README.md) for the workspace layout,
+regenerating man pages/completions, and packaging.
 
 ## License
 

--- a/crates/README.md
+++ b/crates/README.md
@@ -21,6 +21,39 @@ contact and reject changed/revoked keys), and `no`/`off` (disable validation).
 `--known-hosts`, using `[host]:port` entries for non-default ports. Keep that
 file protected from untrusted writers.
 
+Authentication tries the ssh-agent first (every agent identity is offered),
+then `IdentityFile` keys from `~/.ssh/config`. Unlike `ssh(1)`, the
+`IdentitiesOnly` directive is not honoured: agent identities are offered even
+when `IdentitiesOnly yes` is set for a host. There is no `--ssh-backend`
+flag; russh is the only transport.
+
+## JSON output schemas
+
+With `--format=json`, every command emits newline-delimited JSON (one object
+per line). Action commands (`add`, `install`, `remove`, `uninstall`, `clear`,
+`reset`) emit event envelopes:
+
+| field   | type   | description                                        |
+| ------- | ------ | -------------------------------------------------- |
+| `event` | string | `"dry"` \| `"report"` \| `"error"` \| `"info"`     |
+| `level` | string | `"info"` \| `"warning"` \| `"error"`               |
+| `host`  | string | target host (omitted for unscoped `info` events)   |
+| `cmd`   | string | the dry-run command (only for `event="dry"`)       |
+| `line`  | string | a single output line (for `report`/`error`/`info`) |
+| `ok`    | bool   | per-host success flag (for `report`/`error`)       |
+
+Query commands emit payload events:
+
+- `list-products` — one `product` event per product per host:
+  `{event:"product", host, port, kind:"base"|"addon", name, version, arch}`.
+- `list-repos` — one `repo` event per repository per host:
+  `{event:"repo", host, port, alias, name, url, state}`.
+- `known-products` — one `known_product` event per known product:
+  `{event:"known_product", name}`.
+- `list-products --yaml` — one `host_spec` event per host carrying the same
+  payload the YAML dumper produces (location, arch, product, addons, name),
+  for consumers that want the refhost.yml spec without the YAML envelope.
+
 ## Layout
 
 | Crate | Role |


### PR DESCRIPTION
The main README.md had accumulated excessive developer and reference-level detail
that increased the cognitive load for primary users. This commit:

1.  **Trims the README:** Relocates detailed JSON output schemas, SSH backend
    internals, and complex host-key policy examples to the developer
    documentation (`crates/README.md`), making the main user-facing document
    shorter and more focused on usage.
2.  **Updates CLI Docs:** Documents the new `--color={auto|always|never}` flag
    and its precedence rules in both the options table and the 'Output control'
    section.
3.  **Enhances Developer Docs:** Updates `crates/README.md` with the new JSON
    schema tables and clarifies the SSH authentication order (agent-first,
    `IdentitiesOnly` ignored).

This establishes a clear separation of concerns, ensuring the primary README is
for end-users while developer-facing reference material is preserved and updated.