### PR TITLE
fix(ssh): bound connection setup with the configured timeout and harden accept-new

### DIFF
--- a/crates/repose-ssh/src/hostkey.rs
+++ b/crates/repose-ssh/src/hostkey.rs
@@ -67,6 +67,11 @@ impl KnownHostEntry {
 ///
 /// `accept-new` uses trust-on-first-use: it appends a key only when no trusted
 /// entry exists for the host, and rejects a changed or explicitly revoked key.
+///
+/// Evaluation is split in two so the async handshake never does filesystem
+/// I/O on a worker thread: [`HostKeyVerifier::decide_public_key`] is pure,
+/// and [`persist_first_contact`] runs on the blocking pool (see
+/// `session.rs`'s `check_server_key`).
 pub(crate) struct HostKeyVerifier {
     policy: HostKeyPolicy,
     host: String,
@@ -74,6 +79,17 @@ pub(crate) struct HostKeyVerifier {
     aliases: Vec<String>,
     path: Option<PathBuf>,
     entries: Vec<KnownHostEntry>,
+}
+
+/// Outcome of evaluating the offered host key against `known_hosts`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HostKeyDecision {
+    /// Trusted (or policy off): proceed.
+    Accept,
+    /// First contact under accept-new: persist the key material, then proceed.
+    Persist(String),
+    /// Unknown, changed, or revoked key: abort the connection.
+    Reject,
 }
 
 impl HostKeyVerifier {
@@ -113,24 +129,26 @@ impl HostKeyVerifier {
         self
     }
 
-    pub(crate) fn verify_public_key(&mut self, key: &PublicKey) -> bool {
+    /// Evaluate the offered key against the loaded `known_hosts` snapshot.
+    /// Pure: no I/O, safe to call on an async worker.
+    pub(crate) fn decide_public_key(&self, key: &PublicKey) -> HostKeyDecision {
         let encoded = match key.to_openssh() {
             Ok(encoded) => encoded,
             Err(error) => {
                 log::error!("could not encode offered SSH host key: {error}");
-                return false;
+                return HostKeyDecision::Reject;
             }
         };
         let Some(key) = key_material(&encoded) else {
             log::error!("could not encode offered SSH host key");
-            return false;
+            return HostKeyDecision::Reject;
         };
-        self.verify_key(&key)
+        self.decide_key(&key)
     }
 
-    fn verify_key(&mut self, key: &str) -> bool {
+    fn decide_key(&self, key: &str) -> HostKeyDecision {
         match self.policy {
-            HostKeyPolicy::No | HostKeyPolicy::Off => true,
+            HostKeyPolicy::No | HostKeyPolicy::Off => HostKeyDecision::Accept,
             HostKeyPolicy::Yes | HostKeyPolicy::AcceptNew => {
                 let matches: Vec<_> = self
                     .entries
@@ -142,7 +160,7 @@ impl HostKeyVerifier {
                     .any(|entry| entry.is_revoked() && entry.key == key)
                 {
                     log::error!("host key for {} is explicitly revoked", self.host);
-                    return false;
+                    return HostKeyDecision::Reject;
                 }
 
                 let trusted: Vec<_> = matches
@@ -150,50 +168,49 @@ impl HostKeyVerifier {
                     .filter(|entry| entry.is_trusted())
                     .collect();
                 if trusted.iter().any(|entry| entry.key == key) {
-                    return true;
+                    return HostKeyDecision::Accept;
                 }
 
                 match self.policy {
                     HostKeyPolicy::Yes => {
                         log::error!("no trusted host key for {}", self.host);
-                        false
+                        HostKeyDecision::Reject
                     }
                     HostKeyPolicy::AcceptNew if !trusted.is_empty() => {
                         log::error!("host key changed for {}", self.host);
-                        false
+                        HostKeyDecision::Reject
                     }
-                    HostKeyPolicy::AcceptNew => self.accept_new(key),
-                    HostKeyPolicy::No | HostKeyPolicy::Off => true,
+                    HostKeyPolicy::AcceptNew => match &self.path {
+                        Some(_) => HostKeyDecision::Persist(key.to_string()),
+                        None => HostKeyDecision::Accept,
+                    },
+                    HostKeyPolicy::No | HostKeyPolicy::Off => HostKeyDecision::Accept,
                 }
             }
         }
     }
 
-    fn accept_new(&mut self, key: &str) -> bool {
-        let Some(path) = &self.path else {
-            return true;
-        };
-        if let Err(error) = append_known_host(path, &self.host, self.port, key) {
-            // TOFU degrades to trust-without-recording: the session proceeds,
-            // but every future connection will re-accept this host unverified
-            // until the file becomes writable — make that loud, not a warn.
-            log::error!(
-                "accept-new: could not persist host key for {} to {}: {} — \
-                 the key was NOT recorded; future connections will re-accept \
-                 this host without verification",
-                self.host,
-                path.display(),
-                error
-            );
-            return true;
-        }
+    /// Everything [`persist_first_contact`] needs, offloaded by the caller.
+    /// `Some` exactly when a known_hosts path applies (`yes` / `accept-new`).
+    pub(crate) fn persist_context(&self) -> Option<(PathBuf, String, u16, Vec<String>)> {
+        self.path
+            .clone()
+            .map(|path| (path, self.host.clone(), self.port, self.host_names()))
+    }
 
+    /// Record a just-persisted first-contact key so later checks within this
+    /// handshake treat it as trusted.
+    pub(crate) fn note_persisted(&mut self, key: &str) {
         self.entries.push(KnownHostEntry {
             patterns: vec![host_pattern(&self.host, self.port)],
             key: key.to_string(),
             marker: None,
         });
-        true
+    }
+
+    /// The configured host name (for diagnostics).
+    pub(crate) fn host(&self) -> &str {
+        &self.host
     }
 
     // Lookup keys are the configured names only; OpenSSH `CheckHostIP`-style
@@ -274,9 +291,47 @@ fn malformed_known_hosts(path: &Path, line_no: usize) -> SshError {
     ))
 }
 
-fn append_known_host(path: &Path, host: &str, port: u16, key: &str) -> std::io::Result<()> {
+/// Append a first-contact key while holding the process-global write lock,
+/// re-reading the file **under that lock** first: two concurrent first
+/// contacts for the same known_hosts name (e.g. two targets whose ssh-config
+/// `HostName` resolves to one machine in a single fan-out run) must not both
+/// persist keys. Without the re-check, a MITM key presented to one connection
+/// would be permanently recorded next to the real one and trusted by future
+/// `yes`-policy runs.
+///
+/// Returns `Ok(true)` when the key is persisted (or an identical trusted
+/// entry was recorded concurrently), `Ok(false)` when a *different* trusted
+/// key won the race, and `Err` on filesystem failure.
+///
+/// Runs synchronously on purpose — offload via `spawn_blocking`.
+pub(crate) fn persist_first_contact(
+    path: &Path,
+    host: &str,
+    port: u16,
+    host_names: &[String],
+    key: &str,
+) -> Result<bool, SshError> {
     let lock = KNOWN_HOSTS_WRITE_LOCK.get_or_init(|| Mutex::new(()));
     let _guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let current = load_known_hosts(path)?;
+    let trusted: Vec<_> = current
+        .iter()
+        .filter(|entry| entry.matches(host_names) && entry.is_trusted())
+        .collect();
+    if !trusted.is_empty() {
+        // No longer first contact: accept only the already-recorded key.
+        return Ok(trusted.iter().any(|entry| entry.key == key));
+    }
+    append_known_host_locked(path, host, port, key).map_err(|error| {
+        SshError::Transport(format!(
+            "could not persist host key to {}: {error}",
+            path.display()
+        ))
+    })?;
+    Ok(true)
+}
+
+fn append_known_host_locked(path: &Path, host: &str, port: u16, key: &str) -> std::io::Result<()> {
     let existed = path.exists();
     let needs_newline = fs::read(path)
         .ok()
@@ -374,7 +429,7 @@ mod tests {
     use repose_core::config::HostKeyPolicy;
     use tempfile::tempdir;
 
-    use super::HostKeyVerifier;
+    use super::{HostKeyDecision, HostKeyVerifier, persist_first_contact};
 
     const KEY_ONE: &str =
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti";
@@ -385,11 +440,10 @@ mod tests {
         let temp = tempdir().unwrap();
         let path = temp.path().join("known_hosts");
         fs::write(&path, format!("host {KEY_ONE}\n")).unwrap();
-        let mut verifier =
-            HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "host", 22).unwrap();
+        let verifier = HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "host", 22).unwrap();
 
-        assert!(verifier.verify_key(KEY_ONE));
-        assert!(!verifier.verify_key(KEY_TWO));
+        assert_eq!(verifier.decide_key(KEY_ONE), HostKeyDecision::Accept);
+        assert_eq!(verifier.decide_key(KEY_TWO), HostKeyDecision::Reject);
     }
 
     #[test]
@@ -401,12 +455,70 @@ mod tests {
             HostKeyVerifier::new(HostKeyPolicy::AcceptNew, Some(path.clone()), "host", 2222)
                 .unwrap();
 
-        assert!(verifier.verify_key(KEY_ONE));
+        let HostKeyDecision::Persist(key) = verifier.decide_key(KEY_ONE) else {
+            panic!("first contact must decide to persist");
+        };
+        let (persist_path, host, port, names) = verifier.persist_context().unwrap();
+        assert!(persist_first_contact(&persist_path, &host, port, &names, &key).unwrap());
+        verifier.note_persisted(&key);
         assert_eq!(
             fs::read_to_string(&path).unwrap(),
             format!("old-entry {KEY_ONE}\n[host]:2222 {KEY_ONE}\n")
         );
-        assert!(!verifier.verify_key(KEY_TWO));
+        assert_eq!(verifier.decide_key(KEY_TWO), HostKeyDecision::Reject);
+    }
+
+    #[test]
+    fn concurrent_first_contacts_cannot_both_persist() {
+        // Both verifiers snapshot an empty known_hosts (each sees "first
+        // contact"); the loser's persist must fail the re-check under the
+        // write lock instead of recording a second, different key.
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("known_hosts");
+        let first =
+            HostKeyVerifier::new(HostKeyPolicy::AcceptNew, Some(path.clone()), "host", 22).unwrap();
+        let second =
+            HostKeyVerifier::new(HostKeyPolicy::AcceptNew, Some(path.clone()), "host", 22).unwrap();
+
+        let HostKeyDecision::Persist(key_one) = first.decide_key(KEY_ONE) else {
+            panic!("first contact must decide to persist");
+        };
+        let HostKeyDecision::Persist(key_two) = second.decide_key(KEY_TWO) else {
+            panic!("first contact must decide to persist");
+        };
+        let (path_one, host_one, port_one, names_one) = first.persist_context().unwrap();
+        let (path_two, host_two, port_two, names_two) = second.persist_context().unwrap();
+        assert!(
+            persist_first_contact(&path_one, &host_one, port_one, &names_one, &key_one).unwrap()
+        );
+        assert!(
+            !persist_first_contact(&path_two, &host_two, port_two, &names_two, &key_two).unwrap(),
+            "a different key that lost the race must be rejected"
+        );
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            format!("host {KEY_ONE}\n"),
+            "only the winning key is recorded"
+        );
+    }
+
+    #[test]
+    fn concurrent_first_contact_with_the_same_key_is_idempotent() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("known_hosts");
+        let verifier =
+            HostKeyVerifier::new(HostKeyPolicy::AcceptNew, Some(path.clone()), "host", 22).unwrap();
+        let (persist_path, host, port, names) = verifier.persist_context().unwrap();
+        assert!(persist_first_contact(&persist_path, &host, port, &names, KEY_ONE).unwrap());
+        assert!(
+            persist_first_contact(&persist_path, &host, port, &names, KEY_ONE).unwrap(),
+            "the same key recorded concurrently stays accepted"
+        );
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            format!("host {KEY_ONE}\n"),
+            "no duplicate entry is appended"
+        );
     }
 
     #[test]
@@ -414,10 +526,10 @@ mod tests {
         let temp = tempdir().unwrap();
         let path = temp.path().join("known_hosts");
         fs::write(&path, format!("@revoked host {KEY_ONE}\n")).unwrap();
-        let mut verifier =
+        let verifier =
             HostKeyVerifier::new(HostKeyPolicy::AcceptNew, Some(path), "host", 22).unwrap();
 
-        assert!(!verifier.verify_key(KEY_ONE));
+        assert_eq!(verifier.decide_key(KEY_ONE), HostKeyDecision::Reject);
     }
 
     #[test]
@@ -427,9 +539,8 @@ mod tests {
         fs::write(&path, "not a valid known-hosts line\n").unwrap();
 
         for policy in [HostKeyPolicy::No, HostKeyPolicy::Off] {
-            let mut verifier =
-                HostKeyVerifier::new(policy, Some(path.clone()), "host", 22).unwrap();
-            assert!(verifier.verify_key(KEY_ONE));
+            let verifier = HostKeyVerifier::new(policy, Some(path.clone()), "host", 22).unwrap();
+            assert_eq!(verifier.decide_key(KEY_ONE), HostKeyDecision::Accept);
         }
     }
 
@@ -448,12 +559,11 @@ mod tests {
         let path = temp.path().join("known_hosts");
         fs::write(&path, format!("*.example,!bad.example {KEY_ONE}\n")).unwrap();
 
-        let mut good =
+        let good =
             HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path.clone()), "ok.example", 22).unwrap();
-        let mut bad =
-            HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "bad.example", 22).unwrap();
-        assert!(good.verify_key(KEY_ONE));
-        assert!(!bad.verify_key(KEY_ONE));
+        let bad = HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "bad.example", 22).unwrap();
+        assert_eq!(good.decide_key(KEY_ONE), HostKeyDecision::Accept);
+        assert_eq!(bad.decide_key(KEY_ONE), HostKeyDecision::Reject);
     }
 
     #[test]
@@ -462,10 +572,10 @@ mod tests {
         let path = temp.path().join("known_hosts");
         fs::write(&path, format!("alias {KEY_ONE}\n")).unwrap();
 
-        let mut verifier = HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "resolved", 22)
+        let verifier = HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "resolved", 22)
             .unwrap()
             .with_alias("alias");
-        assert!(verifier.verify_key(KEY_ONE));
+        assert_eq!(verifier.decide_key(KEY_ONE), HostKeyDecision::Accept);
     }
 
     // HMAC-SHA1 vectors computed independently (Python `hmac` stdlib) with
@@ -479,11 +589,10 @@ mod tests {
         let temp = tempdir().unwrap();
         let path = temp.path().join("known_hosts");
         fs::write(&path, format!("|1|{HASHED_SALT}|{HASHED_HOST} {KEY_ONE}\n")).unwrap();
-        let mut verifier =
-            HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "host", 22).unwrap();
+        let verifier = HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "host", 22).unwrap();
 
-        assert!(verifier.verify_key(KEY_ONE));
-        assert!(!verifier.verify_key(KEY_TWO));
+        assert_eq!(verifier.decide_key(KEY_ONE), HostKeyDecision::Accept);
+        assert_eq!(verifier.decide_key(KEY_TWO), HostKeyDecision::Reject);
     }
 
     #[test]
@@ -496,11 +605,11 @@ mod tests {
         )
         .unwrap();
 
-        let mut on_2222 =
+        let on_2222 =
             HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path.clone()), "host", 2222).unwrap();
-        let mut on_22 = HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "host", 22).unwrap();
-        assert!(on_2222.verify_key(KEY_ONE));
-        assert!(!on_22.verify_key(KEY_ONE));
+        let on_22 = HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "host", 22).unwrap();
+        assert_eq!(on_2222.decide_key(KEY_ONE), HostKeyDecision::Accept);
+        assert_eq!(on_22.decide_key(KEY_ONE), HostKeyDecision::Reject);
     }
 
     #[test]
@@ -509,14 +618,14 @@ mod tests {
         let path = temp.path().join("known_hosts");
         let contents = format!("|1|{HASHED_SALT}|{HASHED_HOST} {KEY_ONE}\n");
         fs::write(&path, &contents).unwrap();
-        let mut verifier =
+        let verifier =
             HostKeyVerifier::new(HostKeyPolicy::AcceptNew, Some(path.clone()), "host", 22).unwrap();
 
         // A hashed pin is not first contact: the changed key must be refused
         // and nothing may be appended to known_hosts.
-        assert!(!verifier.verify_key(KEY_TWO));
+        assert_eq!(verifier.decide_key(KEY_TWO), HostKeyDecision::Reject);
         assert_eq!(fs::read_to_string(&path).unwrap(), contents);
-        assert!(verifier.verify_key(KEY_ONE));
+        assert_eq!(verifier.decide_key(KEY_ONE), HostKeyDecision::Accept);
     }
 
     #[test]
@@ -529,15 +638,15 @@ mod tests {
         )
         .unwrap();
 
-        let mut hashed =
+        let hashed =
             HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path.clone()), "host", 22).unwrap();
-        assert!(hashed.verify_key(KEY_ONE));
-        assert!(!hashed.verify_key(KEY_TWO));
+        assert_eq!(hashed.decide_key(KEY_ONE), HostKeyDecision::Accept);
+        assert_eq!(hashed.decide_key(KEY_TWO), HostKeyDecision::Reject);
 
-        let mut plain =
+        let plain =
             HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "other.example", 22).unwrap();
-        assert!(plain.verify_key(KEY_TWO));
-        assert!(!plain.verify_key(KEY_ONE));
+        assert_eq!(plain.decide_key(KEY_TWO), HostKeyDecision::Accept);
+        assert_eq!(plain.decide_key(KEY_ONE), HostKeyDecision::Reject);
     }
 
     #[test]
@@ -563,9 +672,8 @@ mod tests {
         let temp = tempdir().unwrap();
         let path = temp.path().join("known_hosts");
         fs::write(&path, format!("host {KEY_ONE}\n")).unwrap();
-        let mut verifier =
-            HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "host", 2222).unwrap();
+        let verifier = HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "host", 2222).unwrap();
 
-        assert!(!verifier.verify_key(KEY_ONE));
+        assert_eq!(verifier.decide_key(KEY_ONE), HostKeyDecision::Reject);
     }
 }

--- a/crates/repose-ssh/src/session.rs
+++ b/crates/repose-ssh/src/session.rs
@@ -100,7 +100,52 @@ impl Handler for ClientHandler {
         &mut self,
         server_public_key: &russh::keys::ssh_key::PublicKey,
     ) -> Result<bool, Self::Error> {
-        Ok(self.verifier.verify_public_key(server_public_key))
+        use crate::hostkey::HostKeyDecision;
+        match self.verifier.decide_public_key(server_public_key) {
+            HostKeyDecision::Accept => Ok(true),
+            HostKeyDecision::Reject => Ok(false),
+            HostKeyDecision::Persist(key) => {
+                let Some((path, host, port, names)) = self.verifier.persist_context() else {
+                    // Policy without a known_hosts path: nothing to record.
+                    return Ok(true);
+                };
+                // The append does filesystem I/O under a process-global
+                // lock — offload it so a slow known_hosts (NFS, a contended
+                // lock) cannot freeze every other host on the runtime.
+                let key_material = key.clone();
+                let persisted = tokio::task::spawn_blocking(move || {
+                    crate::hostkey::persist_first_contact(&path, &host, port, &names, &key)
+                })
+                .await;
+                match persisted {
+                    Ok(Ok(true)) => {
+                        self.verifier.note_persisted(&key_material);
+                        Ok(true)
+                    }
+                    Ok(Ok(false)) => {
+                        log::error!(
+                            "host key for {} changed while connecting (a concurrent first contact recorded a different key); rejecting",
+                            self.verifier.host()
+                        );
+                        Ok(false)
+                    }
+                    Ok(Err(error)) => {
+                        // Deliberate fail-open: TOFU degrades to
+                        // trust-without-recording, but loudly.
+                        log::error!(
+                            "accept-new: {error} — the key was NOT recorded; future connections will re-accept this host without verification"
+                        );
+                        Ok(true)
+                    }
+                    Err(error) => {
+                        log::error!(
+                            "accept-new: persist task failed: {error} — the key was NOT recorded"
+                        );
+                        Ok(true)
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -165,6 +210,26 @@ impl RusshSession {
         keys
     }
 
+    /// The configured per-operation bound as a [`Duration`].
+    ///
+    /// `ConnectionConfig.timeout` is a public, unvalidated `f64`: never
+    /// panic on NaN/negative/overflow (a connect runs under `join_all`, so
+    /// one panic would kill the whole host group); fall back to a small
+    /// positive bound like [`Self::sftp_timeout_secs`] does.
+    fn op_timeout(&self) -> Duration {
+        match self.config.timeout {
+            t if t.is_finite() && t > 0.0 => Duration::from_secs_f64(t),
+            _ => Duration::from_secs(1),
+        }
+    }
+
+    /// Timeout error for a stalled network operation (connect, auth,
+    /// channel setup, SFTP init) — mirrors the command-timeout wording the
+    /// `Host` adapter matches on.
+    fn timed_out(&self, what: &str) -> SshError {
+        SshError::Transport(format!("{what} timed out after {}s", self.config.timeout))
+    }
+
     async fn connect_inner(&mut self) -> Result<(), SshError> {
         // Any cached SFTP channel rode on the previous transport.
         self.sftp = None;
@@ -222,17 +287,25 @@ impl RusshSession {
             .map(|verifier| verifier.with_alias(self.hostname.clone()))?
         };
         let handler = ClientHandler { verifier };
+        // Every network step is bounded by the configured timeout: an
+        // unbounded connect/handshake lets one blackholed or stalling
+        // target hang the whole host group behind `join_all`.
         let mut session = if let Some(command) =
             proxy_command_line(&options, &self.hostname, self.port, &target_user)
         {
             let stream = ProxyStream::spawn(&command)?;
-            client::connect_stream(conf, stream, handler)
-                .await
-                .map_err(|e| SshError::Transport(e.to_string()))?
+            tokio::time::timeout(
+                self.op_timeout(),
+                client::connect_stream(conf, stream, handler),
+            )
+            .await
+            .map_err(|_| self.timed_out("connect"))?
+            .map_err(|e| SshError::Transport(e.to_string()))?
         } else {
             let addrs = (target_host.as_str(), target_port);
-            client::connect(conf, addrs, handler)
+            tokio::time::timeout(self.op_timeout(), client::connect(conf, addrs, handler))
                 .await
+                .map_err(|_| self.timed_out("connect"))?
                 .map_err(|e| SshError::Transport(e.to_string()))?
         };
 
@@ -240,7 +313,13 @@ impl RusshSession {
         // skipped when SSH_AUTH_SOCK is absent or unusable), then
         // IdentityFile / default key files, then one password prompt.
         let mut last_err = "no SSH private key found (~/.ssh/id_ed25519|id_rsa)".to_string();
-        if try_agent_auth(&mut session, &target_user, &mut last_err).await {
+        if tokio::time::timeout(
+            self.op_timeout(),
+            try_agent_auth(&mut session, &target_user, &mut last_err),
+        )
+        .await
+        .map_err(|_| self.timed_out("authentication"))?
+        {
             self.handle = Some(session);
             return Ok(());
         }
@@ -264,18 +343,21 @@ impl RusshSession {
                     continue;
                 }
             };
-            let hash = session
-                .best_supported_rsa_hash()
+            let hash = tokio::time::timeout(self.op_timeout(), session.best_supported_rsa_hash())
                 .await
+                .map_err(|_| self.timed_out("authentication"))?
                 .map_err(|e| SshError::Transport(e.to_string()))?
                 .flatten();
-            let auth = session
-                .authenticate_publickey(
+            let auth = tokio::time::timeout(
+                self.op_timeout(),
+                session.authenticate_publickey(
                     target_user.clone(),
                     PrivateKeyWithHashAlg::new(Arc::new(key_pair), hash),
-                )
-                .await
-                .map_err(|e| SshError::Transport(e.to_string()))?;
+                ),
+            )
+            .await
+            .map_err(|_| self.timed_out("authentication"))?
+            .map_err(|e| SshError::Transport(e.to_string()))?;
             if auth.success() {
                 self.handle = Some(session);
                 return Ok(());
@@ -298,11 +380,15 @@ impl RusshSession {
             .await
             .map_err(|e| SshError::Transport(format!("password prompt task failed: {e}")))?
             .map_err(|e| SshError::Transport(format!("could not read SSH password: {e}")))?;
-        let auth = session
-            .authenticate_password(target_user.clone(), &password)
-            .await;
+        let auth = tokio::time::timeout(
+            self.op_timeout(),
+            session.authenticate_password(target_user.clone(), &password),
+        )
+        .await;
         password.zeroize();
-        let auth = auth.map_err(|e| SshError::Transport(e.to_string()))?;
+        let auth = auth
+            .map_err(|_| self.timed_out("authentication"))?
+            .map_err(|e| SshError::Transport(e.to_string()))?;
         if auth.success() {
             self.handle = Some(session);
             return Ok(());
@@ -315,20 +401,23 @@ impl RusshSession {
     }
 
     async fn run_inner(&mut self, command: &str) -> Result<(String, String, i32), SshError> {
+        let timeout = self.op_timeout();
         let handle = self
             .handle
             .as_mut()
             .ok_or_else(|| SshError::NotConnected(self.hostname.clone()))?;
-        let mut channel = handle
-            .channel_open_session()
+        let mut channel = tokio::time::timeout(timeout, handle.channel_open_session())
             .await
+            .map_err(|_| self.timed_out("channel open"))?
             .map_err(|e| SshError::Transport(e.to_string()))?;
-        channel
-            .exec(true, command)
+        // Note: in russh 0.62 `exec` only enqueues the request; its timeout
+        // can fire solely on a wedged local session loop. The server-side
+        // round-trip is bounded by the collect wrap below.
+        tokio::time::timeout(timeout, channel.exec(true, command))
             .await
+            .map_err(|_| self.timed_out("exec"))?
             .map_err(|e| SshError::Transport(e.to_string()))?;
 
-        let timeout = Duration::from_secs_f64(self.config.timeout);
         let collect = async {
             let mut stdout = Vec::new();
             let mut stderr = Vec::new();
@@ -357,10 +446,18 @@ impl RusshSession {
 
         match tokio::time::timeout(timeout, collect).await {
             Ok(r) => r,
-            Err(_) => Err(SshError::Transport(format!(
-                "command timed out after {}s",
-                self.config.timeout
-            ))),
+            Err(_) => {
+                // A plain russh::Channel does NOT close on drop (only
+                // ChannelCloseOnDrop does): tell the server to kill the
+                // orphaned command instead of leaking the channel slot —
+                // sshd's MaxSessions would otherwise degrade the host.
+                // Bounded best-effort: a wedged peer must not hang us.
+                let _ = tokio::time::timeout(Duration::from_secs(2), channel.close()).await;
+                Err(SshError::Transport(format!(
+                    "command timed out after {}s",
+                    self.config.timeout
+                )))
+            }
         }
     }
 
@@ -374,20 +471,22 @@ impl RusshSession {
 
     async fn sftp_session(&mut self) -> Result<&SftpSession, SshError> {
         if self.sftp.is_none() {
+            let timeout = self.op_timeout();
             let handle = self
                 .handle
                 .as_mut()
                 .ok_or_else(|| SshError::NotConnected(self.hostname.clone()))?;
-            let channel = handle
-                .channel_open_session()
+            let channel = tokio::time::timeout(timeout, handle.channel_open_session())
                 .await
+                .map_err(|_| self.timed_out("channel open"))?
                 .map_err(|e| SshError::Transport(e.to_string()))?;
-            channel
-                .request_subsystem(true, "sftp")
+            tokio::time::timeout(timeout, channel.request_subsystem(true, "sftp"))
                 .await
+                .map_err(|_| self.timed_out("SFTP subsystem request"))?
                 .map_err(|e| SshError::Transport(e.to_string()))?;
-            let sftp = SftpSession::new(channel.into_stream())
+            let sftp = tokio::time::timeout(timeout, SftpSession::new(channel.into_stream()))
                 .await
+                .map_err(|_| self.timed_out("SFTP initialization"))?
                 .map_err(|e| SshError::Transport(format!("SFTP initialization failed: {e}")))?;
             sftp.set_timeout(self.sftp_timeout_secs());
             self.sftp = Some(sftp);
@@ -594,17 +693,18 @@ impl SshSession for RusshSession {
     }
 
     async fn fire_and_forget(&mut self, command: &str) -> Result<(), SshError> {
+        let timeout = self.op_timeout();
         let handle = self
             .handle
             .as_mut()
             .ok_or_else(|| SshError::NotConnected(self.hostname.clone()))?;
-        let channel = handle
-            .channel_open_session()
+        let channel = tokio::time::timeout(timeout, handle.channel_open_session())
             .await
+            .map_err(|_| self.timed_out("channel open"))?
             .map_err(|e| SshError::Transport(e.to_string()))?;
-        channel
-            .exec(true, command)
+        tokio::time::timeout(timeout, channel.exec(true, command))
             .await
+            .map_err(|_| self.timed_out("exec"))?
             .map_err(|e| SshError::Transport(e.to_string()))?;
         // Do not wait for exit — reboot drops the link.
         Ok(())
@@ -705,5 +805,42 @@ mod tests {
         assert_eq!(schedule, [10, 30, 40, 50, 60, 70, 80, 90, 100, 110]);
         assert_eq!(schedule.iter().sum::<u64>(), 640);
         assert!((1..=10).all(|attempt| super::reconnect_sleep_secs(attempt, 10, false) == 10));
+    }
+
+    #[tokio::test]
+    async fn connect_to_a_banner_stalled_server_times_out() {
+        use repose_core::traits::SshSession;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        // Accept and hold the connection without ever sending an SSH banner:
+        // before the timeout wrapped the handshake, this hung forever and
+        // stalled the whole host group behind join_all.
+        let hold = tokio::spawn(async move {
+            let _accepted = listener.accept().await;
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+
+        let config = ConnectionConfig {
+            timeout: 0.2,
+            // Policy off keeps the test hermetic: no real ~/.ssh/known_hosts
+            // is consulted (the ssh-config lookup still reads ~/.ssh/config,
+            // which is empty/absent on CI machines).
+            host_key_policy: repose_core::HostKeyPolicy::Off,
+            ..ConnectionConfig::default()
+        };
+        let mut session = RusshSession::new("127.0.0.1", port, "root", config);
+        let started = std::time::Instant::now();
+        let err = session.connect().await.unwrap_err();
+        assert!(
+            err.to_string().contains("connect timed out"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(10),
+            "an unbounded connect would hang far past the configured timeout"
+        );
+        hold.abort();
     }
 }


### PR DESCRIPTION
## Problem

The configured `timeout` only bounded the command-output collection loop. Everything before it was unbounded:

- TCP connect, the SSH handshake, every auth method (agent, publickey, password), channel open, and SFTP subsystem init. One blackholed target (firewall DROP) or a server stalling the banner/auth/SFTP init hung **the entire host group** behind `join_all` — violating the workspace rule "Bound network operations with the configured timeout".
- A timed-out command dropped its channel without `CHANNEL_CLOSE` (plain `russh::Channel` does not close on drop in russh 0.62 — only `ChannelCloseOnDrop` does), orphaning the remote process and leaking an sshd `MaxSessions` slot; ~10 timed-out commands would degrade a host.
- `accept-new` appended to `known_hosts` synchronously (fs I/O under a process-global mutex) inside russh's async `check_server_key` callback — blocking the runtime for every other host on a slow/locked home directory.
- The TOFU check-then-act raced: two concurrent first contacts for the same known_hosts name (e.g. two targets whose ssh-config `HostName` resolves to one machine) both appended keys, so a MITM key presented to one connection would be permanently recorded next to the real one and trusted by future `yes`-policy runs.

## Fix

- `tokio::time::timeout` (configured timeout) around connect/connect_stream, agent auth, `best_supported_rsa_hash`, publickey/password auth, channel open + exec (run and fire-and-forget), and channel open + subsystem request + `SftpSession::new`. Interactive prompts stay unbounded by design. A saturating conversion keeps a malformed `f64` config from panicking inside the group fan-out.
- On command timeout, a best-effort `channel.close()` under a short bound before returning the error.
- Host-key verification is split into a pure `decide` step (no I/O) and a `spawn_blocking`'d `persist_first_contact` step, keeping the async worker free of filesystem I/O.
- The persist re-reads `known_hosts` **under the write lock** and rejects when a *different* trusted key was recorded concurrently (same-key races stay idempotent). The deliberate fail-open-on-io-error policy (loud log, session proceeds) is unchanged.

## Tests

New regression test: a banner-stalled local server fails with "connect timed out" well within the bound (previously it hung forever). New `known_hosts` race/idempotency tests. Converted host-key tests preserve their old assertions' meaning. Full workspace gate green: `cargo test --workspace --all-targets --locked`, clippy `-D warnings`, `cargo deny check`, `scripts/check-rust-layering.sh`.