### PR TITLE
chore(hawk): remove dead code and tighten visibility via cargo-hawk audit

### DIFF
--- a/crates/repose-core/src/commands/mod.rs
+++ b/crates/repose-core/src/commands/mod.rs
@@ -87,7 +87,7 @@ pub(crate) struct SharedConsole<'a, W: Write> {
 }
 
 impl<'a, W: Write> SharedConsole<'a, W> {
-    pub(crate) const fn new(console: &'a mut Console<W>) -> Self {
+    const fn new(console: &'a mut Console<W>) -> Self {
         Self {
             inner: Mutex::new(console),
         }
@@ -97,24 +97,24 @@ impl<'a, W: Write> SharedConsole<'a, W> {
     ///
     /// A poisoned lock only means a sibling host future panicked mid-write;
     /// keep reporting from the remaining hosts.
-    pub(crate) fn with<R>(&self, f: impl FnOnce(&mut Console<W>) -> R) -> R {
+    fn with<R>(&self, f: impl FnOnce(&mut Console<W>) -> R) -> R {
         let mut guard = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
         f(&mut guard)
     }
 
-    pub(crate) fn dry(&self, host: &str, cmd: &str) {
+    fn dry(&self, host: &str, cmd: &str) {
         self.with(|c| {
             let _ = c.dry(host, cmd);
         });
     }
 
-    pub(crate) fn error(&self, host: &str, msg: &str) {
+    fn error(&self, host: &str, msg: &str) {
         self.with(|c| {
             let _ = c.error(host, msg);
         });
     }
 
-    pub(crate) fn info(&self, msg: &str) {
+    fn info(&self, msg: &str) {
         self.with(|c| {
             let _ = c.info(msg);
         });
@@ -131,7 +131,7 @@ impl<'a, W: Write> SharedConsole<'a, W> {
 /// - any other exit: both streams at error level, failure — some diagnostics
 ///   (e.g. "repository already exists") go to stdout, so reporting stderr
 ///   alone would leave a non-zero exit unexplained.
-pub(crate) fn report_target<W: Write>(host: &dyn Host, console: &mut Console<W>) -> bool {
+fn report_target<W: Write>(host: &dyn Host, console: &mut Console<W>) -> bool {
     let Some((_, stdout, stderr, exitcode, _)) = host.out().last() else {
         return false;
     };
@@ -179,7 +179,7 @@ pub(crate) async fn run_reported_shared<W: Write>(
 /// Serial-console convenience wrapper around [`run_reported_shared`], kept
 /// for unit tests that drive a single host with a plain `&mut Console`.
 #[cfg(test)]
-pub(crate) async fn run_reported<W: Write>(
+async fn run_reported<W: Write>(
     host: &mut dyn Host,
     command: &str,
     console: &mut Console<W>,
@@ -261,7 +261,7 @@ pub(crate) async fn reboot_and_verify_shared<W: Write>(
 /// Serial-console convenience wrapper around [`reboot_and_verify_shared`],
 /// kept for unit tests that drive a single host with a plain `&mut Console`.
 #[cfg(test)]
-pub(crate) async fn reboot_and_verify<W: Write>(
+async fn reboot_and_verify<W: Write>(
     host: &mut dyn Host,
     products: &[String],
     present: bool,
@@ -279,7 +279,7 @@ pub(crate) async fn reboot_and_verify<W: Write>(
 }
 
 /// Aggregate per-host bool results (Python `_aggregate`).
-pub fn aggregate(results: impl IntoIterator<Item = bool>) -> ExitCode {
+pub(crate) fn aggregate(results: impl IntoIterator<Item = bool>) -> ExitCode {
     ExitCode::aggregate(results)
 }
 
@@ -295,7 +295,7 @@ pub(crate) struct ProbeBudget(Arc<Semaphore>);
 
 impl ProbeBudget {
     #[must_use]
-    pub(crate) fn new(limit: NonZeroUsize) -> Self {
+    fn new(limit: NonZeroUsize) -> Self {
         Self(Arc::new(Semaphore::new(limit.get())))
     }
 }
@@ -576,14 +576,14 @@ pub(crate) mod seq {
     /// One expected command-sequence scenario for a mutation command.
     #[derive(Debug, Deserialize)]
     pub(crate) struct SeqCase {
-        pub name: String,
-        pub exit: String,
+        name: String,
+        exit: String,
         /// Remote commands issued in order (live path); empty for dry/abort.
         #[serde(default)]
-        pub ran: Vec<String>,
+        pub(crate) ran: Vec<String>,
         /// Dry-run preview lines in order; empty for live/abort.
         #[serde(default)]
-        pub dry: Vec<String>,
+        dry: Vec<String>,
     }
 
     impl SeqCase {

--- a/crates/repose-core/src/config.rs
+++ b/crates/repose-core/src/config.rs
@@ -47,28 +47,6 @@ pub enum HostKeyPolicy {
     Off,
 }
 
-impl HostKeyPolicy {
-    pub fn parse(s: &str) -> Option<Self> {
-        match s {
-            "yes" => Some(Self::Yes),
-            "accept-new" => Some(Self::AcceptNew),
-            "no" => Some(Self::No),
-            "off" => Some(Self::Off),
-            _ => None,
-        }
-    }
-
-    #[must_use]
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Yes => "yes",
-            Self::AcceptNew => "accept-new",
-            Self::No => "no",
-            Self::Off => "off",
-        }
-    }
-}
-
 /// Immutable connection settings shared by all hosts.
 ///
 /// **No `ssh_backend` field** — Rust has a single SSH stack (russh).

--- a/crates/repose-core/src/console.rs
+++ b/crates/repose-core/src/console.rs
@@ -28,7 +28,7 @@ pub enum Level {
 
 impl Level {
     #[must_use]
-    pub const fn as_str(self) -> &'static str {
+    const fn as_str(self) -> &'static str {
         match self {
             Self::Info => "info",
             Self::Warning => "warning",
@@ -52,7 +52,7 @@ impl Write for Buffer {
 }
 
 pub struct Console<W: Write> {
-    pub stream: W,
+    stream: W,
     pub format: OutputFormat,
     pub color: ColorMode,
     /// When `ColorMode::Auto`, honour this (tests inject false).
@@ -90,11 +90,17 @@ impl<W: Write> Console<W> {
         }
     }
 
-    pub fn dry(&mut self, host: &str, cmd: &str) -> io::Result<()> {
+    pub(crate) fn dry(&mut self, host: &str, cmd: &str) -> io::Result<()> {
         self.emit("dry", Level::Info, json!({"host": host, "cmd": cmd}))
     }
 
-    pub fn report(&mut self, host: &str, line: &str, ok: bool, level: Level) -> io::Result<()> {
+    pub(crate) fn report(
+        &mut self,
+        host: &str,
+        line: &str,
+        ok: bool,
+        level: Level,
+    ) -> io::Result<()> {
         self.emit(
             "report",
             level,
@@ -102,7 +108,7 @@ impl<W: Write> Console<W> {
         )
     }
 
-    pub fn error(&mut self, host: &str, msg: &str) -> io::Result<()> {
+    pub(crate) fn error(&mut self, host: &str, msg: &str) -> io::Result<()> {
         self.emit(
             "error",
             Level::Error,
@@ -110,7 +116,7 @@ impl<W: Write> Console<W> {
         )
     }
 
-    pub fn info(&mut self, msg: &str) -> io::Result<()> {
+    pub(crate) fn info(&mut self, msg: &str) -> io::Result<()> {
         self.emit("info", Level::Info, json!({"line": msg}))
     }
 

--- a/crates/repose-core/src/display.rs
+++ b/crates/repose-core/src/display.rs
@@ -268,7 +268,7 @@ fn version_json(v: &Value) -> String {
 /// order event, host, location, arch, product, addons, name, byte-matching
 /// `json.dumps` (default separators and `ensure_ascii`). The addon list order
 /// is sorted (see `sorted_addons`).
-pub fn list_products_yaml_json<W: Write>(
+pub(crate) fn list_products_yaml_json<W: Write>(
     out: &mut W,
     hostname: &str,
     system: &System,

--- a/crates/repose-core/src/error.rs
+++ b/crates/repose-core/src/error.rs
@@ -25,7 +25,7 @@ pub enum TimeoutPhase {
 
 impl TimeoutPhase {
     #[must_use]
-    pub const fn as_str(self) -> &'static str {
+    const fn as_str(self) -> &'static str {
         match self {
             Self::Connect => "connect",
             Self::Authentication => "authentication",
@@ -52,7 +52,7 @@ pub enum OutputStream {
 
 impl OutputStream {
     #[must_use]
-    pub const fn as_str(self) -> &'static str {
+    const fn as_str(self) -> &'static str {
         match self {
             Self::Stdout => "stdout",
             Self::Stderr => "stderr",

--- a/crates/repose-core/src/host_parse.rs
+++ b/crates/repose-core/src/host_parse.rs
@@ -3,9 +3,9 @@
 use thiserror::Error;
 
 /// Default SSH user (Python `ParseHosts`).
-pub const DEFAULT_USER: &str = "root";
+const DEFAULT_USER: &str = "root";
 /// Default SSH port.
-pub const DEFAULT_PORT: u16 = 22;
+const DEFAULT_PORT: u16 = 22;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HostSpec {

--- a/crates/repose-core/src/lib.rs
+++ b/crates/repose-core/src/lib.rs
@@ -16,10 +16,10 @@ pub mod product_parse;
 pub mod repa;
 pub mod repo_parse;
 pub mod repoq;
-pub mod shell;
+pub(crate) mod shell;
 pub mod template;
 pub mod traits;
-pub mod transform;
+pub(crate) mod transform;
 pub mod types;
 
 /// Crate version string (workspace version).
@@ -29,12 +29,8 @@ pub use config::{ConnectionConfig, HostKeyPolicy};
 pub use error::{OutputStream, SshError, TimeoutPhase};
 pub use host_parse::{HostParseError, HostSpec, parse_host};
 pub use repa::{Repa, RepaError};
-pub use shell::{join as shell_join, quote as shell_quote};
-pub use traits::{Host, HostGroup, Probe, SshSession, last_out_succeeded};
-pub use types::{
-    ExitCode, OutEntry, Product, Repositories, Repository, System, ZYPPER_SUCCESS_EXIT_CODES,
-    zypper_exit_ok,
-};
+pub use traits::{Host, HostGroup, Probe, SshSession};
+pub use types::{ExitCode, OutEntry, Product, Repositories, Repository, System};
 
 #[cfg(test)]
 mod tests {

--- a/crates/repose-core/src/mock.rs
+++ b/crates/repose-core/src/mock.rs
@@ -31,8 +31,9 @@ pub enum MockRunOutcome {
 }
 
 impl MockRunOutcome {
+    #[cfg(test)]
     #[must_use]
-    pub fn ok_stdout(stdout: impl Into<String>) -> Self {
+    pub(crate) fn ok_stdout(stdout: impl Into<String>) -> Self {
         Self::Complete {
             stdout: stdout.into(),
             stderr: String::new(),
@@ -42,7 +43,7 @@ impl MockRunOutcome {
     }
 
     #[must_use]
-    pub const fn exit(code: i32) -> Self {
+    const fn exit(code: i32) -> Self {
         Self::Complete {
             stdout: String::new(),
             stderr: String::new(),
@@ -52,14 +53,14 @@ impl MockRunOutcome {
     }
 }
 
-/// Cooperative rendezvous for concurrency tests: [`RunBarrier::enter`]
+/// Cooperative rendezvous for concurrency tests: `enter`
 /// completes only once `total` participants have entered.
 ///
 /// Under truly concurrent fan-out every participant reaches the barrier
 /// while the others are still inside it, so it releases immediately. Under
 /// serial per-host execution the first participant can never be joined by
 /// the second; it gives up after a bounded number of polls and sets
-/// [`RunBarrier::timed_out`], which tests assert against (no hang, no
+/// `timed_out`, which tests assert against (no hang, no
 /// wall-clock timing).
 #[derive(Debug)]
 pub struct RunBarrier {
@@ -69,8 +70,9 @@ pub struct RunBarrier {
 }
 
 impl RunBarrier {
+    #[cfg(test)]
     #[must_use]
-    pub fn new(total: usize) -> Arc<Self> {
+    pub(crate) fn new(total: usize) -> Arc<Self> {
         Arc::new(Self {
             total,
             entered: AtomicUsize::new(0),
@@ -79,7 +81,7 @@ impl RunBarrier {
     }
 
     /// Enter the barrier and cooperatively wait for the other participants.
-    pub async fn enter(&self) {
+    async fn enter(&self) {
         const MAX_SPINS: usize = 100_000;
         self.entered.fetch_add(1, Ordering::SeqCst);
         let mut spins = 0usize;
@@ -100,8 +102,9 @@ impl RunBarrier {
     }
 
     /// Whether any participant gave up waiting (i.e. execution was serial).
+    #[cfg(test)]
     #[must_use]
-    pub fn timed_out(&self) -> bool {
+    pub(crate) fn timed_out(&self) -> bool {
         self.timed_out.load(Ordering::SeqCst)
     }
 }
@@ -110,7 +113,7 @@ impl RunBarrier {
 ///
 /// Every [`Host`] method boundary maps to exactly one kind; `reboot`'s
 /// nested `run` call is counted separately under [`Self::Run`] (see
-/// [`MockMetricsSnapshot::operations_by_kind`]).
+/// `MockMetricsSnapshot::operations_by_kind`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum MockOpKind {
     Connect,
@@ -260,18 +263,18 @@ impl MockMetrics {
 /// Immutable snapshot of [`MockMetrics`] at the time it was taken.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MockMetricsSnapshot {
-    pub total_operations: usize,
+    total_operations: usize,
     pub current_operations: usize,
     pub peak_operations: usize,
-    pub operations_by_kind: BTreeMap<MockOpKind, usize>,
+    operations_by_kind: BTreeMap<MockOpKind, usize>,
     /// `Host::run` calls that passed the connected-state check.
-    pub commands_attempted: usize,
+    commands_attempted: usize,
     /// Commands that appended an `out` entry (excludes transport failures).
     pub commands_completed: usize,
     pub probe_total: usize,
     pub current_probes: usize,
-    pub peak_probes: usize,
-    pub probe_counts: BTreeMap<String, usize>,
+    peak_probes: usize,
+    probe_counts: BTreeMap<String, usize>,
 }
 
 /// RAII guard: decrements `current_operations` on drop (including early
@@ -320,7 +323,7 @@ pub struct MockHost {
     /// FIFO outcomes for successive `run` calls. Empty → default exit 0.
     run_queue: Vec<MockRunOutcome>,
     /// Commands observed by `run` (in order).
-    pub ran: Vec<String>,
+    pub(crate) ran: Vec<String>,
     connect_fail: bool,
     /// When set, `run` enters this barrier before executing (concurrency
     /// proof in fan-out tests).
@@ -347,44 +350,50 @@ impl MockHost {
         self
     }
 
+    #[cfg(test)]
     #[must_use]
-    pub fn with_raw_repos(mut self, repos: Vec<Repository>) -> Self {
+    pub(crate) fn with_raw_repos(mut self, repos: Vec<Repository>) -> Self {
         self.raw_repos = Some(repos);
         self
     }
 
+    #[cfg(test)]
     #[must_use]
-    pub fn with_repos(mut self, repos: Repositories) -> Self {
+    pub(crate) fn with_repos(mut self, repos: Repositories) -> Self {
         self.repos = Some(repos);
         self
     }
 
     /// System that `reboot` swaps into `products`, modelling the post-reboot
     /// product re-read that transactional install/uninstall verify against.
+    #[cfg(test)]
     #[must_use]
-    pub fn with_post_reboot_products(mut self, system: System) -> Self {
+    pub(crate) fn with_post_reboot_products(mut self, system: System) -> Self {
         self.post_reboot_products = Some(system);
         self
     }
 
     /// After `reboot`, clear `products` to `None` (post-reboot re-read
     /// succeeded but yielded no product state).
+    #[cfg(test)]
     #[must_use]
-    pub const fn with_post_reboot_no_products(mut self) -> Self {
+    pub(crate) const fn with_post_reboot_no_products(mut self) -> Self {
         self.post_reboot_clear_products = true;
         self
     }
 
     /// Make `read_products` fail (models a re-read failure after reboot).
+    #[cfg(test)]
     #[must_use]
-    pub const fn with_read_products_err(mut self) -> Self {
+    pub(crate) const fn with_read_products_err(mut self) -> Self {
         self.read_products_err = true;
         self
     }
 
     /// Enter `barrier` at the start of every `run` call (see [`RunBarrier`]).
+    #[cfg(test)]
     #[must_use]
-    pub fn with_run_barrier(mut self, barrier: Arc<RunBarrier>) -> Self {
+    pub(crate) fn with_run_barrier(mut self, barrier: Arc<RunBarrier>) -> Self {
         self.run_barrier = Some(barrier);
         self
     }
@@ -407,11 +416,13 @@ impl MockHost {
     }
 
     /// Queue scripted outcomes for the next `run` calls.
-    pub fn push_run(&mut self, outcome: MockRunOutcome) {
+    #[cfg(test)]
+    pub(crate) fn push_run(&mut self, outcome: MockRunOutcome) {
         self.run_queue.push(outcome);
     }
 
-    pub const fn fail_connect(&mut self) {
+    #[cfg(test)]
+    const fn fail_connect(&mut self) {
         self.connect_fail = true;
     }
 
@@ -626,7 +637,8 @@ impl MockHostGroup {
         self.hosts.insert(host.key().to_string(), host);
     }
 
-    pub fn get_mock_mut(&mut self, key: &str) -> Option<&mut MockHost> {
+    #[cfg(test)]
+    pub(crate) fn get_mock_mut(&mut self, key: &str) -> Option<&mut MockHost> {
         self.hosts.get_mut(key)
     }
 }
@@ -762,7 +774,7 @@ async fn close_one(host: &mut MockHost) {
 /// Probe that always returns the configured answer (tests).
 #[derive(Debug, Clone)]
 pub struct ConstProbe {
-    pub live: bool,
+    pub(crate) live: bool,
 }
 
 #[async_trait]
@@ -783,8 +795,9 @@ pub struct MapProbe {
 
 impl MapProbe {
     /// Mark the given exact URLs as dead (all others live).
+    #[cfg(test)]
     #[must_use]
-    pub fn dead(urls: impl IntoIterator<Item = impl Into<String>>) -> Self {
+    pub(crate) fn dead(urls: impl IntoIterator<Item = impl Into<String>>) -> Self {
         Self {
             dead_urls: urls.into_iter().map(Into::into).collect(),
         }
@@ -832,8 +845,9 @@ impl MetricProbe {
     }
 
     /// Override the outcome for one exact URL (input-independent lookup).
+    #[cfg(test)]
     #[must_use]
-    pub fn set(mut self, url: impl Into<String>, live: bool) -> Self {
+    fn set(mut self, url: impl Into<String>, live: bool) -> Self {
         self.overrides.insert(url.into(), live);
         self
     }

--- a/crates/repose-core/src/probe.rs
+++ b/crates/repose-core/src/probe.rs
@@ -21,7 +21,7 @@ pub struct HttpProbe {
 }
 
 impl HttpProbe {
-    pub fn new() -> Result<Self, reqwest::Error> {
+    fn new() -> Result<Self, reqwest::Error> {
         let client = Client::builder()
             .redirect(reqwest::redirect::Policy::limited(10))
             .build()?;
@@ -33,12 +33,12 @@ impl HttpProbe {
     /// Probe that treats every URL as dead. Fallback when the HTTP client
     /// cannot be built; also usable in tests.
     #[must_use]
-    pub const fn disabled() -> Self {
+    const fn disabled() -> Self {
         Self { client: None }
     }
 
     /// Probe one base URL with HEAD→GET fallback per suffix.
-    pub async fn check_url(&self, url: &str, timeout: Duration) -> bool {
+    async fn check_url(&self, url: &str, timeout: Duration) -> bool {
         let Some(client) = &self.client else {
             return false;
         };

--- a/crates/repose-core/src/product_parse.rs
+++ b/crates/repose-core/src/product_parse.rs
@@ -43,7 +43,7 @@ fn field_index(tag: &[u8]) -> Option<usize> {
 /// Like ElementTree's `.text`, a field's value is the concatenation of the
 /// character data — text, resolved entity/char references, CDATA — between
 /// its start tag and its first child element (comments do not interrupt it).
-pub fn parse_prod_xml(xml: &str, _filename: &str) -> Option<Product> {
+fn parse_prod_xml(xml: &str, _filename: &str) -> Option<Product> {
     let mut reader = Reader::from_str(xml);
     let mut buf = Vec::new();
     // Per-field committed `.text` (index shape from `field_index`). `Some("")`
@@ -157,7 +157,7 @@ pub fn parse_prod_xml(xml: &str, _filename: &str) -> Option<Product> {
 }
 
 /// Parse `/etc/os-release` body into (name, version, arch).
-pub fn parse_os_release(text: &str) -> (String, String, String) {
+fn parse_os_release(text: &str) -> (String, String, String) {
     let mut values = std::collections::BTreeMap::new();
     for raw_line in text.lines() {
         let line = raw_line.trim();

--- a/crates/repose-core/src/repa.rs
+++ b/crates/repose-core/src/repa.rs
@@ -5,12 +5,12 @@ use thiserror::Error;
 /// Parsed repository/product pattern from CLI REPA tokens.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Repa {
-    pub product: Option<String>,
-    pub version: Option<String>,
-    pub arch: Option<String>,
-    pub repo: Option<String>,
-    pub baseversion: Option<String>,
-    pub smallver: Option<String>,
+    pub(crate) product: Option<String>,
+    pub(crate) version: Option<String>,
+    pub(crate) arch: Option<String>,
+    pub(crate) repo: Option<String>,
+    pub(crate) baseversion: Option<String>,
+    smallver: Option<String>,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -49,7 +49,7 @@ impl Repa {
     }
 
     #[must_use]
-    pub fn from_parts(
+    pub(crate) fn from_parts(
         product: Option<String>,
         version: Option<String>,
         arch: Option<String>,

--- a/crates/repose-core/src/repoq.rs
+++ b/crates/repose-core/src/repoq.rs
@@ -9,9 +9,9 @@ use crate::types::{Product, System};
 /// One resolved repository (Python `Repos` NamedTuple).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Repos {
-    pub name: String,
-    pub url: String,
-    pub refresh: bool,
+    pub(crate) name: String,
+    pub(crate) url: String,
+    pub(crate) refresh: bool,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -23,21 +23,21 @@ pub enum RepoqError {
 /// Unsupported installed product when solving defaults for a host.
 #[derive(Debug, Error, PartialEq, Eq)]
 #[error("Unsupported product: {0}")]
-pub struct UnsupportedProductError(pub String);
+pub struct UnsupportedProductError(String);
 
 /// Repository template resolver.
-pub struct Repoq {
+pub(crate) struct Repoq {
     template: Value,
 }
 
 impl Repoq {
     #[must_use]
-    pub const fn new(template: Value) -> Self {
+    pub(crate) const fn new(template: Value) -> Self {
         Self { template }
     }
 
     /// Resolve repositories for a REPA against host base product.
-    pub fn solve_repa(
+    pub(crate) fn solve_repa(
         &self,
         orepa: &Repa,
         base: &Product,
@@ -169,7 +169,7 @@ impl Repoq {
     }
 
     /// Resolve default repos for each installed product (exact version keys only).
-    pub fn solve_product(
+    pub(crate) fn solve_product(
         &self,
         products: &System,
     ) -> Result<std::collections::BTreeMap<String, Vec<Repos>>, UnsupportedProductError> {

--- a/crates/repose-core/src/shell.rs
+++ b/crates/repose-core/src/shell.rs
@@ -11,7 +11,7 @@ const fn is_safe_char(c: char) -> bool {
 
 /// Quote `s` for a POSIX shell, matching Python `shlex.quote`.
 #[must_use]
-pub fn quote(s: &str) -> String {
+fn quote(s: &str) -> String {
     if s.is_empty() {
         return "''".to_string();
     }
@@ -33,7 +33,7 @@ pub fn quote(s: &str) -> String {
 
 /// Join arguments with spaces after quoting each (Python `shlex.join`).
 #[must_use]
-pub fn join(parts: impl IntoIterator<Item = impl AsRef<str>>) -> String {
+pub(crate) fn join(parts: impl IntoIterator<Item = impl AsRef<str>>) -> String {
     parts
         .into_iter()
         .map(|p| quote(p.as_ref()))
@@ -42,32 +42,32 @@ pub fn join(parts: impl IntoIterator<Item = impl AsRef<str>>) -> String {
 }
 
 /// Remote command templates (Python `Command` class attributes).
-pub mod cmd {
+pub(crate) mod cmd {
     use super::join;
 
     /// `zypper -n ar {params} {name} {url} {name}` with shell-quoted interpolations.
     #[must_use]
-    pub fn zypper_ar(refresh: bool, name: &str, url: &str) -> String {
+    pub(crate) fn zypper_ar(refresh: bool, name: &str, url: &str) -> String {
         let params = if refresh { "-cfkn" } else { "-ckn" };
         join(["zypper", "-n", "ar", params, name, url, name])
     }
 
     #[must_use]
-    pub fn zypper_rr(aliases: &[&str]) -> String {
+    pub(crate) fn zypper_rr(aliases: &[&str]) -> String {
         let mut parts: Vec<&str> = vec!["zypper", "-n", "rr"];
         parts.extend_from_slice(aliases);
         join(parts)
     }
 
     #[must_use]
-    pub fn zypper_in_products(products: &[&str]) -> String {
+    pub(crate) fn zypper_in_products(products: &[&str]) -> String {
         let mut parts: Vec<&str> = vec!["zypper", "-n", "in", "-t", "product", "-l", "-f"];
         parts.extend_from_slice(products);
         join(parts)
     }
 
     #[must_use]
-    pub fn transactional_in_products(products: &[&str]) -> String {
+    pub(crate) fn transactional_in_products(products: &[&str]) -> String {
         let mut parts: Vec<&str> = vec![
             "transactional-update",
             "-n",
@@ -83,14 +83,14 @@ pub mod cmd {
     }
 
     #[must_use]
-    pub fn zypper_rm_products(products: &[&str]) -> String {
+    pub(crate) fn zypper_rm_products(products: &[&str]) -> String {
         let mut parts: Vec<&str> = vec!["zypper", "-n", "rm", "-t", "product"];
         parts.extend_from_slice(products);
         join(parts)
     }
 
     #[must_use]
-    pub fn transactional_rm_products(products: &[&str]) -> String {
+    pub(crate) fn transactional_rm_products(products: &[&str]) -> String {
         let mut parts: Vec<&str> = vec![
             "transactional-update",
             "-n",
@@ -105,9 +105,10 @@ pub mod cmd {
         join(parts)
     }
 
-    pub const REFCMD: &str = "zypper -n --gpg-auto-import-keys ref -f";
-    pub const REFTCMD: &str = "transactional-update -n run zypper -n --gpg-auto-import-keys ref -f";
-    pub const REBOOT: &str = "systemctl reboot";
+    pub(crate) const REFCMD: &str = "zypper -n --gpg-auto-import-keys ref -f";
+    pub(crate) const REFTCMD: &str =
+        "transactional-update -n run zypper -n --gpg-auto-import-keys ref -f";
+    pub(crate) const REBOOT: &str = "systemctl reboot";
 }
 
 #[cfg(test)]

--- a/crates/repose-core/src/template.rs
+++ b/crates/repose-core/src/template.rs
@@ -43,7 +43,7 @@ pub enum TemplateError {
 /// itself carries `<<: *a`) merges are fully flattened. `serde_yaml`'s own
 /// [`serde_yaml::Value::apply_merge`] leaves a residual `<<` key on chained
 /// merges, so it is not sufficient here.
-pub fn load_template(path: &Path) -> Result<Value, TemplateError> {
+pub(crate) fn load_template(path: &Path) -> Result<Value, TemplateError> {
     let path_s = path.display().to_string();
     let text = fs::read_to_string(path).map_err(|source| TemplateError::Io {
         path: path_s.clone(),

--- a/crates/repose-core/src/traits.rs
+++ b/crates/repose-core/src/traits.rs
@@ -157,8 +157,9 @@ pub trait Probe: Send + Sync {
 /// Classify last `out` entry like Python `_report_target` (success codes only).
 ///
 /// Returns `None` if `out` is empty (caller should treat as failure / bug).
+#[cfg(test)]
 #[must_use]
-pub fn last_out_succeeded(out: &[OutEntry]) -> Option<bool> {
+pub(crate) fn last_out_succeeded(out: &[OutEntry]) -> Option<bool> {
     let entry = out.last()?;
     Some(crate::types::zypper_exit_ok(entry.3))
 }

--- a/crates/repose-core/src/transform.rs
+++ b/crates/repose-core/src/transform.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 ///
 /// Mirrors Python `repose.types.refhost.transformations.transform_version_partialy`.
 #[must_use]
-pub fn transform_version_partialy(version: &str) -> Value {
+pub(crate) fn transform_version_partialy(version: &str) -> Value {
     let result = (|| {
         if version.contains('-') {
             let (major_str, minor_str) = version.split_once('-')?;

--- a/crates/repose-core/src/types.rs
+++ b/crates/repose-core/src/types.rs
@@ -23,7 +23,7 @@ pub struct System {
 
 impl System {
     #[must_use]
-    pub const fn is_transactional(&self) -> bool {
+    pub(crate) const fn is_transactional(&self) -> bool {
         self.transactional
     }
 
@@ -33,18 +33,18 @@ impl System {
     }
 
     #[must_use]
-    pub const fn get_base(&self) -> &Product {
+    pub(crate) const fn get_base(&self) -> &Product {
         &self.base
     }
 
     #[must_use]
-    pub fn get_addons(&self) -> &[Product] {
+    pub(crate) fn get_addons(&self) -> &[Product] {
         &self.addons
     }
 
     /// Base + addons (Python `System.flatten`).
     #[must_use]
-    pub fn flatten(&self) -> Vec<Product> {
+    pub(crate) fn flatten(&self) -> Vec<Product> {
         let mut v = Vec::with_capacity(1 + self.addons.len());
         v.push(self.base.clone());
         v.extend(self.addons.iter().cloned());
@@ -54,7 +54,7 @@ impl System {
 
 /// Parse zypper repo **name** `a:b:c:d` into a product (Python `Repositories`).
 #[must_use]
-pub fn product_from_repo_name(name: &str, host_arch: &str) -> Option<Product> {
+fn product_from_repo_name(name: &str, host_arch: &str) -> Option<Product> {
     let parts: Vec<&str> = name.split(':').collect();
     if parts.len() != 4 {
         return None;
@@ -80,10 +80,10 @@ pub fn repositories_from_raw(raw: &[Repository], host_arch: &str) -> Repositorie
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Repository {
     pub alias: String,
-    pub name: String,
-    pub url: String,
+    pub(crate) name: String,
+    pub(crate) url: String,
     /// `enabled` from zypper XML (`"1"` → true).
-    pub state: bool,
+    pub(crate) state: bool,
 }
 
 /// Alias → optional product parse (Python `Repositories`).
@@ -96,35 +96,20 @@ pub struct Repositories {
 
 impl Repositories {
     #[must_use]
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
-    pub fn insert(&mut self, alias: String, product: Option<Product>) {
+    pub(crate) fn insert(&mut self, alias: String, product: Option<Product>) {
         self.inner.insert(alias, product);
     }
 
-    #[must_use]
-    pub fn get(&self, alias: &str) -> Option<&Option<Product>> {
-        self.inner.get(alias)
-    }
-
-    pub fn keys(&self) -> impl Iterator<Item = &String> {
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &String> {
         self.inner.keys()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &Option<Product>)> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&String, &Option<Product>)> {
         self.inner.iter()
-    }
-
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.inner.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
     }
 }
 
@@ -151,7 +136,7 @@ impl ExitCode {
     ///
     /// Empty → Ok. All true → Ok. All false → AllFailed. Mixed → Partial.
     #[must_use]
-    pub fn aggregate(results: impl IntoIterator<Item = bool>) -> Self {
+    pub(crate) fn aggregate(results: impl IntoIterator<Item = bool>) -> Self {
         let mut total = 0usize;
         let mut failed = 0usize;
         for ok in results {
@@ -177,11 +162,11 @@ impl ExitCode {
 
 /// zypper exit codes treated as success by `_report_target`
 /// (`ZYPPER_SUCCESS_EXIT_CODES` in Python).
-pub const ZYPPER_SUCCESS_EXIT_CODES: &[i32] = &[0, 100, 101, 102, 103, 106, 107];
+const ZYPPER_SUCCESS_EXIT_CODES: &[i32] = &[0, 100, 101, 102, 103, 106, 107];
 
 /// Whether a zypper-style exit code is a successful host result.
 #[must_use]
-pub fn zypper_exit_ok(code: i32) -> bool {
+pub(crate) fn zypper_exit_ok(code: i32) -> bool {
     ZYPPER_SUCCESS_EXIT_CODES.contains(&code)
 }
 

--- a/crates/repose-ssh/src/host.rs
+++ b/crates/repose-ssh/src/host.rs
@@ -52,11 +52,6 @@ impl RusshHost {
             out: Vec::new(),
         }
     }
-
-    #[must_use]
-    pub fn key_str(&self) -> &str {
-        &self.key
-    }
 }
 
 #[async_trait]
@@ -332,14 +327,14 @@ pub struct RusshHostGroup {
 
 impl RusshHostGroup {
     #[must_use]
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self {
             hosts: BTreeMap::new(),
             host_operation_limit: ConnectionConfig::default().host_operation_limit,
         }
     }
 
-    pub fn insert(&mut self, host: RusshHost) {
+    fn insert(&mut self, host: RusshHost) {
         self.hosts.insert(host.key.clone(), host);
     }
 

--- a/crates/repose-ssh/src/lib.rs
+++ b/crates/repose-ssh/src/lib.rs
@@ -16,14 +16,16 @@ pub use repose_core::error::SshError;
 pub use repose_core::traits::{Host, HostGroup, Probe, SshSession};
 
 /// Confirms the workspace link to `repose-core` at compile time.
+#[cfg(test)]
 #[must_use]
-pub const fn core_version() -> &'static str {
+const fn core_version() -> &'static str {
     CORE_VERSION
 }
 
 /// Chosen single backend name.
+#[cfg(test)]
 #[must_use]
-pub const fn backend_name() -> &'static str {
+const fn backend_name() -> &'static str {
     "russh"
 }
 

--- a/hawk.toml
+++ b/hawk.toml
@@ -1,0 +1,9 @@
+[[production]]
+package = "repose-cli"
+bin = "repose"
+reason = "shipped application binary"
+
+[[production]]
+package = "repose-cli"
+bin = "repose-gen"
+reason = "dev/packaging asset generator binary"


### PR DESCRIPTION
## Summary

A `cargo-hawk` 0.1.9 audit against the two shipped binaries (`repose`, `repose-gen`) surfaced 107 findings: 6 provably dead public items with no callers anywhere in the workspace, plus ~101 items marked `pub` that are only ever reached from within their own crate.

## Changes

- `hawk.toml`: declare `repose-gen` as a second production target
- Delete 6 dead public items: `HostKeyPolicy::parse`/`as_str`, `Repositories::get`/`len`/`is_empty`, `RusshHost::key_str`
- Narrow ~101 `pub` declarations to `pub(crate)`/private via `cargo hawk --fix`, run to a fixpoint (visibility narrowing cascades and exposes further narrowing opportunities)
- Split compound `pub use` re-exports that mixed still-public and now-crate-only items, and drop re-exports that had no callers through any path
- Mark test-only helpers `#[cfg(test)]` where narrowing visibility turned them into rustc `dead_code` in non-test builds

## Verification

- `cargo fmt --check` passes
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `cargo test --workspace --all-targets --locked` passes
- `cargo hawk check --manifest-path Cargo.toml -D warnings` exits 0 (zero findings)
- `cargo deny check` passes
- No diff under `tests/vectors/` (behavior unchanged)