### PR TITLE
ci: build and test on macOS, publish macOS release binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,34 @@ jobs:
           echo "got: $out"
           echo "$out" | grep -E '^repose version: [0-9]+\.[0-9]+\.[0-9]+$'
 
+  rust-macos:
+    # Portability check on macOS (Apple Silicon, aarch64-apple-darwin): build
+    # and test the workspace + SSH transport so the platform stays viable for
+    # release binaries. Kept lean (no fmt — formatting is platform-independent
+    # and covered by the ubuntu `rust` job).
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
+        with:
+          toolchain: stable
+          components: clippy
+      - name: Cache cargo
+        # Tag runs re-verify a release: keep them off restored build state;
+        # PR/master runs keep the cache.
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: . -> target
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+      - name: Test
+        run: cargo test --workspace --all-targets --locked
+
   rust-beta:
     # Early warning on the upcoming compiler: never blocks, but surfaces
     # new-lint and regression noise before beta becomes stable. No fmt leg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,21 @@ permissions:
   contents: read
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      # required for `gh release create`
-      contents: write
+  build:
+    name: build (${{ matrix.triple }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      # Build every platform even if one fails, so a single broken target
+      # surfaces on its own. The release job needs all legs to succeed, so a
+      # failure still blocks publishing a partial set of artifacts.
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            triple: x86_64-unknown-linux-gnu
+          - os: macos-latest  # Apple Silicon
+            triple: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -31,6 +40,7 @@ jobs:
       # build state can never influence published artifacts.
 
       - name: Verify tag matches workspace version
+        shell: bash
         run: |
           pkg="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
           if [ "$pkg" != "$GITHUB_REF_NAME" ]; then
@@ -42,21 +52,50 @@ jobs:
         run: cargo build --release --locked -p repose-cli
 
       - name: Package release artifact
+        shell: bash
         run: |
-          triple="x86_64-unknown-linux-gnu"
+          triple="${{ matrix.triple }}"
           dist="repose-${GITHUB_REF_NAME}-${triple}"
           mkdir "$dist"
           cp target/release/repose LICENSE README.md "$dist/"
           cp -r crates/repose-cli/man crates/repose-cli/completions "$dist/"
           tar czf "${dist}.tar.gz" "$dist"
-          sha256sum "${dist}.tar.gz" >"${dist}.tar.gz.sha256"
+          # shasum -a 256 exists on both the ubuntu and macOS runners and its
+          # output is compatible with `sha256sum -c`.
+          shasum -a 256 "${dist}.tar.gz" >"${dist}.tar.gz.sha256"
           echo "DIST=$dist" >>"$GITHUB_ENV"
 
+      - name: Upload build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ matrix.triple }}
+          path: |
+            ${{ env.DIST }}.tar.gz
+            ${{ env.DIST }}.tar.gz.sha256
+          if-no-files-found: error
+
+  release:
+    # Publish only after every platform built successfully, so a release never
+    # ships a partial artifact set.
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # required for `gh release create`
+      contents: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          path: dist
+          merge-multiple: true
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          # No checkout in this job, so tell gh which repo to act on.
+          GH_REPO: ${{ github.repository }}
         run: >-
           gh release create "$GITHUB_REF_NAME"
           --title "$GITHUB_REF_NAME"
           --generate-notes
-          "${DIST}.tar.gz" "${DIST}.tar.gz.sha256"
+          dist/*

--- a/crates/repose-cli/tests/cli.rs
+++ b/crates/repose-cli/tests/cli.rs
@@ -155,12 +155,19 @@ fn color_always_flag_colorizes_known_products_label() {
     );
 }
 
+// Linux-only: both stderr-log color tests below rely on `-d` emitting at least
+// one DEBUG record. The only such record for these no-network commands is
+// "Loaded N CA root certificates" from rustls-platform-verifier — and that
+// string is emitted solely on the Linux/BSD path that reads CA files from disk.
+// On macOS the verifier uses Apple's Security framework, and on Windows the
+// CryptoAPI, neither of which logs it; the commands then produce no DEBUG line
+// and there is nothing to (not) colorize. The tests knowingly couple to this
+// third-party string, so gate them to the platform where it exists.
+#[cfg(target_os = "linux")]
 #[test]
 fn color_never_disables_ansi_in_stderr_logs() {
-    // -d emits at least one DEBUG log line ("Loaded N CA root certificates"
-    // from rustls-platform-verifier — a third-party string, unix-only; the
-    // tests knowingly couple to it). --color=never must keep stderr
-    // ANSI-free, exactly like its documented alias --no-color.
+    // --color=never must keep stderr ANSI-free, exactly like its documented
+    // alias --no-color.
     let output = repose(&[
         "-d",
         "--color=never",
@@ -181,6 +188,7 @@ fn color_never_disables_ansi_in_stderr_logs() {
     );
 }
 
+#[cfg(target_os = "linux")]
 #[test]
 fn color_always_enables_ansi_in_stderr_logs_even_when_piped() {
     let output = repose(&[


### PR DESCRIPTION
## Summary

Add macOS support to CI and release publishing.

- **CI: macOS build/test leg** — new `rust-macos` job on `macos-latest`
  (aarch64-apple-darwin) running clippy + the full test suite, so the platform
  stays viable as a portability early-warning. Kept lean (no fmt; formatting is
  platform-independent and covered by the ubuntu `rust` job).
- **Release: publish macOS binaries** — `release.yml` becomes a build matrix
  (`x86_64-unknown-linux-gnu` + `aarch64-apple-darwin`) that uploads per-triple
  artifacts, plus a publish job that gathers them into one GitHub release.
  Builds stay hermetic (no cargo cache), every leg re-verifies the tag matches
  the workspace version, and the release publishes only if all legs succeed, so
  a partial artifact set can never ship. `sha256` generation switches to
  `shasum -a 256` for parity across the ubuntu and macOS runners.
- **Test portability fix** — two stderr-log color tests assert on a DEBUG
  record that only the Linux/BSD CA-file path of `rustls-platform-verifier`
  emits (`"Loaded N CA root certificates"`); it is absent on macOS
  (Security.framework) and Windows (CryptoAPI), so the commands emit no DEBUG
  output and both assertions fail. Gated to `target_os = "linux"` where the
  coupling holds; the misleading "unix-only" comment is corrected. Linux
  coverage is unchanged.

## Testing

Validated on a fork run: the `rust-macos` job is green — clippy and the full
test suite pass on Apple Silicon. Linux jobs remain green. `release.yml` is
tag-triggered and not exercised end-to-end here (that would cut a real
release); it is statically validated and reuses the same `cargo build --release`
command proven to compile on the macOS runner.
