### PR TITLE
fix(core): report and count unreachable hosts and failed repo reads

### DIFF
--- a/crates/repose-core/src/commands/add.rs
+++ b/crates/repose-core/src/commands/add.rs
@@ -1,7 +1,7 @@
 //! `repose add` — resolve REPA, probe, zypper ar, cohort refresh.
 
 use crate::commands::{
-    CommandOptions, ProbeBudget, SharedConsole, aggregate, filter_live, load_repoq,
+    CommandOptions, ProbeBudget, SharedConsole, aggregate, filter_live, load_repoq, report_pruned,
     run_reported_shared,
 };
 use crate::console::Console;
@@ -20,7 +20,7 @@ pub async fn run_add<W: Write>(
     console: &mut Console<W>,
 ) -> Result<ExitCode, crate::template::TemplateError> {
     let repoq = load_repoq(&opts.config)?;
-    group.connect_and_prune().await;
+    let pruned = group.connect_and_prune().await;
     group.read_products().await;
 
     // Fan out per-host work concurrently (Python spawned one worker task per
@@ -38,7 +38,7 @@ pub async fn run_add<W: Write>(
     // replacing the old per-host `min(16, n)` local cap.
     let probe_budget = ProbeBudget::new(opts.probe_concurrency_limit);
     let console = SharedConsole::new(console);
-    let results = join_all(group.hosts_mut().into_iter().map(|host| {
+    let mut results = join_all(group.hosts_mut().into_iter().map(|host| {
         let semaphore = Arc::clone(&semaphore);
         let probe_budget = probe_budget.clone();
         let repoq = &repoq;
@@ -53,6 +53,7 @@ pub async fn run_add<W: Write>(
     }))
     .await;
 
+    report_pruned(&pruned, &mut results, &console);
     if !opts.dry {
         group.run_all(cmd::REFCMD).await;
     }
@@ -188,6 +189,34 @@ mod tests {
         assert!(
             buf.contains("h1 - Repository 'update' successfully added\n"),
             "live run must report stdout lines, got: {buf:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_reports_and_counts_pruned_hosts() {
+        let mut g = MockHostGroup::new();
+        let mut bad = MockHost::new("bad");
+        bad.fail_connect();
+        g.insert(bad);
+        g.insert(sles_host());
+        let opts = CommandOptions {
+            config: sample_config(),
+            repa: ["SLES:15-SP3:x86_64:update"]
+                .iter()
+                .map(|r| Repa::parse(r).unwrap())
+                .collect(),
+            no_probe: true,
+            ..Default::default()
+        };
+        let mut buf = Buffer::default();
+        let mut c = Console::new(&mut buf);
+        let probe = ConstProbe { live: true };
+        let code = run_add(&opts, &mut g, &probe, &mut c).await.unwrap();
+        assert_eq!(code, ExitCode::Partial);
+        assert!(
+            buf.0.contains("connect failed:") && buf.0.contains("bad"),
+            "pruned host must be reported, got: {:?}",
+            buf.0
         );
     }
 

--- a/crates/repose-core/src/commands/clear.rs
+++ b/crates/repose-core/src/commands/clear.rs
@@ -1,6 +1,6 @@
 //! `repose clear` — `zypper rr` every raw alias; never `_report_target`.
 
-use crate::commands::{CommandOptions, SharedConsole, aggregate};
+use crate::commands::{CommandOptions, SharedConsole, aggregate, report_pruned};
 use crate::console::Console;
 use crate::shell::cmd;
 use crate::traits::{Host, HostGroup};
@@ -15,7 +15,7 @@ pub async fn run_clear<W: Write>(
     group: &mut dyn HostGroup,
     console: &mut Console<W>,
 ) -> ExitCode {
-    group.connect_and_prune().await;
+    let pruned = group.connect_and_prune().await;
     group.read_repos().await;
 
     // Fan out per-host work concurrently (Python spawned one worker task per
@@ -26,7 +26,7 @@ pub async fn run_clear<W: Write>(
     let cap = group.host_operation_limit().get();
     let semaphore = Arc::new(Semaphore::new(cap));
     let console = SharedConsole::new(console);
-    let results = join_all(group.hosts_mut().into_iter().map(|host| {
+    let mut results = join_all(group.hosts_mut().into_iter().map(|host| {
         let semaphore = Arc::clone(&semaphore);
         let console = &console;
         async move {
@@ -39,6 +39,7 @@ pub async fn run_clear<W: Write>(
     }))
     .await;
 
+    report_pruned(&pruned, &mut results, &console);
     group.close().await;
     aggregate(results)
 }
@@ -48,10 +49,14 @@ async fn clear_one<W: Write>(
     host: &mut dyn Host,
     console: &SharedConsole<'_, W>,
 ) -> bool {
-    let mut aliases: Vec<String> = host
-        .raw_repos()
-        .map(|r| r.iter().map(|x| x.alias.clone()).collect())
-        .unwrap_or_default();
+    // A failed `zypper -x lr` leaves `raw_repos` as `None`: that is a host
+    // failure, not "zero repositories" — reporting a successful no-op would
+    // hide it.
+    let Some(raw) = host.raw_repos() else {
+        console.error(host.key(), "could not read repositories");
+        return false;
+    };
+    let mut aliases: Vec<String> = raw.iter().map(|x| x.alias.clone()).collect();
     if aliases.is_empty() {
         console.info(&format!("No repositories to clear from {}", host.key()));
         return true;
@@ -142,6 +147,62 @@ mod tests {
         let code = run_clear(&opts, &mut g, &mut c).await;
         assert_eq!(code, ExitCode::Ok);
         assert!(buf.0.contains("zypper") && buf.0.contains("rr"));
+    }
+
+    #[tokio::test]
+    async fn clear_reports_and_counts_pruned_hosts() {
+        let mut g = MockHostGroup::new();
+        let mut bad = MockHost::new("bad");
+        bad.fail_connect();
+        g.insert(bad);
+        let mut good = MockHost::new("good");
+        good.connect().await.unwrap();
+        g.insert(good.with_raw_repos(vec![Repository {
+            alias: "a".into(),
+            name: "n".into(),
+            url: "http://x".into(),
+            state: true,
+        }]));
+        let mut buf = Buffer::default();
+        let mut c = Console::new(&mut buf);
+        let code = run_clear(&CommandOptions::default(), &mut g, &mut c).await;
+        assert_eq!(code, ExitCode::Partial);
+        assert!(
+            buf.0.contains("connect failed:") && buf.0.contains("bad"),
+            "pruned host must be reported, got: {:?}",
+            buf.0
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_all_unreachable_is_all_failed() {
+        let mut g = MockHostGroup::new();
+        for key in ["bad1", "bad2"] {
+            let mut h = MockHost::new(key);
+            h.fail_connect();
+            g.insert(h);
+        }
+        let mut buf = Buffer::default();
+        let mut c = Console::new(&mut buf);
+        let code = run_clear(&CommandOptions::default(), &mut g, &mut c).await;
+        assert_eq!(code, ExitCode::AllFailed);
+        assert!(buf.0.contains("connect failed:"));
+    }
+
+    #[tokio::test]
+    async fn clear_failed_repo_read_fails_the_host() {
+        let mut g = MockHostGroup::new();
+        let mut h = MockHost::new("h1");
+        h.connect().await.unwrap();
+        g.insert(h.with_read_repos_err());
+        let mut buf = Buffer::default();
+        let mut c = Console::new(&mut buf);
+        let code = run_clear(&CommandOptions::default(), &mut g, &mut c).await;
+        assert_eq!(code, ExitCode::AllFailed);
+        assert!(buf.0.contains("could not read repositories"));
+        // No mutation may run after a failed read.
+        let ran = g.get_mock_mut("h1").unwrap().ran.clone();
+        assert!(!ran.iter().any(|c| c.contains(" rr")), "ran: {ran:?}");
     }
 
     /// P1 step 17: a configured host-operation limit below the host count

--- a/crates/repose-core/src/commands/install.rs
+++ b/crates/repose-core/src/commands/install.rs
@@ -2,7 +2,7 @@
 
 use crate::commands::{
     CommandOptions, ProbeBudget, SharedConsole, aggregate, filter_live, load_repoq,
-    reboot_and_verify_shared, run_reported_shared,
+    reboot_and_verify_shared, report_pruned, run_reported_shared,
 };
 use crate::console::Console;
 use crate::repoq::Repos;
@@ -49,7 +49,7 @@ pub async fn run_install<W: Write>(
     console: &mut Console<W>,
 ) -> Result<ExitCode, crate::template::TemplateError> {
     let repoq = load_repoq(&opts.config)?;
-    group.connect_and_prune().await;
+    let pruned = group.connect_and_prune().await;
     group.read_products().await;
     group.read_repos().await;
 
@@ -64,7 +64,7 @@ pub async fn run_install<W: Write>(
     // replacing the old per-host `min(16, n)` local cap.
     let probe_budget = ProbeBudget::new(opts.probe_concurrency_limit);
     let console = SharedConsole::new(console);
-    let results = join_all(group.hosts_mut().into_iter().map(|host| {
+    let mut results = join_all(group.hosts_mut().into_iter().map(|host| {
         let semaphore = Arc::clone(&semaphore);
         let probe_budget = probe_budget.clone();
         let repoq = &repoq;
@@ -78,6 +78,7 @@ pub async fn run_install<W: Write>(
         }
     }))
     .await;
+    report_pruned(&pruned, &mut results, &console);
     group.close().await;
     Ok(aggregate(results))
 }
@@ -226,6 +227,31 @@ mod tests {
             .map(|h| h.ran.clone())
             .unwrap_or_default();
         (code, ran, buf.0)
+    }
+
+    #[tokio::test]
+    async fn install_reports_and_counts_pruned_hosts() {
+        let mut g = MockHostGroup::new();
+        let mut bad = MockHost::new("bad");
+        bad.fail_connect();
+        g.insert(bad);
+        g.insert(MockHost::new("h1").with_products(system("SLES", false)));
+        let mut buf = Buffer::default();
+        let mut c = Console::new(&mut buf);
+        let code = run_install(
+            &opts(&["SLES:15-SP3:x86_64"], false, false),
+            &mut g,
+            &ConstProbe { live: true },
+            &mut c,
+        )
+        .await
+        .unwrap();
+        assert_eq!(code, ExitCode::Partial);
+        assert!(
+            buf.0.contains("connect failed:") && buf.0.contains("bad"),
+            "pruned host must be reported, got: {:?}",
+            buf.0
+        );
     }
 
     #[tokio::test]

--- a/crates/repose-core/src/commands/mod.rs
+++ b/crates/repose-core/src/commands/mod.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 use tokio::sync::Semaphore;
 
 use crate::console::{Console, Level, OutputFormat};
+use crate::error::SshError;
 use crate::probe::HttpProbe;
 use crate::repa::Repa;
 use crate::repoq::Repoq;
@@ -281,6 +282,21 @@ async fn reboot_and_verify<W: Write>(
 /// Aggregate per-host bool results (Python `_aggregate`).
 pub(crate) fn aggregate(results: impl IntoIterator<Item = bool>) -> ExitCode {
     ExitCode::aggregate(results)
+}
+
+/// Report the hosts dropped by `connect_and_prune` and append one `false`
+/// per pruned host to the exit aggregation. A connect failure must surface
+/// in both the output and the process exit status — otherwise a run where
+/// every target is unreachable exits `Ok` with no output at all.
+pub(crate) fn report_pruned<W: Write>(
+    pruned: &[(String, SshError)],
+    results: &mut Vec<bool>,
+    console: &SharedConsole<'_, W>,
+) {
+    for (key, err) in pruned {
+        console.error(key, &format!("connect failed: {err}"));
+    }
+    results.extend(std::iter::repeat_n(false, pruned.len()));
 }
 
 /// Fleet-wide URL-liveness probe concurrency budget (P1 steps 19–23),

--- a/crates/repose-core/src/commands/remove.rs
+++ b/crates/repose-core/src/commands/remove.rs
@@ -1,6 +1,8 @@
 //! `repose remove` — pattern match aliases, zypper rr.
 
-use crate::commands::{CommandOptions, SharedConsole, aggregate, run_reported_shared};
+use crate::commands::{
+    CommandOptions, SharedConsole, aggregate, report_pruned, run_reported_shared,
+};
 use crate::console::Console;
 use crate::repa::Repa;
 use crate::shell::cmd;
@@ -62,7 +64,7 @@ pub async fn run_remove<W: Write>(
     group: &mut dyn HostGroup,
     console: &mut Console<W>,
 ) -> ExitCode {
-    group.connect_and_prune().await;
+    let pruned = group.connect_and_prune().await;
     group.read_repos().await;
     group.parse_repos().await;
 
@@ -74,7 +76,7 @@ pub async fn run_remove<W: Write>(
     let cap = group.host_operation_limit().get();
     let semaphore = Arc::new(Semaphore::new(cap));
     let console = SharedConsole::new(console);
-    let results = join_all(group.hosts_mut().into_iter().map(|host| {
+    let mut results = join_all(group.hosts_mut().into_iter().map(|host| {
         let semaphore = Arc::clone(&semaphore);
         let console = &console;
         async move {
@@ -87,6 +89,7 @@ pub async fn run_remove<W: Write>(
     }))
     .await;
 
+    report_pruned(&pruned, &mut results, &console);
     group.close().await;
     aggregate(results)
 }
@@ -107,10 +110,14 @@ async fn remove_one<W: Write>(
         console.info(&format!("For {} no repos for remove found", host.key()));
         return true;
     }
-    let aliases = host
-        .repos()
-        .map(|r| r.keys().cloned().collect::<Vec<_>>())
-        .unwrap_or_default();
+    // A failed repo read leaves `repos` as `None`: matching zero aliases
+    // against it would silently skip the removal and count the host as
+    // successful.
+    let Some(repos) = host.repos() else {
+        console.error(host.key(), "could not read repositories");
+        return false;
+    };
+    let aliases = repos.keys().cloned().collect::<Vec<_>>();
     let repolist = calculate_repolist(aliases.into_iter(), &patterns);
     if repolist.is_empty() {
         console.info(&format!("For {} no repos for remove found", host.key()));
@@ -189,6 +196,59 @@ mod tests {
         );
         assert!(list.contains("SLES:15-SP3::update"));
         assert!(!list.contains("other"));
+    }
+
+    #[tokio::test]
+    async fn remove_reports_and_counts_pruned_hosts() {
+        let mut g = MockHostGroup::new();
+        let mut bad = MockHost::new("bad");
+        bad.fail_connect();
+        g.insert(bad);
+        g.insert(MockHost::new("h1").with_products(System {
+            base: Product {
+                name: "SLES".into(),
+                version: "15-SP3".into(),
+                arch: "x86_64".into(),
+            },
+            addons: vec![],
+            transactional: false,
+        }));
+        // "OTHER" matches no product → patterns empty → the surviving host
+        // is a successful no-op; only the pruned host fails.
+        let opts = CommandOptions {
+            repa: ["OTHER:1.0"]
+                .iter()
+                .map(|r| Repa::parse(r).unwrap())
+                .collect(),
+            ..Default::default()
+        };
+        let mut buf = Buffer::default();
+        let mut c = Console::new(&mut buf);
+        let code = run_remove(&opts, &mut g, &mut c).await;
+        assert_eq!(code, ExitCode::Partial);
+        assert!(
+            buf.0.contains("connect failed:") && buf.0.contains("bad"),
+            "pruned host must be reported, got: {:?}",
+            buf.0
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_failed_repo_read_fails_the_host() {
+        let host = MockHost::new("h1")
+            .with_products(System {
+                base: Product {
+                    name: "SLES".into(),
+                    version: "15-SP3".into(),
+                    arch: "x86_64".into(),
+                },
+                addons: vec![],
+                transactional: false,
+            })
+            .with_read_repos_err();
+        let (code, buf) = run(host, &["SLES:15-SP3"]).await;
+        assert_eq!(code, ExitCode::AllFailed);
+        assert!(buf.contains("could not read repositories"));
     }
 
     #[test]

--- a/crates/repose-core/src/commands/reset.rs
+++ b/crates/repose-core/src/commands/reset.rs
@@ -2,7 +2,7 @@
 
 use crate::commands::{
     CommandOptions, ProbeBudget, SharedConsole, aggregate, load_repoq, partition_live,
-    run_reported_shared,
+    report_pruned, run_reported_shared,
 };
 use crate::console::Console;
 use crate::shell::cmd;
@@ -20,7 +20,7 @@ pub async fn run_reset<W: Write>(
     console: &mut Console<W>,
 ) -> Result<ExitCode, crate::template::TemplateError> {
     let repoq = load_repoq(&opts.config)?;
-    group.connect_and_prune().await;
+    let pruned = group.connect_and_prune().await;
     group.read_products().await;
     group.read_repos().await;
 
@@ -35,7 +35,7 @@ pub async fn run_reset<W: Write>(
     // replacing the old per-host `min(16, n)` local cap.
     let probe_budget = ProbeBudget::new(opts.probe_concurrency_limit);
     let console = SharedConsole::new(console);
-    let results = join_all(group.hosts_mut().into_iter().map(|host| {
+    let mut results = join_all(group.hosts_mut().into_iter().map(|host| {
         let semaphore = Arc::clone(&semaphore);
         let probe_budget = probe_budget.clone();
         let repoq = &repoq;
@@ -49,6 +49,7 @@ pub async fn run_reset<W: Write>(
         }
     }))
     .await;
+    report_pruned(&pruned, &mut results, &console);
     group.close().await;
     Ok(aggregate(results))
 }
@@ -61,16 +62,20 @@ async fn reset_one<W: Write>(
     console: &SharedConsole<'_, W>,
     probe_budget: &ProbeBudget,
 ) -> bool {
-    let aliases: Vec<String> = host
-        .raw_repos()
-        .map(|r| {
-            let mut a: Vec<_> = r.iter().map(|x| x.alias.clone()).collect();
-            // Python `_clear` collects into a set: sorted + unique.
-            a.sort();
-            a.dedup();
-            a
-        })
-        .unwrap_or_default();
+    // A failed `zypper -x lr` leaves `raw_repos` as `None`: skipping the rr
+    // wipe but still adding the replacement repos would leave old and new
+    // repos coexisting, violating reset's "only these repos" contract.
+    let Some(raw) = host.raw_repos() else {
+        console.error(host.key(), "could not read repositories");
+        return false;
+    };
+    let aliases: Vec<String> = {
+        let mut a: Vec<_> = raw.iter().map(|x| x.alias.clone()).collect();
+        // Python `_clear` collects into a set: sorted + unique.
+        a.sort();
+        a.dedup();
+        a
+    };
     if aliases.is_empty() {
         console.info(&format!("No repositories to clear from {}", host.key()));
     }
@@ -222,6 +227,43 @@ mod tests {
             .map(|h| h.ran.clone())
             .unwrap_or_default();
         (code, ran, buf.0)
+    }
+
+    #[tokio::test]
+    async fn reset_reports_and_counts_pruned_hosts() {
+        let mut g = MockHostGroup::new();
+        let mut bad = MockHost::new("bad");
+        bad.fail_connect();
+        g.insert(bad);
+        g.insert(
+            MockHost::new("h1")
+                .with_products(sles_system())
+                .with_raw_repos(vec![raw_repo("existing-repo1")]),
+        );
+        let mut buf = Buffer::default();
+        let mut c = Console::new(&mut buf);
+        let code = run_reset(&opts(false), &mut g, &ConstProbe { live: true }, &mut c)
+            .await
+            .unwrap();
+        assert_eq!(code, ExitCode::Partial);
+        assert!(
+            buf.0.contains("connect failed:") && buf.0.contains("bad"),
+            "pruned host must be reported, got: {:?}",
+            buf.0
+        );
+    }
+
+    #[tokio::test]
+    async fn reset_failed_repo_read_fails_the_host() {
+        let host = MockHost::new("h1")
+            .with_products(sles_system())
+            .with_read_repos_err();
+        let (code, ran, buf) = run(host, opts(false), &ConstProbe { live: true }).await;
+        assert_eq!(code, ExitCode::AllFailed);
+        assert!(buf.contains("could not read repositories"));
+        // A failed read must not silently skip the rr wipe but still add
+        // the replacement repos: no mutation runs at all.
+        assert!(ran.is_empty(), "no mutation may run, ran: {ran:?}");
     }
 
     #[tokio::test]

--- a/crates/repose-core/src/commands/uninstall.rs
+++ b/crates/repose-core/src/commands/uninstall.rs
@@ -2,7 +2,8 @@
 
 use crate::commands::remove::{calculate_patterns, calculate_repolist};
 use crate::commands::{
-    CommandOptions, SharedConsole, aggregate, reboot_and_verify_shared, run_reported_shared,
+    CommandOptions, SharedConsole, aggregate, reboot_and_verify_shared, report_pruned,
+    run_reported_shared,
 };
 use crate::console::Console;
 use crate::repa::Repa;
@@ -26,7 +27,7 @@ pub async fn run_uninstall<W: Write>(
         .map(|r| Repa::from_parts(r.product.clone(), r.version.clone(), r.arch.clone(), None))
         .collect();
 
-    group.connect_and_prune().await;
+    let pruned = group.connect_and_prune().await;
     group.read_repos().await;
     group.parse_repos().await;
 
@@ -38,7 +39,7 @@ pub async fn run_uninstall<W: Write>(
     let cap = group.host_operation_limit().get();
     let semaphore = Arc::new(Semaphore::new(cap));
     let console = SharedConsole::new(console);
-    let results = join_all(group.hosts_mut().into_iter().map(|host| {
+    let mut results = join_all(group.hosts_mut().into_iter().map(|host| {
         let semaphore = Arc::clone(&semaphore);
         let orepa = &orepa;
         let console = &console;
@@ -51,6 +52,7 @@ pub async fn run_uninstall<W: Write>(
         }
     }))
     .await;
+    report_pruned(&pruned, &mut results, &console);
     group.close().await;
     aggregate(results)
 }
@@ -77,15 +79,17 @@ async fn uninstall_one<W: Write>(
 
     // Skip the sentinel aliases whose repo name is not a 4-part product string
     // (Python `_calculate_repodict` skips entries where `product.name is None`).
-    let aliases = host
-        .repos()
-        .map(|r| {
-            r.iter()
-                .filter(|(_, product)| product.is_some())
-                .map(|(alias, _)| alias.clone())
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
+    // A failed repo read leaves `repos` as `None`: removing the products
+    // while dropping zero repos would leave stale repos behind.
+    let Some(repos) = host.repos() else {
+        console.error(host.key(), "could not read repositories");
+        return false;
+    };
+    let aliases = repos
+        .iter()
+        .filter(|(_, product)| product.is_some())
+        .map(|(alias, _)| alias.clone())
+        .collect::<Vec<_>>();
     // Patterns already end with `::` (repo forced None) → substring match.
     let repolist = calculate_repolist(aliases.into_iter(), &patterns);
     if repolist.is_empty() {
@@ -193,6 +197,43 @@ mod tests {
             .map(|h| h.ran.clone())
             .unwrap_or_default();
         (code, ran, buf.0)
+    }
+
+    #[tokio::test]
+    async fn uninstall_reports_and_counts_pruned_hosts() {
+        let mut g = MockHostGroup::new();
+        let mut bad = MockHost::new("bad");
+        bad.fail_connect();
+        g.insert(bad);
+        let sles = product("SLES", "15-SP4");
+        g.insert(MockHost::new("h1").with_products(system(sles, vec![], false)));
+        // "OTHER" matches no product → patterns empty → the surviving host
+        // is a successful no-op; only the pruned host fails.
+        let mut buf = Buffer::default();
+        let mut c = Console::new(&mut buf);
+        let code = run_uninstall(&opts(&["OTHER:1.0"], false, false), &mut g, &mut c).await;
+        assert_eq!(code, ExitCode::Partial);
+        assert!(
+            buf.0.contains("connect failed:") && buf.0.contains("bad"),
+            "pruned host must be reported, got: {:?}",
+            buf.0
+        );
+    }
+
+    #[tokio::test]
+    async fn uninstall_failed_repo_read_fails_the_host() {
+        let sles = product("SLES", "15-SP4");
+        let host = MockHost::new("h1")
+            .with_products(system(sles, vec![], false))
+            .with_read_repos_err();
+        let (code, ran, buf) = run(host, opts(&["SLES:15-SP4"], false, false)).await;
+        assert_eq!(code, ExitCode::AllFailed);
+        assert!(buf.contains("could not read repositories"));
+        // No product removal may run after a failed repo read.
+        assert!(
+            !ran.iter().any(|c| c.contains("rm -t product")),
+            "ran: {ran:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/repose-core/src/mock.rs
+++ b/crates/repose-core/src/mock.rs
@@ -319,6 +319,9 @@ pub struct MockHost {
     post_reboot_clear_products: bool,
     /// `read_products` returns `Err` (models a re-read failure).
     read_products_err: bool,
+    /// `read_repos` returns `Err` and leaves `raw_repos` as `None` (models
+    /// a failed `zypper -x lr`, distinct from "read ok, zero repos").
+    read_repos_err: bool,
     out: Vec<OutEntry>,
     /// FIFO outcomes for successive `run` calls. Empty → default exit 0.
     run_queue: Vec<MockRunOutcome>,
@@ -390,6 +393,16 @@ impl MockHost {
         self
     }
 
+    /// Make `read_repos` fail like a failed `zypper -x lr`: returns `Err`
+    /// and leaves `raw_repos` as `None` — which commands must not confuse
+    /// with a successful read of zero repositories.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) const fn with_read_repos_err(mut self) -> Self {
+        self.read_repos_err = true;
+        self
+    }
+
     /// Enter `barrier` at the start of every `run` call (see [`RunBarrier`]).
     #[cfg(test)]
     #[must_use]
@@ -422,7 +435,7 @@ impl MockHost {
     }
 
     #[cfg(test)]
-    const fn fail_connect(&mut self) {
+    pub(crate) const fn fail_connect(&mut self) {
         self.connect_fail = true;
     }
 
@@ -563,6 +576,18 @@ impl Host for MockHost {
         if !self.connected {
             return Err(SshError::NotConnected(self.key.clone()));
         }
+        if self.read_repos_err {
+            return Err(SshError::Other(format!(
+                "mock read_repos failed for {}",
+                self.key
+            )));
+        }
+        // Production parity: a successful `zypper -x lr` always populates
+        // raw_repos (possibly with zero entries); an injected set stays
+        // authoritative. `None` therefore means "read failed / not done".
+        if self.raw_repos.is_none() {
+            self.raw_repos = Some(Vec::new());
+        }
         Ok(())
     }
 
@@ -678,17 +703,20 @@ impl HostGroup for MockHostGroup {
     // These phases mutate host state in place (no per-host result vector to
     // reorder); order restoration is a mutation-worker concern (P1 steps
     // 13–18), not this trait's.
-    async fn connect_and_prune(&mut self) {
+    async fn connect_and_prune(&mut self) -> Vec<(String, SshError)> {
         let cap = self.host_operation_limit.get();
-        let failed: Vec<String> = stream::iter(self.hosts.iter_mut())
+        let mut failed: Vec<(String, SshError)> = stream::iter(self.hosts.iter_mut())
             .map(connect_one)
             .buffer_unordered(cap)
             .filter_map(std::future::ready)
             .collect()
             .await;
-        for key in failed {
-            self.hosts.remove(&key);
+        // Deterministic key order regardless of completion order.
+        failed.sort_by(|a, b| a.0.cmp(&b.0));
+        for (key, _) in &failed {
+            self.hosts.remove(key);
         }
+        failed
     }
 
     async fn read_products(&mut self) {
@@ -747,8 +775,8 @@ impl HostGroup for MockHostGroup {
 // closure's argument lifetime. A plain `fn` item has a concrete
 // `for<'a> fn(&'a mut MockHost) -> impl Future + 'a` signature the
 // compiler resolves without that ambiguity.
-async fn connect_one((key, host): (&String, &mut MockHost)) -> Option<String> {
-    host.connect().await.is_err().then(|| key.clone())
+async fn connect_one((key, host): (&String, &mut MockHost)) -> Option<(String, SshError)> {
+    host.connect().await.err().map(|e| (key.clone(), e))
 }
 
 async fn read_products_one(host: &mut MockHost) {
@@ -964,6 +992,62 @@ mod tests {
         g.insert(bad);
         g.connect_and_prune().await;
         assert_eq!(g.keys(), vec!["good".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn connect_and_prune_returns_pruned_pairs_sorted_by_key() {
+        let mut g = MockHostGroup::new();
+        let mut bad2 = MockHost::new("bad2");
+        bad2.fail_connect();
+        let mut bad1 = MockHost::new("bad1");
+        bad1.fail_connect();
+        g.insert(MockHost::new("good"));
+        g.insert(bad2);
+        g.insert(bad1);
+        let pruned = g.connect_and_prune().await;
+        assert_eq!(g.keys(), vec!["good".to_string()]);
+        let keys: Vec<&str> = pruned.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(
+            keys,
+            ["bad1", "bad2"],
+            "pruned pairs must be key-sorted regardless of completion order"
+        );
+        for (_, err) in &pruned {
+            assert!(err.to_string().contains("mock connect failed"));
+        }
+    }
+
+    #[tokio::test]
+    async fn read_repos_success_populates_empty_raw_repos() {
+        let mut h = MockHost::new("h1");
+        h.connect().await.unwrap();
+        h.read_repos().await.unwrap();
+        assert_eq!(h.raw_repos(), Some(&[][..]));
+    }
+
+    #[tokio::test]
+    async fn read_repos_keeps_injected_raw_repos() {
+        let mut h = MockHost::new("h1").with_raw_repos(vec![Repository {
+            alias: "a".into(),
+            name: "n".into(),
+            url: "http://x".into(),
+            state: true,
+        }]);
+        h.connect().await.unwrap();
+        h.read_repos().await.unwrap();
+        assert_eq!(h.raw_repos().map(<[_]>::len), Some(1));
+    }
+
+    #[tokio::test]
+    async fn read_repos_err_leaves_repos_unread() {
+        let mut h = MockHost::new("h1").with_read_repos_err();
+        h.connect().await.unwrap();
+        assert!(h.read_repos().await.is_err());
+        assert_eq!(h.raw_repos(), None);
+        // parse_repos propagates the failure and never fabricates an empty
+        // repo set over a failed read.
+        assert!(h.parse_repos().await.is_err());
+        assert_eq!(h.repos(), None);
     }
 
     #[tokio::test]

--- a/crates/repose-core/src/traits.rs
+++ b/crates/repose-core/src/traits.rs
@@ -134,7 +134,12 @@ pub trait HostGroup: Send {
     fn host_operation_limit(&self) -> NonZeroUsize;
 
     /// Connect all; drop hosts that fail to connect.
-    async fn connect_and_prune(&mut self);
+    ///
+    /// Returns the pruned `(key, error)` pairs sorted by key, so callers
+    /// can report the failures and count them in exit aggregation — a
+    /// connect failure must surface in the process exit status, not vanish
+    /// with the dropped host.
+    async fn connect_and_prune(&mut self) -> Vec<(String, SshError)>;
 
     async fn read_products(&mut self);
 

--- a/crates/repose-ssh/src/host.rs
+++ b/crates/repose-ssh/src/host.rs
@@ -393,17 +393,20 @@ impl HostGroup for RusshHostGroup {
     // `connect_and_prune`'s removal set stays consistent regardless of
     // completion order; the other phases mutate host state in place (no
     // per-host result vector to reorder).
-    async fn connect_and_prune(&mut self) {
+    async fn connect_and_prune(&mut self) -> Vec<(String, SshError)> {
         let cap = self.host_operation_limit.get();
-        let failed: Vec<String> = stream::iter(self.hosts.iter_mut())
+        let mut failed: Vec<(String, SshError)> = stream::iter(self.hosts.iter_mut())
             .map(connect_one)
             .buffer_unordered(cap)
             .filter_map(std::future::ready)
             .collect()
             .await;
-        for key in failed {
-            self.hosts.remove(&key);
+        // Deterministic key order regardless of completion order.
+        failed.sort_by(|a, b| a.0.cmp(&b.0));
+        for (key, _) in &failed {
+            self.hosts.remove(key);
         }
+        failed
     }
 
     async fn read_products(&mut self) {
@@ -458,8 +461,8 @@ impl HostGroup for RusshHostGroup {
 
 // Named async fns (not closures) as `.map()` arguments above — see
 // `repose_core::mock`'s identical helpers for why.
-async fn connect_one((key, host): (&String, &mut RusshHost)) -> Option<String> {
-    host.connect().await.is_err().then(|| key.clone())
+async fn connect_one((key, host): (&String, &mut RusshHost)) -> Option<(String, SshError)> {
+    host.connect().await.err().map(|e| (key.clone(), e))
 }
 
 async fn read_products_one(host: &mut RusshHost) {


### PR DESCRIPTION
**Rewritten on top of the P1 fan-out rework** (the original version of this PR was based on the pre-P1 command layout; the findings are unchanged, the implementation is new).

## Problem

Two failure paths are invisible to users **and** to the process exit status:

1. **Unreachable targets vanish silently.** `connect_and_prune` drops failed hosts without reporting anything, and the mutation commands aggregate only the survivors — so a run where *every* target fails to connect exits **0 with zero output** (`aggregate([]) == Ok`), and mixed groups never even report `Partial` for connect failures. Repro: `repose add -t no.such.host.invalid SLES:15-SP3` → exit 0, no output. This also masks `--known-hosts` misconfiguration.

2. **A failed `zypper -x lr` read is indistinguishable from "zero repositories"** (`raw_repos()`/`repos()` stay `None`, commands default to empty):
   - `clear` prints "No repositories to clear" and counts the host **successful**;
   - `uninstall` removes the products while removing zero repos, leaving stale repos behind;
   - `reset` skips the `rr` wipe but still `ar`s the replacement repos — old and new repos coexisting, violating reset's "only these repos" contract.

## Fix

- `HostGroup::connect_and_prune` now returns the pruned `(key, error)` pairs (key-sorted for deterministic output; both the mock and `RusshHostGroup`). Every mutation command reports each as `connect failed: ...` and seeds one failure per pruned host into the exit aggregation: all-unreachable runs exit `AllFailed`, mixed runs `Partial`. `list-products`/`list-repos` keep their documented always-0 behavior.
- `clear`/`reset` fail the host with `could not read repositories` when `raw_repos()` is `None`; `remove`/`uninstall` do the same when `repos()` is `None` — after the patterns-empty early return, so genuine no-ops stay successful.
- The mock now models the distinction like `RusshHost` does: a successful `read_repos` populates `raw_repos` (possibly empty, injected set stays authoritative); the new `with_read_repos_err` knob fails the read and leaves it `None`, and `parse_repos` propagates the failure without fabricating an empty repo set.

## Tests

Per command: pruned-host reporting + exit code (mixed `Partial`; all-unreachable `AllFailed` for clear). Failed-read behavior for clear/reset/remove/uninstall, including "no mutation runs after a failed read" and "no-op stays successful". Mock coverage for the pruned-pair contract and the read_repos success/injected/error semantics. Full workspace gate green: `cargo test --workspace --all-targets --locked`, clippy `-D warnings`, `cargo deny check`, `scripts/check-rust-layering.sh`.