### PR TITLE
ci: fuzz repose-core parsers with ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,15 @@
+# ClusterFuzzLite build image for the cargo-fuzz targets in fuzz/.
+# Digest-pinned like every other external dependency; v1 currently aliases
+# latest.
+FROM gcr.io/oss-fuzz-base/base-builder-rust:v1@sha256:8a5b2b370c7778ce0190986e487dde952aa1d80496721f5647a3f11838a00a1c
+# The pinned builder ships nightly-2025-09-05 (rustc 1.91), which is older
+# than the workspace MSRV (rust-version = "1.96"). Install a newer dated
+# nightly for the fuzz build; -Zsanitizer needs nightly, so the repo's
+# stable toolchain pin is not an option here. The base image selects its
+# toolchain through the RUSTUP_TOOLCHAIN env var, which shadows
+# `rustup default`, so override the env var.
+RUN rustup toolchain install nightly-2026-07-01 --profile minimal
+ENV RUSTUP_TOOLCHAIN=nightly-2026-07-01-x86_64-unknown-linux-gnu
+COPY . $SRC/repose
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/repose

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eu
+# oss-fuzz/ClusterFuzzLite build contract: build every cargo-fuzz target and
+# place the resulting binaries in $OUT. cargo-fuzz comes preinstalled in the
+# base-builder-rust image and picks up fuzz/ automatically.
+cargo fuzz build
+find fuzz/target/x86_64-unknown-linux-gnu/release -maxdepth 1 -type f -executable ! -name '*.d' -exec cp -t "$OUT" {} +

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: rust

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,19 @@
 !tests/vectors/refhosts/sles-16-0/products.d/
 !tests/vectors/refhosts/sles-16-0/products.d/*.prod
 !tests/vectors/refhosts/sles-16-0/zypper-x-lr.xml
+# ClusterFuzzLite fuzz build context (.clusterfuzzlite/Dockerfile). Kept
+# minimal and deliberately excludes rust-toolchain.toml so the builder
+# image's nightly toolchain is used.
+!/.clusterfuzzlite/
+!/.clusterfuzzlite/Dockerfile
+!/.clusterfuzzlite/build.sh
+!/.clusterfuzzlite/project.yaml
+!/Cargo.toml
+!/crates/
+!/crates/repose-core/
+!/crates/repose-ssh/
+!/crates/repose-cli/
+!/fuzz/
+!/fuzz/Cargo.toml
+!/fuzz/fuzz_targets/
+!/fuzz/fuzz_targets/*.rs

--- a/.github/workflows/cflite_fuzz.yml
+++ b/.github/workflows/cflite_fuzz.yml
@@ -1,0 +1,41 @@
+---
+name: fuzz
+# ClusterFuzzLite: builds the cargo-fuzz targets in fuzz/ and runs each for
+# a short burst on every pull request and master push. A crash fails the
+# job and is uploaded as an artifact. Rust uses the address sanitizer.
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs, but let master runs finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Build fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          language: rust
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Run fuzzers (${{ matrix.sanitizer }})
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 300
+          mode: code-change
+          sanitizer: ${{ matrix.sanitizer }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ Cargo.lock.bak
 /tests/performance/profiles/raw/
 # Criterion's own HTML/statistics reports.
 /target/criterion/
+
+# cargo-fuzz: the fuzz crate is detached from the root workspace; ignore its
+# build dir, crash artifacts, local corpus, and lockfile.
+/fuzz/target/
+/fuzz/artifacts/
+/fuzz/corpus/
+/fuzz/Cargo.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,10 @@ crate boundaries.
   live transport behavior for `repose-ssh` integration tests.
 - The committed vectors in `tests/vectors/` define the binary's expected
   output; update them only for an intentional, documented behavior change.
+- Parser fuzz targets live in `fuzz/` (cargo-fuzz, nightly-only, detached
+  from the workspace so they do not affect the MSRV, `Cargo.lock`, or
+  `cargo deny`). CI runs them via ClusterFuzzLite (the `fuzz` workflow);
+  locally use `cargo +nightly fuzz run <target>`.
 - A dependency change must update `Cargo.lock`, preserve the MSRV, and pass
   `cargo deny check`. Prefer the smallest compatible version change; do not
   run a broad `cargo update` as part of an unrelated change.

--- a/crates/repose-core/src/lib.rs
+++ b/crates/repose-core/src/lib.rs
@@ -19,7 +19,7 @@ pub mod repoq;
 pub(crate) mod shell;
 pub mod template;
 pub mod traits;
-pub(crate) mod transform;
+pub mod transform;
 pub mod types;
 
 /// Crate version string (workspace version).

--- a/crates/repose-core/src/product_parse.rs
+++ b/crates/repose-core/src/product_parse.rs
@@ -43,7 +43,7 @@ fn field_index(tag: &[u8]) -> Option<usize> {
 /// Like ElementTree's `.text`, a field's value is the concatenation of the
 /// character data — text, resolved entity/char references, CDATA — between
 /// its start tag and its first child element (comments do not interrupt it).
-fn parse_prod_xml(xml: &str, _filename: &str) -> Option<Product> {
+pub fn parse_prod_xml(xml: &str, _filename: &str) -> Option<Product> {
     let mut reader = Reader::from_str(xml);
     let mut buf = Vec::new();
     // Per-field committed `.text` (index shape from `field_index`). `Some("")`
@@ -157,7 +157,7 @@ fn parse_prod_xml(xml: &str, _filename: &str) -> Option<Product> {
 }
 
 /// Parse `/etc/os-release` body into (name, version, arch).
-fn parse_os_release(text: &str) -> (String, String, String) {
+pub fn parse_os_release(text: &str) -> (String, String, String) {
     let mut values = std::collections::BTreeMap::new();
     for raw_line in text.lines() {
         let line = raw_line.trim();

--- a/crates/repose-core/src/transform.rs
+++ b/crates/repose-core/src/transform.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 ///
 /// Mirrors Python `repose.types.refhost.transformations.transform_version_partialy`.
 #[must_use]
-pub(crate) fn transform_version_partialy(version: &str) -> Value {
+pub fn transform_version_partialy(version: &str) -> Value {
     let result = (|| {
         if version.contains('-') {
             let (major_str, minor_str) = version.split_once('-')?;

--- a/crates/repose-core/src/types.rs
+++ b/crates/repose-core/src/types.rs
@@ -54,7 +54,7 @@ impl System {
 
 /// Parse zypper repo **name** `a:b:c:d` into a product (Python `Repositories`).
 #[must_use]
-fn product_from_repo_name(name: &str, host_arch: &str) -> Option<Product> {
+pub fn product_from_repo_name(name: &str, host_arch: &str) -> Option<Product> {
     let parts: Vec<&str> = name.split(':').collect();
     if parts.len() != 4 {
         return None;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,44 @@
+# cargo-fuzz harness for repose-core parsers. Deliberately detached from the
+# root workspace (empty [workspace] table below): fuzzing requires nightly +
+# cargo-fuzz and must not affect the workspace MSRV, Cargo.lock, cargo-deny
+# graph, or the stable CI jobs. Run with:
+#   cargo +nightly fuzz run <target>
+[package]
+name = "repose-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+license = "GPL-3.0-or-later"
+
+[package.metadata]
+cargo-fuzz = true
+
+[workspace]
+
+[dependencies]
+libfuzzer-sys = "0.4"
+repose-core = { path = "../crates/repose-core" }
+
+[[bin]]
+name = "repo_xml"
+path = "fuzz_targets/repo_xml.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "prod_parse"
+path = "fuzz_targets/prod_parse.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "host_spec"
+path = "fuzz_targets/host_spec.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "transform"
+path = "fuzz_targets/transform.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/host_spec.rs
+++ b/fuzz/fuzz_targets/host_spec.rs
@@ -1,0 +1,10 @@
+//! Fuzzes the `-t/--target` host spec parser with CLI input.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(text) = std::str::from_utf8(data) {
+        let _ = repose_core::host_parse::parse_host(text);
+    }
+});

--- a/fuzz/fuzz_targets/prod_parse.rs
+++ b/fuzz/fuzz_targets/prod_parse.rs
@@ -1,0 +1,29 @@
+//! Fuzzes the `/etc/products.d/*.prod` and `os-release` parsers with
+//! host-controlled file contents.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use repose_core::product_parse::{ProdFile, parse_os_release, parse_prod_xml, parse_system};
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(text) = std::str::from_utf8(data) else {
+        return;
+    };
+    let _ = parse_prod_xml(text, "fuzz.prod");
+    let _ = parse_os_release(text);
+    // SUSE path: one synthesized addon candidate + the same bytes as the
+    // baseproduct target, base XML, and os-release content.
+    let files = [ProdFile {
+        filename: "fuzz.prod".into(),
+        xml: Some(text.to_owned()),
+    }];
+    let _ = parse_system(
+        Some(&files),
+        Some("fuzz.prod"),
+        Some(text),
+        Some(text),
+        false,
+    );
+    // Fallback path: no products.d at all, os-release only.
+    let _ = parse_system(None, None, None, Some(text), false);
+});

--- a/fuzz/fuzz_targets/repo_xml.rs
+++ b/fuzz/fuzz_targets/repo_xml.rs
@@ -1,0 +1,10 @@
+//! Fuzzes the `zypper -x lr` XML parser with host-controlled output.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(text) = std::str::from_utf8(data) {
+        let _ = repose_core::repo_parse::parse_repositories(text);
+    }
+});

--- a/fuzz/fuzz_targets/transform.rs
+++ b/fuzz/fuzz_targets/transform.rs
@@ -1,0 +1,11 @@
+//! Fuzzes the version-transform and repo-name-to-product derivation helpers.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(text) = std::str::from_utf8(data) {
+        let _ = repose_core::transform::transform_version_partialy(text);
+        let _ = repose_core::types::product_from_repo_name(text, "x86_64");
+    }
+});


### PR DESCRIPTION
## Problem

OSSF Scorecard's **Fuzzing** check scores 0: the project has no fuzzer integration, despite parsing plenty of untrusted input — XML and product files returned by managed hosts, and the `-t/--target` spec from the CLI.

## Fix

A `cargo-fuzz` harness with four targets over exactly that attack surface:

| Target | Entry points |
|---|---|
| `repo_xml` | `repo_parse::parse_repositories` (zypper `-x lr` output) |
| `prod_parse` | `parse_prod_xml`, `parse_os_release`, `parse_system` (SUSE + fallback paths) |
| `host_spec` | `host_parse::parse_host` |
| `transform` | `transform_version_partialy`, `product_from_repo_name` |

The fuzz crate is deliberately **detached from the workspace** (empty `[workspace]` table, explicit members list untouched): cargo-fuzz needs nightly, and the harness must not affect the MSRV, `Cargo.lock`, the `cargo deny` graph, or stable CI. Its build dir/corpus/lockfile are gitignored; `AGENTS.md` documents the layout.

## CI

New `fuzz` workflow: ClusterFuzzLite (SHA-pinned, like every other action) builds and runs the targets under the address sanitizer for 300s per PR / master push; a crash fails the job. This PR's own run validates the harness end-to-end. ClusterFuzzLite in `.github/workflows` is what Scorecard's Fuzzing check detects, so it closes alert #21.

## Validation

- `cargo check --manifest-path fuzz/Cargo.toml` compiles all four harnesses (stable, no instrumentation).
- Full workspace gate green and unaffected: fmt, clippy `-D warnings`, `test --workspace --all-targets --locked`, `cargo deny check`, layering script; `cargo metadata` confirms the workspace still has exactly three members.

## Public API note

The harness drives pure parsing helpers that were previously crate-private; they become public in `repose-core` with their existing docs: `parse_prod_xml`, `parse_os_release`, `product_from_repo_name`, `transform_version_partialy` (+ the `transform` module). No behavior change; workspace gates unaffected.
