### PR TITLE
ci: pin remaining GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,11 +23,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-    # dtolnay/rust-toolchain pins the Rust version in the git ref (e.g.
-    # @1.96 installs Rust 1.96), not the action's own release version.
-    # Dependabot reads the ref as semver and "bumps" it to nonexistent
-    # Rust toolchains (e.g. 1.100). The MSRV must only change deliberately
-    # alongside Cargo.toml `rust-version` and rust-toolchain.toml.
+    # dtolnay/rust-toolchain is pinned to a master-branch commit SHA and the
+    # toolchain is selected via its `toolchain:` input; the action has no
+    # semver releases for Dependabot to bump to. The MSRV must only change
+    # deliberately alongside Cargo.toml `rust-version` and rust-toolchain.toml.
     ignore:
       - dependency-name: "dtolnay/rust-toolchain"
     groups:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # Pin a commit from the action's master branch (commits of the
+        # toolchain branches are garbage-collected upstream) and select the
+        # toolchain via the input instead of the ref.
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
+          toolchain: stable
           components: rustfmt, clippy
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
@@ -54,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25  # v2
         with:
           manifest-path: Cargo.toml
           command: check
@@ -67,8 +71,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
+          toolchain: stable
           components: llvm-tools-preview
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
@@ -97,7 +102,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
+        with:
+          toolchain: stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
@@ -117,7 +124,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
+        with:
+          toolchain: stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
@@ -144,7 +153,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install Rust toolchain (MSRV)
-        uses: dtolnay/rust-toolchain@1.96
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
+        with:
+          # Keep in sync with rust-version in Cargo.toml and
+          # rust-toolchain.toml.
+          toolchain: "1.96"
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,11 +32,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
       - name: Analyze
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
+        with:
+          toolchain: stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
+        with:
+          toolchain: stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:


### PR DESCRIPTION
## Problem

OSSF Scorecard flags 10 workflow refs under **Pinned-Dependencies** (open alerts #8–#17): every other action in the repo is already pinned by full-length SHA, but these still float by tag/branch:

- `dtolnay/rust-toolchain@stable` (×5) and `@1.96` (×1) in ci.yml, docs.yml, release.yml
- `EmbarkStudios/cargo-deny-action@v2` in ci.yml
- `github/codeql-action/init@v4` and `analyze@v4` in codeql.yml

## Fix

- **rust-toolchain**: pin the master-branch HEAD commit (`2c7215f`) — per the action's README, commits of the toolchain branches (`stable`, `1.96`) are not in master's history and eventually get garbage-collected, so a SHA pin must come from master. The toolchain is now selected via the documented `toolchain:` input instead of the ref. Behavior is unchanged: `stable` still floats, the MSRV job still resolves `1.96` to the latest 1.96.x via rustup.
- **cargo-deny-action / codeql-action**: pin the commits the `v2`/`v4` annotated tags resolve to.

Dependabot (already configured for `github-actions`, weekly) will keep the newly pinned SHAs current, same as the previously pinned actions. `dtolnay/rust-toolchain` stays in the dependabot `ignore` list — it publishes no semver releases to bump to — with an updated comment matching the new pinning style.

## Validation

- All workflow YAML + dependabot.yml parse cleanly; a repo-wide scan confirms zero remaining non-SHA `uses:` refs.
- The PR's own CI run exercises every changed job (ci, codeql, docs), validating the pinned SHAs end-to-end.