### PR TITLE
fix(cli): honor --color modes for stderr log coloring

### DIFF
--- a/crates/repose-cli/src/lib.rs
+++ b/crates/repose-cli/src/lib.rs
@@ -268,7 +268,7 @@ async fn async_main() -> ExitCode {
         eprintln!("error: --debug and --quiet are mutually exclusive");
         return ExitCode::from(2);
     }
-    init_logging(cli.debug, cli.quiet, cli.no_color);
+    init_logging(cli.debug, cli.quiet, cli.no_color, cli.color);
 
     let conn = ConnectionConfig {
         host_key_policy: cli.strict_host_key_checking.into(),
@@ -314,10 +314,13 @@ const fn log_level(debug: bool, quiet: bool) -> Level {
 }
 
 /// Install the stderr tracing subscriber (also captures repose-ssh `log`
-/// events via the tracing-log bridge). ANSI is disabled for `--no-color`
-/// or a non-empty `NO_COLOR`, matching Python's `log_no_color`.
-fn init_logging(debug: bool, quiet: bool, no_color: bool) {
-    let ansi = !no_color && std::env::var_os("NO_COLOR").is_none_or(|v| v.is_empty());
+/// events via the tracing-log bridge). ANSI follows the same
+/// [`resolve_color`] decision as stdout — `--no-color`/`--color=never` force
+/// off, `--color=always` forces on, `auto` colors only when stderr is a TTY
+/// (honoring `NO_COLOR`/`COLOR`) — so the two documented aliases cannot
+/// diverge and piped logs stay clean.
+fn init_logging(debug: bool, quiet: bool, no_color: bool, color: Color) {
+    let ansi = resolve_color(no_color, color, std::io::stderr().is_terminal());
     let _ = tracing_subscriber::fmt()
         .with_max_level(log_level(debug, quiet))
         .with_writer(std::io::stderr)
@@ -327,10 +330,11 @@ fn init_logging(debug: bool, quiet: bool, no_color: bool) {
         .try_init();
 }
 
-/// Resolve the effective color decision for stdout `list-*` output, mirroring
+/// Resolve the effective color decision, mirroring
 /// `repose_core::console::Console::use_color`: `--no-color`/`--color=never`
 /// force off, `--color=always` forces on, and `auto` honors `NO_COLOR`, then
-/// `COLOR`, then `is_tty`.
+/// `COLOR`, then `is_tty`. Used for both the stdout `list-*` display output
+/// and the stderr log subscriber (each with its own TTY bit).
 fn resolve_color(no_color: bool, color: Color, is_tty: bool) -> bool {
     if no_color {
         return false;

--- a/crates/repose-cli/tests/cli.rs
+++ b/crates/repose-cli/tests/cli.rs
@@ -6,6 +6,10 @@ fn repose(args: &[&str]) -> Output {
         .args(args)
         .env_remove("COLOR")
         .env_remove("NO_COLOR")
+        // Keep the log-color tests hermetic: a cert store pointed at empty
+        // locations would suppress the debug line they rely on.
+        .env_remove("SSL_CERT_FILE")
+        .env_remove("SSL_CERT_DIR")
         .output()
         .expect("repose process should start")
 }
@@ -149,6 +153,46 @@ fn color_always_flag_colorizes_known_products_label() {
         "{}",
         stdout(&output)
     );
+}
+
+#[test]
+fn color_never_disables_ansi_in_stderr_logs() {
+    // -d emits at least one DEBUG log line ("Loaded N CA root certificates"
+    // from rustls-platform-verifier — a third-party string, unix-only; the
+    // tests knowingly couple to it). --color=never must keep stderr
+    // ANSI-free, exactly like its documented alias --no-color.
+    let output = repose(&[
+        "-d",
+        "--color=never",
+        "add",
+        "-t",
+        "nonexistent.invalid",
+        "--no-probe",
+        "SLES",
+    ]);
+    let logs = stderr(&output);
+    assert!(
+        logs.contains("DEBUG"),
+        "expected a debug log record: {logs:?}"
+    );
+    assert!(
+        !logs.contains('\u{1b}'),
+        "no ANSI escapes allowed: {logs:?}"
+    );
+}
+
+#[test]
+fn color_always_enables_ansi_in_stderr_logs_even_when_piped() {
+    let output = repose(&[
+        "-d",
+        "--color=always",
+        "add",
+        "-t",
+        "nonexistent.invalid",
+        "--no-probe",
+        "SLES",
+    ]);
+    assert!(stderr(&output).contains('\u{1b}'));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`init_logging` set the tracing subscriber's ANSI flag from only `--no-color`/`NO_COLOR`, ignoring `--color` and stderr's TTY state:

- `repose -d --color=never ... 2>err.txt` still wrote `\x1b[` escapes — while the flag is documented as an exact alias of `--no-color` (which was clean), so the two documented aliases diverged.
- Default `auto` (documented as "color on a TTY unless NO_COLOR") colorized logs even when stderr was piped.

Repro: `repose -d --color=never add -t nonexistent.invalid --no-probe SLES 2>&1 | cat -v` → `^[[34mDEBUG^[[0m ...`.

## Fix

The subscriber now shares the same `resolve_color` decision as stdout, computed against stderr's own TTY bit: `never`/`--no-color` force off, `always` forces on, `auto` colors only on a TTY (honoring `NO_COLOR`/`COLOR`).

One deliberate semantic alignment to call out: `--color=always` + `NO_COLOR` now colors stderr logs, matching how stdout already resolved that combination.

## Tests

New subprocess tests: `--color=never -d` asserts an ANSI-free stderr against a real debug log record; `--color=always -d` asserts color survives piping. Cert-store env vars are scrubbed for hermeticity. Full workspace gate green: `cargo test --workspace --all-targets --locked`, clippy `-D warnings`, `cargo deny check`, `scripts/check-rust-layering.sh`.