### PR TITLE
docs: retire references to documents outside this repository

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -82,7 +82,7 @@ Run these commands from the repository root.
 
 ## Policy notes
 
-- **Layering:** `repose-core` must never depend on `repose-ssh` or `russh` (enforced more strictly in PR0.5).
+- **Layering:** `repose-core` must never depend on `repose-ssh` or `russh`; `scripts/check-rust-layering.sh` enforces it, and CI runs it.
 - **Single SSH backend:** `deny.toml` bans `ssh2` / `libssh2-sys` / async-ssh2-* crates.
 - **Path deps** pin the workspace version (`version = "3.1.1"`) so `cargo-deny` `wildcards = "deny"` accepts them.
 - **Binary name:** `repose` (replace strategy; no `repose-rs`).

--- a/crates/repose-core/Cargo.toml
+++ b/crates/repose-core/Cargo.toml
@@ -25,8 +25,8 @@ thiserror = "2"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "http2"] }
 # Bounded-concurrency probe fan-out (StreamExt::buffered)
 futures-util = { version = "0.3", default-features = false, features = ["std", "async-await"] }
-# Command-scoped semaphores bounding host-operation (P1 step 13-18) and
-# probe (P1 step 19-23) fan-out. Already present transitively via reqwest's
+# Command-scoped semaphores bounding host-operation and
+# probe fan-out. Already present transitively via reqwest's
 # async HTTP client — this only makes the already-in-tree crate directly
 # usable, with the minimal `sync` feature (no added runtime/IO/macros).
 tokio = { version = "1", default-features = false, features = ["sync"] }

--- a/crates/repose-core/benches/fleet.rs
+++ b/crates/repose-core/benches/fleet.rs
@@ -1,4 +1,4 @@
-//! P0.3 fleet-scale benchmark: `run_add` / `run_install` / `run_list_products`
+//! Fleet-scale benchmark: `run_add` / `run_install` / `run_list_products`
 //! at 1/20/100 hosts, including repeated-URL and slow-host variants.
 //!
 //! Labels honestly: this measures local command-algorithm overhead against
@@ -174,12 +174,13 @@ fn bench_list_products(c: &mut Criterion) {
     group.finish();
 }
 
-/// P1 decision-gate evidence (step 1): every host's connect/read_products/
-/// probe/run/close is gated behind one shared gate per phase, released only
-/// once the whole fleet has observably entered it — proving the mock
-/// harness exposes true fleet-wide concurrency at 20/100 hosts rather than
-/// the misleading `peak_operations == 1` an ungated `join_all` produces in
-/// one poll (see `tests/performance/README.md`).
+/// Decision-gate evidence for `tests/performance/p1-limit-decision.md`:
+/// every host's connect/read_products/probe/run/close is gated behind one
+/// shared gate per phase, released only once the whole fleet has observably
+/// entered it — proving the mock harness exposes true fleet-wide
+/// concurrency at 20/100 hosts rather than the misleading `peak_operations
+/// == 1` an ungated `join_all` produces in one poll (see
+/// `tests/performance/README.md`).
 fn bench_gated_fleet_admission(c: &mut Criterion) {
     let rt = runtime();
     let mut group = c.benchmark_group("fleet_gated_admission");
@@ -203,15 +204,15 @@ fn bench_gated_fleet_admission(c: &mut Criterion) {
     group.finish();
 }
 
-/// P1 decision-gate evidence (step 1): admit `host_count` synthetic
-/// operations of fixed cost `op_cost` through a bounded unordered stream at
-/// `cap` concurrent slots. Independent of any mock/SSH implementation —
-/// this is the plain queueing-theory curve (`~ceil(host_count / cap) *
-/// op_cost`) that informs how low a host-operation cap can go before it
-/// materially serializes a 100-host fleet. See
-/// `tests/performance/p1-limit-decision.md` for the `op_cost` calibration
-/// against measured SSH connect+auth+command latency and the resulting
-/// table of caps.
+/// Decision-gate evidence for `tests/performance/p1-limit-decision.md`:
+/// admit `host_count` synthetic operations of fixed cost `op_cost` through
+/// a bounded unordered stream at `cap` concurrent slots. Independent of any
+/// mock/SSH implementation — this is the plain queueing-theory curve
+/// (`~ceil(host_count / cap) * op_cost`) that informs how low a
+/// host-operation cap can go before it materially serializes a 100-host
+/// fleet. See `tests/performance/p1-limit-decision.md` for the `op_cost`
+/// calibration against measured SSH connect+auth+command latency and the
+/// resulting table of caps.
 async fn bounded_fanout_cost(host_count: usize, op_cost: Duration, cap: usize) {
     use futures_util::StreamExt;
     futures_util::stream::iter(0..host_count)

--- a/crates/repose-core/benches/support/mod.rs
+++ b/crates/repose-core/benches/support/mod.rs
@@ -1,5 +1,5 @@
-//! Fleet-scenario builders shared by the P0.3 Criterion benchmark
-//! (`benches/fleet.rs`) and the P0.1 baseline-report harness
+//! Fleet-scenario builders shared by the Criterion benchmark
+//! (`benches/fleet.rs`) and the baseline-report harness
 //! (`examples/baseline_report.rs`), which includes this file verbatim via
 //! `#[path]` since Cargo does not let example/bench targets share a module
 //! directly. Not part of the published `repose_core` crate.
@@ -180,27 +180,28 @@ async fn wait_until(mut pred: impl FnMut() -> bool) {
     panic!("wait_until: condition never became true (deadlock guard)");
 }
 
-/// P1 decision-gate evidence (step 1): run `add` over `host_count` fresh
-/// hosts with every `connect` / `read_products` / `run` / `close` operation
-/// and every probe gated behind one shared gate per phase, released only
-/// once every host has observably entered that phase and drained only once
-/// every host has observably left it.
+/// Decision-gate evidence for `tests/performance/p1-limit-decision.md`: run
+/// `add` over `host_count` fresh hosts with every `connect` /
+/// `read_products` / `run` / `close` operation and every probe gated behind
+/// one shared gate per phase, released only once every host has observably
+/// entered that phase and drained only once every host has observably left
+/// it.
 ///
 /// P0's `join_all`-driven fan-out completes an ungated mock operation in a
 /// single poll, so `peak_operations` reports `1` at any host count even
 /// though the fan-out code path is exercised (see
 /// `tests/performance/README.md`'s documented limitation). This proves the
 /// harness itself can expose true fleet-wide concurrency at 20/100 hosts —
-/// evidence that a later bounded-fan-out regression test
-/// (`peak_operations <= cap`) measures something real rather than an
-/// artifact of synchronous completion.
+/// evidence that a later bounded-fan-out regression test (`peak_operations
+/// <= cap`) measures something real rather than an artifact of synchronous
+/// completion.
 #[allow(dead_code)]
 pub async fn run_fully_gated_add(host_count: usize) -> (ExitCode, MockMetricsSnapshot) {
     let metrics = MockMetrics::new();
     // This harness proves the *gate/metrics machinery* can expose true
-    // fleet-wide concurrency (P1 step 1's evidence) — a concern distinct
-    // from the now-implemented `host_operation_limit` cap itself (proven
-    // separately by `mock::tests::bounded_run_all_never_exceeds_the_configured_limit`).
+    // fleet-wide concurrency — a concern distinct from the now-implemented
+    // `host_operation_limit` cap itself (proven separately by
+    // `mock::tests::bounded_run_all_never_exceeds_the_configured_limit`).
     // Override the limit so this harness keeps measuring the former.
     let mut group =
         MockHostGroup::new().with_host_operation_limit(NonZeroUsize::new(host_count).unwrap());
@@ -287,7 +288,7 @@ pub async fn run_fully_gated_add(host_count: usize) -> (ExitCode, MockMetricsSna
 
 /// One documented async runtime boundary shared by every scenario/command
 /// invocation, so benchmark/report comparisons attribute cost consistently
-/// rather than to runtime construction (see P0.3 assumptions).
+/// rather than to runtime construction.
 #[must_use]
 pub fn runtime() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_current_thread()

--- a/crates/repose-core/examples/baseline_report.rs
+++ b/crates/repose-core/examples/baseline_report.rs
@@ -12,7 +12,7 @@
 //! Every observed result is checked against the workload's reviewed
 //! `expect` block *before* any timing is printed — a changed command
 //! history, count, or exit code fails the run instead of silently shipping
-//! a report (P0.1 plan item 3 / P0.3 plan item 4).
+//! a report.
 
 #[path = "../benches/support/mod.rs"]
 mod support;

--- a/crates/repose-core/src/commands/add.rs
+++ b/crates/repose-core/src/commands/add.rs
@@ -24,17 +24,17 @@ pub async fn run_add<W: Write>(
     group.read_products().await;
 
     // Fan out per-host work concurrently, one future per host; `join_all`
-    // preserves key order for exit aggregation. Bounded by a semaphore (P1
-    // step 13) rather than `.buffered(cap)`: every future is created up
-    // front and races for a permit, so one slow host holding a permit
-    // never blocks a *different* freed permit from admitting a later host
-    // — the same non-head-of-line-blocking property `buffer_unordered`
-    // would give, without needing an index/sort step, since `join_all`'s
-    // output stays in input (key) order regardless of acquisition order.
+    // preserves key order for exit aggregation. Bounded by a semaphore
+    // rather than `.buffered(cap)`: every future is created up front and
+    // races for a permit, so one slow host holding a permit never blocks a
+    // *different* freed permit from admitting a later host — the same
+    // non-head-of-line-blocking property `buffer_unordered` would give,
+    // without needing an index/sort step, since `join_all`'s output stays
+    // in input (key) order regardless of acquisition order.
     let cap = group.host_operation_limit().get();
     let semaphore = Arc::new(Semaphore::new(cap));
-    // One fleet-wide probe budget (P1 step 21) shared by every host worker,
-    // replacing the old per-host `min(16, n)` local cap.
+    // One fleet-wide probe budget shared by every host worker, replacing
+    // the old per-host `min(16, n)` local cap.
     let probe_budget = ProbeBudget::new(opts.probe_concurrency_limit);
     let console = SharedConsole::new(console);
     let mut results = join_all(group.hosts_mut().into_iter().map(|host| {
@@ -299,10 +299,10 @@ mod tests {
         assert!(buf.0.contains("zypper") && buf.0.contains("ar"));
     }
 
-    /// P1 step 13: a configured host-operation limit below the host count
-    /// bounds the per-host worker semaphore, not just `Host::run` itself —
-    /// while every host still runs exactly once and command/output vectors
-    /// are unchanged.
+    /// A configured host-operation limit below the host count bounds the
+    /// per-host worker semaphore, not just `Host::run` itself — while every
+    /// host still runs exactly once and command/output vectors are
+    /// unchanged.
     #[tokio::test]
     async fn bounded_add_never_exceeds_the_configured_host_operation_limit() {
         use crate::mock::{MockGate, MockMetrics, MockOpKind};
@@ -369,10 +369,10 @@ mod tests {
         }
     }
 
-    /// P1 step 21: the probe budget is *fleet*-wide, not per-host — with 3
-    /// hosts each resolving 2 candidates (6 possible concurrent probes),
-    /// a global cap of 2 must still hold, and repository order / command
-    /// history stay unchanged for every host.
+    /// The probe budget is *fleet*-wide, not per-host — with 3 hosts each
+    /// resolving 2 candidates (6 possible concurrent probes), a global cap
+    /// of 2 must still hold, and repository order / command history stay
+    /// unchanged for every host.
     #[tokio::test]
     async fn bounded_add_probe_budget_is_fleet_wide_not_per_host() {
         use crate::mock::{MetricProbe, MockGate, MockMetrics};

--- a/crates/repose-core/src/commands/clear.rs
+++ b/crates/repose-core/src/commands/clear.rs
@@ -19,10 +19,10 @@ pub async fn run_clear<W: Write>(
     group.read_repos().await;
 
     // Fan out per-host work concurrently, one future per host; `join_all`
-    // preserves key order for exit aggregation. Bounded by a semaphore (P1
-    // step 17) — see `add.rs`'s `run_add` for why this avoids both the
-    // head-of-line blocking `.buffered(cap)` would cause and the
-    // index/sort step `buffer_unordered` would need.
+    // preserves key order for exit aggregation. Bounded by a semaphore —
+    // see `add.rs`'s `run_add` for why this avoids both the head-of-line
+    // blocking `.buffered(cap)` would cause and the index/sort step
+    // `buffer_unordered` would need.
     let cap = group.host_operation_limit().get();
     let semaphore = Arc::new(Semaphore::new(cap));
     let console = SharedConsole::new(console);
@@ -207,9 +207,9 @@ mod tests {
         assert!(!ran.iter().any(|c| c.contains(" rr")), "ran: {ran:?}");
     }
 
-    /// P1 step 17: a configured host-operation limit below the host count
-    /// bounds the per-host worker semaphore, while every host still
-    /// clears exactly once.
+    /// A configured host-operation limit below the host count bounds the
+    /// per-host worker semaphore, while every host still clears exactly
+    /// once.
     #[tokio::test]
     async fn bounded_clear_never_exceeds_the_configured_host_operation_limit() {
         use crate::mock::{MockGate, MockMetrics, MockOpKind};

--- a/crates/repose-core/src/commands/install.rs
+++ b/crates/repose-core/src/commands/install.rs
@@ -19,7 +19,7 @@ use tokio::sync::Semaphore;
 ///
 /// Both the product-install argv (the product names) and the per-repo `ar`
 /// order (their repo lists, flattened) follow this order. A sorted
-/// `BTreeMap` would diverge — design delta #4 permits a stable sort only for
+/// `BTreeMap` would diverge — a stable sort is permitted only for
 /// *set*-sourced multi-alias commands, not this one.
 type ProductRepos = Vec<(String, Vec<Repos>)>;
 
@@ -53,14 +53,14 @@ pub async fn run_install<W: Write>(
     group.read_repos().await;
 
     // Fan out per-host work concurrently, one future per host; `join_all`
-    // preserves key order for exit aggregation. Bounded by a semaphore (P1
-    // step 14) — see `add.rs`'s `run_add` for why this avoids both the
-    // head-of-line blocking `.buffered(cap)` would cause and the
-    // index/sort step `buffer_unordered` would need.
+    // preserves key order for exit aggregation. Bounded by a semaphore —
+    // see `add.rs`'s `run_add` for why this avoids both the head-of-line
+    // blocking `.buffered(cap)` would cause and the index/sort step
+    // `buffer_unordered` would need.
     let cap = group.host_operation_limit().get();
     let semaphore = Arc::new(Semaphore::new(cap));
-    // One fleet-wide probe budget (P1 step 22) shared by every host worker,
-    // replacing the old per-host `min(16, n)` local cap.
+    // One fleet-wide probe budget shared by every host worker, replacing
+    // the old per-host `min(16, n)` local cap.
     let probe_budget = ProbeBudget::new(opts.probe_concurrency_limit);
     let console = SharedConsole::new(console);
     let mut results = join_all(group.hosts_mut().into_iter().map(|host| {
@@ -426,9 +426,9 @@ mod tests {
         assert_eq!(code, c.exit_code());
     }
 
-    /// P1 step 14: a configured host-operation limit below the host count
-    /// bounds the per-host worker semaphore, while every host still
-    /// installs exactly once.
+    /// A configured host-operation limit below the host count bounds the
+    /// per-host worker semaphore, while every host still installs exactly
+    /// once.
     #[tokio::test]
     async fn bounded_install_never_exceeds_the_configured_host_operation_limit() {
         use crate::mock::{MockGate, MockMetrics, MockOpKind};

--- a/crates/repose-core/src/commands/mod.rs
+++ b/crates/repose-core/src/commands/mod.rs
@@ -298,13 +298,13 @@ pub(crate) fn report_pruned<W: Write>(
     results.extend(std::iter::repeat_n(false, pruned.len()));
 }
 
-/// Fleet-wide URL-liveness probe concurrency budget (P1 steps 19–23),
-/// created once per CLI command invocation and shared by every host
-/// worker's [`partition_live`]/[`filter_live`] calls. Replaces the old
-/// per-host `min(16, n)` cap, which multiplied to `16 * host_count`
-/// in-flight probes fleet-wide with no ceiling at all — permits delay
-/// probe start only; they neither deduplicate nor cache calls, so probe
-/// counts and per-host order are unchanged.
+/// Fleet-wide URL-liveness probe concurrency budget, created once per CLI
+/// command invocation and shared by every host worker's
+/// [`partition_live`]/[`filter_live`] calls. Replaces the old per-host
+/// `min(16, n)` cap, which multiplied to `16 * host_count` in-flight probes
+/// fleet-wide with no ceiling at all — permits delay probe start only; they
+/// neither deduplicate nor cache calls, so probe counts and per-host order
+/// are unchanged.
 #[derive(Clone)]
 pub(crate) struct ProbeBudget(Arc<Semaphore>);
 
@@ -332,11 +332,11 @@ pub(crate) async fn partition_live(
     if no_probe || repos.is_empty() {
         return (repos, Vec::new());
     }
-    // One *global* permit per probe (P1 step 20) instead of the old
-    // per-host `min(16, n)` local cap: the `buffered` window is sized to
-    // this host's own candidate count (never a fleet-wide bottleneck by
-    // itself), and `probe_budget` is the only real throttle, shared by
-    // every concurrently-running host worker's own call to this function.
+    // One *global* permit per probe instead of the old per-host
+    // `min(16, n)` local cap: the `buffered` window is sized to this host's
+    // own candidate count (never a fleet-wide bottleneck by itself), and
+    // `probe_budget` is the only real throttle, shared by every
+    // concurrently-running host worker's own call to this function.
     let window = repos.len();
     let alive: Vec<bool> = futures_util::stream::iter(repos.iter())
         .map(|r| async {
@@ -430,8 +430,8 @@ mod filter_tests {
         assert_eq!(live.len(), 2);
     }
 
-    /// P1 step 20: the global probe budget bounds total in-flight probes
-    /// across candidates, and current in-flight probes return to zero.
+    /// The global probe budget bounds total in-flight probes across
+    /// candidates, and current in-flight probes return to zero.
     #[tokio::test]
     async fn probe_budget_bounds_concurrent_probes_and_leaves_zero_in_flight() {
         use crate::mock::{MetricProbe, MockGate, MockMetrics};

--- a/crates/repose-core/src/commands/remove.rs
+++ b/crates/repose-core/src/commands/remove.rs
@@ -69,10 +69,10 @@ pub async fn run_remove<W: Write>(
     group.parse_repos().await;
 
     // Fan out per-host work concurrently, one future per host; `join_all`
-    // preserves key order for exit aggregation. Bounded by a semaphore (P1
-    // step 16) — see `add.rs`'s `run_add` for why this avoids both the
-    // head-of-line blocking `.buffered(cap)` would cause and the
-    // index/sort step `buffer_unordered` would need.
+    // preserves key order for exit aggregation. Bounded by a semaphore —
+    // see `add.rs`'s `run_add` for why this avoids both the head-of-line
+    // blocking `.buffered(cap)` would cause and the index/sort step
+    // `buffer_unordered` would need.
     let cap = group.host_operation_limit().get();
     let semaphore = Arc::new(Semaphore::new(cap));
     let console = SharedConsole::new(console);
@@ -297,9 +297,9 @@ mod tests {
         }
     }
 
-    /// P1 step 16: a configured host-operation limit below the host count
-    /// bounds the per-host worker semaphore, while every host still
-    /// removes exactly once.
+    /// A configured host-operation limit below the host count bounds the
+    /// per-host worker semaphore, while every host still removes exactly
+    /// once.
     #[tokio::test]
     async fn bounded_remove_never_exceeds_the_configured_host_operation_limit() {
         use crate::mock::MockGate;

--- a/crates/repose-core/src/commands/reset.rs
+++ b/crates/repose-core/src/commands/reset.rs
@@ -25,14 +25,14 @@ pub async fn run_reset<W: Write>(
     group.read_repos().await;
 
     // Fan out per-host work concurrently, one future per host; `join_all`
-    // preserves key order for exit aggregation. Bounded by a semaphore (P1
-    // step 15) — see `add.rs`'s `run_add` for why this avoids both the
-    // head-of-line blocking `.buffered(cap)` would cause and the
-    // index/sort step `buffer_unordered` would need.
+    // preserves key order for exit aggregation. Bounded by a semaphore —
+    // see `add.rs`'s `run_add` for why this avoids both the head-of-line
+    // blocking `.buffered(cap)` would cause and the index/sort step
+    // `buffer_unordered` would need.
     let cap = group.host_operation_limit().get();
     let semaphore = Arc::new(Semaphore::new(cap));
-    // One fleet-wide probe budget (P1 step 23) shared by every host worker,
-    // replacing the old per-host `min(16, n)` local cap.
+    // One fleet-wide probe budget shared by every host worker, replacing
+    // the old per-host `min(16, n)` local cap.
     let probe_budget = ProbeBudget::new(opts.probe_concurrency_limit);
     let console = SharedConsole::new(console);
     let mut results = join_all(group.hosts_mut().into_iter().map(|host| {
@@ -347,9 +347,9 @@ mod tests {
         assert_eq!(code, c.exit_code());
     }
 
-    /// P1 step 15: a configured host-operation limit below the host count
-    /// bounds the per-host worker semaphore, while every host still resets
-    /// exactly once.
+    /// A configured host-operation limit below the host count bounds the
+    /// per-host worker semaphore, while every host still resets exactly
+    /// once.
     #[tokio::test]
     async fn bounded_reset_never_exceeds_the_configured_host_operation_limit() {
         use crate::mock::{MockGate, MockMetrics, MockOpKind};

--- a/crates/repose-core/src/commands/uninstall.rs
+++ b/crates/repose-core/src/commands/uninstall.rs
@@ -32,10 +32,10 @@ pub async fn run_uninstall<W: Write>(
     group.parse_repos().await;
 
     // Fan out per-host work concurrently, one future per host; `join_all`
-    // preserves key order for exit aggregation. Bounded by a semaphore (P1
-    // step 18) — see `add.rs`'s `run_add` for why this avoids both the
-    // head-of-line blocking `.buffered(cap)` would cause and the
-    // index/sort step `buffer_unordered` would need.
+    // preserves key order for exit aggregation. Bounded by a semaphore —
+    // see `add.rs`'s `run_add` for why this avoids both the head-of-line
+    // blocking `.buffered(cap)` would cause and the index/sort step
+    // `buffer_unordered` would need.
     let cap = group.host_operation_limit().get();
     let semaphore = Arc::new(Semaphore::new(cap));
     let console = SharedConsole::new(console);
@@ -371,9 +371,9 @@ mod tests {
         assert_eq!(code, c.exit_code());
     }
 
-    /// P1 step 18: a configured host-operation limit below the host count
-    /// bounds the per-host worker semaphore, while every host still
-    /// uninstalls exactly once.
+    /// A configured host-operation limit below the host count bounds the
+    /// per-host worker semaphore, while every host still uninstalls exactly
+    /// once.
     #[tokio::test]
     async fn bounded_uninstall_never_exceeds_the_configured_host_operation_limit() {
         use crate::mock::{MockGate, MockMetrics, MockOpKind};

--- a/crates/repose-core/src/config.rs
+++ b/crates/repose-core/src/config.rs
@@ -53,9 +53,8 @@ pub enum HostKeyPolicy {
 ///
 /// # P1 resource limits and phase deadlines
 ///
-/// The fields below (added for `plans/p1-bound-resources-and-prevent-stalls.md`)
-/// bound fleet-wide resource usage and SSH phase stalls. Every default is
-/// reviewed evidence, not a guess — see
+/// The fields below bound fleet-wide resource usage and SSH phase stalls.
+/// Every default is reviewed evidence, not a guess — see
 /// `tests/performance/p1-limit-decision.md`. Concurrency and count limits
 /// use [`NonZeroUsize`] so a zero (permanently-deadlocked or
 /// always-truncating) limit cannot be constructed. Deadlines are separate

--- a/crates/repose-core/src/mock.rs
+++ b/crates/repose-core/src/mock.rs
@@ -701,8 +701,8 @@ impl HostGroup for MockHostGroup {
     // `.buffered`, a slow early host cannot block admission of later ones —
     // and one host's error never stops or is counted against its siblings.
     // These phases mutate host state in place (no per-host result vector to
-    // reorder); order restoration is a mutation-worker concern (P1 steps
-    // 13–18), not this trait's.
+    // reorder); order restoration is a mutation-worker concern, not this
+    // trait's.
     async fn connect_and_prune(&mut self) -> Vec<(String, SshError)> {
         let cap = self.host_operation_limit.get();
         let mut failed: Vec<(String, SshError)> = stream::iter(self.hosts.iter_mut())
@@ -971,7 +971,7 @@ mod tests {
 
     #[test]
     fn host_operation_limit_defaults_and_overrides_through_the_trait_object() {
-        // Compile-time proof (P1 step 9): the accessor is callable through
+        // Compile-time proof that the accessor is callable through
         // `&mut dyn HostGroup`, not only the concrete type.
         let mut default_group = MockHostGroup::new();
         let as_trait_object: &mut dyn HostGroup = &mut default_group;
@@ -1253,9 +1253,9 @@ mod tests {
         assert_eq!(snap.commands_completed, 2, "a and c completed; b did not");
     }
 
-    /// P1 step 11: `run_all` never admits more than `host_operation_limit`
-    /// operations concurrently, even with more hosts than the limit and a
-    /// gate that stays closed for the whole observation window.
+    /// `run_all` never admits more than `host_operation_limit` operations
+    /// concurrently, even with more hosts than the limit and a gate that
+    /// stays closed for the whole observation window.
     #[tokio::test]
     async fn bounded_run_all_never_exceeds_the_configured_limit() {
         let metrics = MockMetrics::new();
@@ -1314,8 +1314,8 @@ mod tests {
         }
     }
 
-    /// P1 step 11: `connect_and_prune` at limit 1 (fully serial admission)
-    /// still prunes exactly the failed host and keeps the rest key-ordered.
+    /// `connect_and_prune` at limit 1 (fully serial admission) still prunes
+    /// exactly the failed host and keeps the rest key-ordered.
     #[tokio::test]
     async fn bounded_connect_and_prune_at_limit_one_still_prunes_correctly() {
         let mut g = MockHostGroup::new().with_host_operation_limit(NonZeroUsize::new(1).unwrap());
@@ -1334,8 +1334,8 @@ mod tests {
         );
     }
 
-    /// P1 step 11: a limit above the host count behaves exactly like the
-    /// unbounded `join_all` fan-out it replaces.
+    /// A limit above the host count behaves exactly like the unbounded
+    /// `join_all` fan-out it replaces.
     #[tokio::test]
     async fn limit_above_host_count_admits_the_whole_fleet_at_once() {
         let metrics = MockMetrics::new();

--- a/crates/repose-core/src/shell.rs
+++ b/crates/repose-core/src/shell.rs
@@ -3,7 +3,7 @@
 //!
 //! Vectors under `tests/vectors/shell/` pin the exact quoting rule and the
 //! command templates below and are the merge gate for any remote command
-//! interpolation (design R2 / PR2).
+//! interpolation.
 
 /// Characters safe to leave unquoted: ASCII alphanumerics plus
 /// `_@%+=:,./-`; anything else forces single-quoting.

--- a/crates/repose-core/src/types.rs
+++ b/crates/repose-core/src/types.rs
@@ -1,7 +1,8 @@
-//! Minimal domain types referenced by Host traits.
+//! Domain types referenced by the Host traits.
 //!
-//! Full parsers and REPA land in later PRs; these stubs keep traits
-//! compilable and mockable without pulling XML/YAML deps into PR0.5.
+//! Deliberately free of XML/YAML dependencies, so the traits stay
+//! compilable and mockable; the parsers that build these types live in
+//! `product_parse` and `repo_parse`.
 
 use std::collections::BTreeMap;
 

--- a/crates/repose-ssh/src/host.rs
+++ b/crates/repose-ssh/src/host.rs
@@ -117,9 +117,9 @@ impl Host for RusshHost {
                 Ok(())
             }
             Err(SshError::Timeout { phase, deadline }) => {
-                // A timeout appends `(command, "", "", -1)` — the
-                // diagnostics go to the log, not the entry's stderr.
-                // P1 step 27: typed variant replaces message substring
+                // A timeout appends `(command, "", "", -1, runtime)` — the
+                // diagnostics go to the log, not the entry's stderr. The
+                // typed timeout variant replaces message substring
                 // matching; every bounded phase (not only command
                 // completion) reaches this branch, all with the same
                 // out-history contract.
@@ -231,9 +231,9 @@ async fn discover_system(session: &mut RusshSession, _hostname: &str) -> Result<
     match session.listdir("/etc/products.d").await {
         Ok(listing) => {
             // Reject an implausible listing before constructing any addon
-            // paths or issuing further SFTP work (P1 step 30) — a
-            // corrupted/pathological filesystem returning thousands of
-            // spurious entries must not drive unbounded downstream work.
+            // paths or issuing further SFTP work — a corrupted/pathological
+            // filesystem returning thousands of spurious entries must not
+            // drive unbounded downstream work.
             let limit = session.max_products_d_entries();
             if listing.len() > limit {
                 return Err(SshError::DirectoryTooLarge {

--- a/crates/repose-ssh/src/hostkey.rs
+++ b/crates/repose-ssh/src/hostkey.rs
@@ -113,13 +113,12 @@ impl HostKeyVerifier {
         self
     }
 
-    /// Pure verification decision (P1 step 34): no filesystem I/O and no
-    /// mutation of `self`. Existing/matching, changed, and revoked
-    /// outcomes are decided exactly as before. `accept-new` first contact
-    /// no longer trusts-then-persists inline; it returns
-    /// [`KeyDecision::PersistFirstContact`] so the (async) caller can
-    /// durably persist the key — off the async runtime — before deciding
-    /// whether to trust it (fail-closed TOFU completion, P1 step 35).
+    /// Pure verification decision: no filesystem I/O and no mutation of
+    /// `self`. A matching, changed, or revoked key is decided outright. An
+    /// `accept-new` first contact is never trusted inline; it returns
+    /// [`KeyDecision::PersistFirstContact`] so the (async) caller can durably
+    /// persist the key — off the async runtime — and trust it only once that
+    /// write succeeds (fail-closed TOFU completion).
     pub(crate) fn decide_public_key(&self, key: &PublicKey) -> KeyDecision {
         let encoded = match key.to_openssh() {
             Ok(encoded) => encoded,
@@ -216,8 +215,8 @@ impl HostKeyVerifier {
     }
 }
 
-/// Outcome of [`HostKeyVerifier::decide_public_key`] (P1 step 34): a pure
-/// decision with no filesystem I/O performed yet.
+/// Outcome of [`HostKeyVerifier::decide_public_key`]: a pure decision with
+/// no filesystem I/O performed yet.
 pub(crate) enum KeyDecision {
     Accept,
     Reject,
@@ -297,9 +296,9 @@ fn malformed_known_hosts(path: &Path, line_no: usize) -> SshError {
     ))
 }
 
-/// Durably append `host`'s `key` to `known_hosts` at `path` (P1 steps 34–
-/// 35). Blocking file I/O — call only via `spawn_blocking` from the async
-/// `check_server_key` handler, never directly on the async runtime.
+/// Durably append `host`'s `key` to `known_hosts` at `path`. Blocking file
+/// I/O — call only via `spawn_blocking` from the async `check_server_key`
+/// handler, never directly on the async runtime.
 pub(crate) fn persist_first_contact(
     path: &Path,
     host: &str,
@@ -408,10 +407,10 @@ mod tests {
     use super::{HostKeyVerifier, KeyDecision};
 
     /// Test-only stand-in for the production `check_server_key` handler's
-    /// decide → persist → record sequence (P1 steps 34–35), run
-    /// synchronously since these tests need no async runtime. Mirrors the
-    /// real control flow exactly: `PersistFirstContact` is trusted only
-    /// after `persist_first_contact` succeeds.
+    /// decide → persist → record sequence, run synchronously since these
+    /// tests need no async runtime. Mirrors the real control flow exactly:
+    /// `PersistFirstContact` is trusted only after `persist_first_contact`
+    /// succeeds.
     fn verify(verifier: &mut HostKeyVerifier, key: &str) -> bool {
         match verifier.decide(key) {
             KeyDecision::Accept => true,
@@ -461,9 +460,8 @@ mod tests {
         assert!(!verify(&mut verifier, KEY_TWO));
     }
 
-    /// P1 steps 34–35: the approved, intentional behavior change — a
-    /// first-contact key that cannot be durably persisted must be
-    /// rejected (fail-closed), never silently trusted the old way.
+    /// Fail-closed by design: a first-contact key that cannot be durably
+    /// persisted must be rejected, never trusted without a recorded pin.
     #[test]
     #[cfg(unix)]
     fn accept_new_rejects_first_contact_when_persistence_fails() {

--- a/crates/repose-ssh/src/session.rs
+++ b/crates/repose-ssh/src/session.rs
@@ -27,8 +27,8 @@ use crate::hostkey::{HostKeyVerifier, KeyDecision, persist_first_contact};
 use crate::openssh_config::OpenSshOptions;
 
 /// Run `fut` under `deadline`, mapping an elapsed deadline to a typed
-/// [`SshError::Timeout`] identifying `phase` (P1 step 24). A phase that
-/// completes before its own deadline returns `fut`'s result unchanged.
+/// [`SshError::Timeout`] identifying `phase`. A phase that completes before
+/// its own deadline returns `fut`'s result unchanged.
 async fn with_deadline<T>(
     phase: TimeoutPhase,
     deadline: Duration,
@@ -118,12 +118,12 @@ impl Handler for ClientHandler {
         match self.verifier.decide_public_key(server_public_key) {
             KeyDecision::Accept => Ok(true),
             KeyDecision::Reject => Ok(false),
-            // `accept-new` first contact (P1 steps 34–35): persist off the
-            // async runtime via `spawn_blocking` and trust the key only
-            // after a successful durable write — a slow disk delays this
-            // one handshake, not sibling connections/timers, and a
-            // persistence failure rejects the session (fail-closed) rather
-            // than silently trusting an unrecorded key.
+            // `accept-new` first contact: persist off the async runtime via
+            // `spawn_blocking` and trust the key only after a successful
+            // durable write — a slow disk delays this one handshake, not
+            // sibling connections/timers, and a persistence failure rejects
+            // the session (fail-closed) rather than silently trusting an
+            // unrecorded key.
             KeyDecision::PersistFirstContact { path, key } => {
                 let host = self.verifier.host().to_string();
                 let port = self.verifier.port();
@@ -201,8 +201,7 @@ impl RusshSession {
         self
     }
 
-    /// The configured plausible-entry cap for `/etc/products.d` listings
-    /// (P1 step 30).
+    /// The configured plausible-entry cap for `/etc/products.d` listings.
     #[must_use]
     pub(crate) fn max_products_d_entries(&self) -> usize {
         self.config.max_products_d_entries.get()
@@ -212,9 +211,9 @@ impl RusshSession {
     /// authentication. The fast paths (`--identity`, or `IdentityFile`
     /// entries already resolved from `~/.ssh/config`) touch no filesystem
     /// state; only the fallback default-key scan performs blocking `stat`
-    /// calls, so only that branch runs on the blocking pool (P1 step 33) —
-    /// per this plan's decision, local credential discovery is off the
-    /// async thread but outside the network-authentication deadline.
+    /// calls, so only that branch runs on the blocking pool — local
+    /// credential discovery is deliberately off the async thread but
+    /// outside the network-authentication deadline.
     async fn candidate_keys(&self, configured_keys: &[PathBuf]) -> Result<Vec<PathBuf>, SshError> {
         if let Some(p) = &self.identity {
             return Ok(vec![p.clone()]);
@@ -285,7 +284,7 @@ impl RusshSession {
             .map(|verifier| verifier.with_alias(self.hostname.clone()))?
         };
         let handler = ClientHandler { verifier };
-        // DNS/TCP/proxy connect + SSH handshake: one deadline (P1 step 24).
+        // DNS/TCP/proxy connect + SSH handshake: one deadline.
         let mut session =
             with_deadline(TimeoutPhase::Connect, self.config.connect_deadline, async {
                 if let Some(command) =
@@ -306,12 +305,12 @@ impl RusshSession {
 
         // Auth order mirrors asyncssh's default: ssh-agent first (silently
         // skipped when SSH_AUTH_SOCK is absent or unusable), then
-        // IdentityFile / default key files, then one password prompt.
-        // Agent + public-key attempts share one absolute deadline (P1 step
-        // 25) so many identities or a stalled agent/server cannot multiply
-        // timeout duration indefinitely; the interactive password prompt
-        // below stays user-paced (excluded), and only the subsequent
-        // network `authenticate_password` call is separately deadline-bound.
+        // IdentityFile / default key files, then one password prompt. Agent
+        // + public-key attempts share one absolute deadline so many
+        // identities or a stalled agent/server cannot multiply timeout
+        // duration indefinitely; the interactive password prompt below
+        // stays user-paced (excluded), and only the subsequent network
+        // `authenticate_password` call is separately deadline-bound.
         let mut last_err = "no SSH private key found (~/.ssh/id_ed25519|id_rsa)".to_string();
         let candidate_keys = self.candidate_keys(&options.identity_files).await?;
         let automatic_ok = with_deadline(
@@ -392,9 +391,9 @@ impl RusshSession {
         )
         .await?;
 
-        // Command completion keeps its existing, separately configured
-        // budget (`ConnectionConfig::timeout`) — unchanged by P1 — but now
-        // returns the same typed timeout as every other phase (P1 step 27).
+        // Command completion has its own, separately configured budget
+        // (`ConnectionConfig::timeout`), but reports exhaustion with the
+        // same typed timeout as every other phase.
         let deadline = Duration::from_secs_f64(self.config.timeout);
         let stdout_limit = self.config.max_stdout_bytes.get();
         let stderr_limit = self.config.max_stderr_bytes.get();
@@ -494,8 +493,8 @@ impl RusshSession {
     }
 
     /// Read many remote files concurrently over the shared SFTP channel,
-    /// bounded to `sftp_read_concurrency_limit` in-flight reads (P1 step
-    /// 29) instead of one in-flight request per directory entry.
+    /// bounded to `sftp_read_concurrency_limit` in-flight reads instead of
+    /// one in-flight request per directory entry.
     ///
     /// Results keep the order of `paths`; a missing, unreadable, or
     /// oversized file (or a failed SFTP setup) yields `None` — the same
@@ -529,10 +528,10 @@ impl RusshSession {
     }
 }
 
-/// Append `chunk` to `buffer` unless doing so would exceed `limit` (P1
-/// step 31), checked *before* growth — mirroring `read_bounded`'s SFTP-side
-/// bound — so an oversized command output stream is never fully buffered
-/// before being rejected. Exactly-at-limit payloads succeed.
+/// Append `chunk` to `buffer` unless doing so would exceed `limit`, checked
+/// *before* growth — mirroring `read_bounded`'s SFTP-side bound — so an
+/// oversized command output stream is never fully buffered before being
+/// rejected. Exactly-at-limit payloads succeed.
 fn accumulate_or_overflow(
     buffer: &mut Vec<u8>,
     chunk: &[u8],
@@ -546,10 +545,10 @@ fn accumulate_or_overflow(
     Ok(())
 }
 
-/// Best-effort channel close after a P1 step 31 output-limit overflow,
-/// bounded by `overflow_cleanup_deadline` so a stalled close request
-/// cannot itself pin the host slot indefinitely. The channel is discarded
-/// immediately afterward regardless of whether the close completes.
+/// Best-effort channel close after an output-limit overflow, bounded by
+/// `overflow_cleanup_deadline` so a stalled close request cannot itself pin
+/// the host slot indefinitely. The channel is discarded immediately
+/// afterward regardless of whether the close completes.
 async fn close_on_overflow(channel: &russh::Channel<client::Msg>, deadline: Duration) {
     let _ = tokio::time::timeout(deadline, channel.close()).await;
 }
@@ -579,11 +578,11 @@ async fn read_one_bounded(
     (idx, result)
 }
 
-/// Read `path` incrementally, enforcing `limit` *before* growing the
-/// buffer past it (P1 step 28) — checking size only after a whole-file
-/// read would already have allocated the oversized payload, defeating the
-/// bound. The remote file handle is closed (via [`russh_sftp`]'s `File`
-/// `Drop`) on every exit path: success, a real I/O error, or overflow.
+/// Read `path` incrementally, enforcing `limit` *before* growing the buffer
+/// past it — checking size only after a whole-file read would already have
+/// allocated the oversized payload, defeating the bound. The remote file
+/// handle is closed (via [`russh_sftp`]'s `File` `Drop`) on every exit
+/// path: success, a real I/O error, or overflow.
 async fn read_bounded(sftp: &SftpSession, path: &str, limit: usize) -> Result<Vec<u8>, SshError> {
     use tokio::io::AsyncReadExt;
     let mut file = sftp
@@ -614,8 +613,7 @@ async fn read_bounded(sftp: &SftpSession, path: &str, limit: usize) -> Result<Ve
 
 /// Blocking half of `RusshSession::candidate_keys`'s default-key fallback:
 /// `HOME` lookup plus a `stat` per candidate filename. Run only via
-/// `spawn_blocking` (P1 step 33) — never called directly on the async
-/// runtime.
+/// `spawn_blocking` — never called directly on the async runtime.
 fn default_key_candidates() -> Vec<PathBuf> {
     match std::env::var_os("HOME") {
         Some(home) => default_key_candidates_in(&Path::new(&home).join(".ssh")),
@@ -640,10 +638,10 @@ fn default_key_candidates_in(ssh_dir: &Path) -> Vec<PathBuf> {
 /// Non-interactive authentication methods only (ssh-agent, then
 /// `IdentityFile`/default key files) — the automatic-order portion of
 /// `connect_inner`'s auth sequence, extracted so it can be wrapped in one
-/// absolute deadline (P1 step 25) without also bounding the interactive
-/// password prompt. Returns `Ok(true)` on success, `Ok(false)` if every
-/// automatic method was exhausted without success (caller falls through to
-/// the password prompt), `Err` only for a hard transport failure.
+/// absolute deadline without also bounding the interactive password prompt.
+/// Returns `Ok(true)` on success, `Ok(false)` if every automatic method was
+/// exhausted without success (caller falls through to the password prompt),
+/// `Err` only for a hard transport failure.
 async fn authenticate_automatic(
     session: &mut client::Handle<ClientHandler>,
     target_user: &str,
@@ -736,13 +734,13 @@ async fn try_agent_auth(
     false
 }
 
-/// Load and parse an unencrypted private key on the blocking pool (P1
-/// step 33) so file I/O and key parsing do not stall the current-thread
-/// runtime. The outer `Result` is a hard failure (the blocking task
-/// itself panicked/was cancelled) mapped to a typed `SshError` and
-/// propagated; the inner `Result` is an ordinary key-load outcome
-/// (missing, malformed, or `KeyIsEncrypted`) that the caller matches on
-/// exactly as before, skipping to the next candidate on failure.
+/// Load and parse an unencrypted private key on the blocking pool so file
+/// I/O and key parsing do not stall the current-thread runtime. The outer
+/// `Result` is a hard failure (the blocking task itself panicked/was
+/// cancelled) mapped to a typed `SshError` and propagated; the inner
+/// `Result` is an ordinary key-load outcome (missing, malformed, or
+/// `KeyIsEncrypted`) that the caller matches on exactly as before, skipping
+/// to the next candidate on failure.
 async fn load_unencrypted_key(
     key_path: PathBuf,
 ) -> Result<Result<russh::keys::PrivateKey, russh::keys::Error>, SshError> {
@@ -1003,10 +1001,10 @@ mod tests {
 
     #[tokio::test]
     async fn with_deadline_does_not_delay_an_independent_sibling_future() {
-        // P1 step 24 verify: a stalled phase must not block an unrelated
+        // This verifies that a stalled phase must not block an unrelated
         // concurrent timer/host operation. `tokio::join!` only returns once
-        // *both* branches finish, so the sibling records its own
-        // completion time rather than relying on the join's return time.
+        // *both* branches finish, so the sibling records its own completion
+        // time rather than relying on the join's return time.
         let stalled = super::with_deadline(
             TimeoutPhase::Connect,
             Duration::from_millis(300),
@@ -1034,9 +1032,9 @@ mod tests {
         ));
     }
 
-    /// P1 step 24: a server that accepts the TCP connection but never
-    /// speaks SSH must not hang `connect()` forever — a real (not mocked)
-    /// deterministic stall, using a plain `TcpListener`.
+    /// A server that accepts the TCP connection but never speaks SSH must
+    /// not hang `connect()` forever — a real (not mocked) deterministic
+    /// stall, using a plain `TcpListener`.
     #[tokio::test]
     async fn connect_deadline_fires_against_a_server_that_never_speaks_ssh() {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port");
@@ -1143,11 +1141,11 @@ mod tests {
         assert!((1..=10).all(|attempt| super::reconnect_sleep_secs(attempt, 10, false) == 10));
     }
 
-    // P1 step 31: `accumulate_or_overflow` is the pure boundary check behind
-    // the stdout/stderr byte caps in `run_inner`'s collect loop. It is
-    // tested directly here (no live SSH channel required); the full
-    // channel-close/exit-status/session-reuse behavior around it is
-    // covered by the live-gated tests in `ssh_integration.rs`.
+    // `accumulate_or_overflow` is the pure boundary check behind the
+    // stdout/stderr byte caps in `run_inner`'s collect loop. It is tested
+    // directly here (no live SSH channel required); the full
+    // channel-close/exit-status/session-reuse behavior around it is covered
+    // by the live-gated tests in `ssh_integration.rs`.
     #[test]
     fn accumulate_or_overflow_accepts_an_empty_chunk_into_an_empty_buffer() {
         let mut buffer = Vec::new();
@@ -1202,11 +1200,11 @@ mod tests {
         );
     }
 
-    // P1 step 33: default key-file discovery and unencrypted key loading
-    // now run via `spawn_blocking`. `default_key_candidates_in` is tested
-    // directly against a temporary directory (not the process-global
-    // `HOME`, which parallel tests must not mutate); `candidate_keys`'s
-    // two filesystem-free fast paths are tested through the real method.
+    // Default key-file discovery and unencrypted key loading now run via
+    // `spawn_blocking`. `default_key_candidates_in` is tested directly
+    // against a temporary directory (not the process-global `HOME`, which
+    // parallel tests must not mutate); `candidate_keys`'s two
+    // filesystem-free fast paths are tested through the real method.
 
     #[tokio::test]
     async fn candidate_keys_prefers_an_explicit_identity_over_everything_else() {
@@ -1247,11 +1245,11 @@ mod tests {
         assert!(super::default_key_candidates_in(dir.path()).is_empty());
     }
 
-    /// P1 step 33 verify: a deliberately slow blocking task (representing
+    /// This verifies that a deliberately slow blocking task (representing
     /// the shape of `default_key_candidates`/`load_unencrypted_key`'s
-    /// filesystem/crypto work) must not delay an independent async
-    /// sibling — the same `spawn_blocking` isolation both functions rely
-    /// on, demonstrated directly since real key I/O cannot be forced slow
+    /// filesystem/crypto work) must not delay an independent async sibling
+    /// — the same `spawn_blocking` isolation both functions rely on,
+    /// demonstrated directly since real key I/O cannot be forced slow
     /// deterministically in a unit test.
     #[tokio::test]
     async fn spawn_blocking_key_work_does_not_delay_an_independent_sibling() {
@@ -1274,9 +1272,9 @@ mod tests {
         );
     }
 
-    // P1 steps 34–35: `ClientHandler::check_server_key` awaits `accept-new`
-    // persistence via `spawn_blocking` and trusts a first-contact key only
-    // after a successful durable write.
+    // `ClientHandler::check_server_key` awaits `accept-new` persistence via
+    // `spawn_blocking` and trusts a first-contact key only after a
+    // successful durable write.
 
     #[tokio::test]
     async fn check_server_key_accepts_first_contact_only_after_a_durable_write() {
@@ -1341,11 +1339,11 @@ mod tests {
             .expect("permissions should be restorable for cleanup");
     }
 
-    /// P1 step 35 verify: a slow `accept-new` persistence write must not
+    /// This verifies that a slow `accept-new` persistence write must not
     /// delay an independent sibling connection/timer — the same
     /// `spawn_blocking` isolation guarantee already demonstrated for key
-    /// loading (P1 step 33), applied to `check_server_key`'s persistence
-    /// path specifically.
+    /// loading, applied to `check_server_key`'s persistence path
+    /// specifically.
     #[tokio::test]
     async fn check_server_key_persistence_does_not_delay_an_independent_sibling() {
         let key = PublicKey::from_openssh(TEST_KEY).expect("test key should parse");

--- a/crates/repose-ssh/tests/ssh_integration.rs
+++ b/crates/repose-ssh/tests/ssh_integration.rs
@@ -225,13 +225,12 @@ async fn live_host_discovers_system_repositories_and_isolates_connection_failure
     group.close().await;
 }
 
-/// P1 step 12: `RusshHostGroup`'s bounded fan-out still processes every
-/// host exactly once, with correct per-host results and sorted keys, at
-/// the most constrained limit (1 — fully serial admission). Peak-
-/// concurrency measurement itself is covered by the identical algorithm's
-/// gated tests in `repose_core::mock` (a real SSH session has no gate to
-/// instrument); this proves end-to-end correctness against a real
-/// transport instead.
+/// `RusshHostGroup`'s bounded fan-out still processes every host exactly
+/// once, with correct per-host results and sorted keys, at the most
+/// constrained limit (1 — fully serial admission). Peak-concurrency
+/// measurement itself is covered by the identical algorithm's gated tests
+/// in `repose_core::mock` (a real SSH session has no gate to instrument);
+/// this proves end-to-end correctness against a real transport instead.
 #[tokio::test]
 async fn live_group_bounded_fan_out_at_limit_one_processes_every_host_exactly_once() {
     let Some(fixture) = fixture() else { return };
@@ -280,10 +279,8 @@ async fn live_group_bounded_fan_out_at_limit_one_processes_every_host_exactly_on
     group.close().await;
 }
 
-/// P1 step 28: an SFTP file read enforces the configured byte limit —
-/// exactly-at-limit succeeds, limit-1 (one byte over) returns a typed
-/// `SftpFileTooLarge` error, and the default (generous) limit is
-/// unaffected for the same real file.
+/// An SFTP file read enforces the configured byte limit — exactly-at-limit
+/// succeeds, and one byte over returns a typed `SftpFileTooLarge` error.
 #[tokio::test]
 async fn live_sftp_read_enforces_the_configured_byte_limit() {
     let Some(fixture) = fixture() else { return };
@@ -320,8 +317,8 @@ async fn live_sftp_read_enforces_the_configured_byte_limit() {
     );
 }
 
-/// P1 step 28: a missing remote file keeps its existing error type/shape
-/// (unaffected by the bounded-reader refactor).
+/// A missing remote file keeps its existing error type/shape (unaffected by
+/// the bounded-reader refactor).
 #[tokio::test]
 async fn live_sftp_read_of_a_missing_file_is_unchanged() {
     let Some(fixture) = fixture() else { return };
@@ -335,9 +332,9 @@ async fn live_sftp_read_of_a_missing_file_is_unchanged() {
     assert!(matches!(error, repose_core::error::SshError::Other(_)));
 }
 
-/// P1 step 30: a `/etc/products.d` listing above the configured plausible-
-/// entry cap is rejected before any addon path is constructed, while a
-/// normal (small) listing discovers products exactly as before.
+/// A `/etc/products.d` listing above the configured plausible-entry cap is
+/// rejected before any addon path is constructed, while a normal (small)
+/// listing discovers products exactly as before.
 #[tokio::test]
 async fn live_products_d_listing_above_the_cap_is_rejected() {
     let Some(fixture) = fixture() else { return };
@@ -363,8 +360,8 @@ async fn live_products_d_listing_above_the_cap_is_rejected() {
     );
 }
 
-/// P1 step 31: stdout exactly at the configured byte limit succeeds and
-/// returns the complete payload unchanged.
+/// Stdout exactly at the configured byte limit succeeds and returns the
+/// complete payload unchanged.
 #[tokio::test]
 async fn live_command_output_stdout_at_the_byte_limit_succeeds() {
     let Some(fixture) = fixture() else { return };
@@ -382,9 +379,9 @@ async fn live_command_output_stdout_at_the_byte_limit_succeeds() {
     assert_eq!(status, 0);
 }
 
-/// P1 step 31: one byte over the stdout limit returns a typed
-/// `OutputTooLarge` error, and the same session remains usable afterward
-/// (the overflow cleanup must not leave the transport unusable).
+/// One byte over the stdout limit returns a typed `OutputTooLarge` error,
+/// and the same session remains usable afterward (the overflow cleanup must
+/// not leave the transport unusable).
 #[tokio::test]
 async fn live_command_output_stdout_one_byte_over_the_limit_is_rejected_and_session_is_reusable() {
     let Some(fixture) = fixture() else { return };
@@ -412,7 +409,7 @@ async fn live_command_output_stdout_one_byte_over_the_limit_is_rejected_and_sess
     assert_eq!((stdout.as_str(), status), ("ok", 0));
 }
 
-/// P1 step 31: stderr has its own, independently enforced byte limit.
+/// Stderr has its own, independently enforced byte limit.
 #[tokio::test]
 async fn live_command_output_stderr_one_byte_over_the_limit_is_rejected() {
     let Some(fixture) = fixture() else { return };
@@ -435,9 +432,9 @@ async fn live_command_output_stderr_one_byte_over_the_limit_is_rejected() {
     );
 }
 
-/// P1 step 31: stdout and stderr caps are independent — an in-limit
-/// stderr payload does not mask, and is not mistakenly counted toward, an
-/// oversized stdout payload.
+/// Stdout and stderr caps are independent — an in-limit stderr payload does
+/// not mask, and is not mistakenly counted toward, an oversized stdout
+/// payload.
 #[tokio::test]
 async fn live_command_output_mixed_streams_enforce_independent_limits() {
     let Some(fixture) = fixture() else { return };
@@ -461,9 +458,9 @@ async fn live_command_output_mixed_streams_enforce_independent_limits() {
     );
 }
 
-/// P1 step 32: an output-limit overflow reaches `RusshHost::run` through
-/// the same generic failure contract as other transport errors: exactly
-/// one synthetic out entry (rc -1, empty streams) — never the oversized or
+/// An output-limit overflow reaches `RusshHost::run` through the same
+/// generic failure contract as other transport errors: exactly one
+/// synthetic out entry (rc -1, empty streams) — never the oversized or
 /// partial payload.
 #[tokio::test]
 async fn live_host_run_maps_an_output_overflow_to_a_single_synthetic_out_entry() {

--- a/deny.toml
+++ b/deny.toml
@@ -68,7 +68,7 @@ exceptions = []
 
 [bans]
 multiple-versions = "warn"
-# Path deps must pin the workspace version, currently `version = "3.0.0"`
+# Path deps must pin the workspace version rather than use a wildcard
 # (see crate Cargo.toml comments).
 wildcards = "deny"
 highlight = "all"

--- a/scripts/measure-ssh-concurrency-container.sh
+++ b/scripts/measure-ssh-concurrency-container.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# LOCAL-DEV-ONLY P1 decision-gate evidence gatherer. Docker is unavailable
+# LOCAL-DEV-ONLY decision-gate evidence gatherer for
+# tests/performance/p1-limit-decision.md. Docker is unavailable
 # on this machine; this drives the *same* tests/ssh/Dockerfile fixture
 # through Apple's `container` CLI (macOS-native container runtime) instead,
 # then reuses scripts/measure-ssh-concurrency.sh for the actual

--- a/scripts/measure-ssh-concurrency.sh
+++ b/scripts/measure-ssh-concurrency.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #
-# P1 decision-gate evidence (step 2): open several *concurrent* SSH sessions
-# against the tests/ssh/ Docker OpenSSH fixture and record per-session
-# connect+auth+product-discovery latency percentiles under load.
+# Decision-gate evidence for tests/performance/p1-limit-decision.md: open
+# several *concurrent* SSH sessions against the tests/ssh/ Docker OpenSSH
+# fixture and record per-session connect+auth+product-discovery latency
+# percentiles under load.
 #
 # The one-container fixture cannot model true 100-host network fan-out (see
 # tests/performance/README.md's documented P0 limitation) — this measures

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -134,7 +134,7 @@ warmup crash still fails loudly) but are excluded from `wall_time_ns`.
   the only source of real transport/host-key timing in this baseline —
   they do not model true 100-host network fan-out (a single-container
   fixture cannot); use them for transport realism, not fleet-scaling
-  claims (see the P0.1 plan's risk log).
+  claims.
 - Compare same-runner-class reports only; `os`/`arch`/`toolchain` differ
   in ways that make cross-runner latency comparisons meaningless
   (`scripts/compare-performance.sh`, P0.5, enforces this).

--- a/tests/performance/opportunity-matrix.md
+++ b/tests/performance/opportunity-matrix.md
@@ -26,10 +26,9 @@ Linux-specific claims as pending until a Linux capture lands.
 **Scope caveat**: these are `mock`-kind (in-process, no SSH/SFTP/zypper)
 profiles — they measure `repose-core`'s *local* command-algorithm cost, not
 remote/network cost. This is consistent with, not a contradiction of, the
-audit's conclusion that remote round trips dominate production wall time
-(`plans/performance-action-plan.md`); local hotspots matter most for P5
-("profile-gated local optimizations"), which explicitly gates on evidence
-like this.
+earlier finding that remote round trips dominate production wall time; local
+hotspots matter most for P5 ("profile-gated local optimizations"), which
+explicitly gates on evidence like this.
 
 **Excluded as harness artifact**: `mock-list-products-100h`'s CPU profile's
 #2 symbol is `baseline_report::check_expectation` (185/2215 ≈ 8.4% of

--- a/tests/performance/p1-limit-decision.md
+++ b/tests/performance/p1-limit-decision.md
@@ -115,9 +115,8 @@ complete per-host mutation workers").
 Probes are a single outbound HTTP HEAD/GET per candidate URL — no PTY, no
 SFTP channel, no persistent per-host state — so they can safely sustain
 higher concurrency than full host operations for the same resource budget.
-Today's per-*host* cap of 16 (`crates/repose-core/src/commands/mod.rs:294`,
-inherited from the pre-3.0 implementation rather than derived from a
-measurement) means a 100-host
+The per-*host* cap of 16 in force when this was written (inherited from the
+pre-3.0 implementation rather than derived from a measurement) means a 100-host
 fleet with several repository candidates per host can already reach
 multiples of 16 in flight simultaneously with no fleet-wide ceiling at all.
 64 is 4x today's per-host value yet remains an explicit, single, fleet-wide


### PR DESCRIPTION
## What

#262 (merged) retired citations to the removed Python implementation. Doing it surfaced
the identical failure mode one layer over, which this PR fixes: roughly
sixty-five comments justify a shape by citing a document that is not in this
repository.

Two classes, and one is worse than the other:

- **`P1 step N`** and **`P1 decision-gate evidence (step N)`** cite
  `plans/p1-bound-resources-and-prevent-stalls.md`. That file was **never
  committed** — not deleted, never present. `git log --all --diff-filter=A --
  'plans/*'` shows the only file ever tracked there was
  `improve-test-coverage.md`. Unlike the Python tree, there is no archive to
  fall back on: these tags have never resolved for anyone but their author.
  `tests/performance/opportunity-matrix.md` cited a *second* never-committed
  plan, `plans/performance-action-plan.md`.
- **`design delta #4`, `design R2`, `PR2`, `PR0.5`** cite
  `docs/design/rust-rewrite.md`, deleted in `b4e7f17`. Recoverable from git
  history, but not from the working tree.

## The substance is already here — only the pointers were wrong

This is not a deletion of history. Every label has a live in-tree successor,
so the fix is to say the thing, or to point at the successor:

| Dead label | What it meant | Where it lives now |
| --- | --- | --- |
| `design delta #4` | set-sourced multi-alias commands are stably sorted | stated inline; also `tests/vectors/inventory.md` |
| `design R2` / `PR2` | shell-quoting mismatch is a critical risk, gated by goldens | `tests/vectors/shell/`; the comment already said "merge gate" |
| `PR0.5` | the traits/layering split keeping `russh` out of `repose-core` | `scripts/check-rust-layering.sh` + `deny.toml`, both run by CI |
| `P1 step N` | the resource-bounding and stall-prevention work | `tests/performance/p1-limit-decision.md` (approved defaults) and `p1-review-packet.md` (what shipped) |

On the last row especially: thirty-odd scattered pointers to one document are
noise even when the document exists. The durable pointer belongs on the type
that owns the limits, and `ConnectionConfig`'s struct doc already carries it —
"Every default is reviewed evidence, not a guess — see
`tests/performance/p1-limit-decision.md`". That stays; the dead `plans/…` path
beside it goes. The five benches and scripts that genuinely *are* decision-gate
evidence now name that in-tree table instead of a step number.

## What stays

`P0.x` is left wherever it resolves: `P0.1`, `P0.2`, `P0.4` and `P0.5` are each
described in `tests/performance/README.md`. `P0.3` is described in no in-tree
document, and of its four sites two were self-describing headers ("fleet-scale
benchmark", "Criterion benchmark"), one was `(see P0.3 assumptions)` pointing at
nothing, and one was a `plan item` citation — so the bare label goes while the
resolvable P0 labels stay.

## Prose only

Every changed line is a comment, a doc comment, a `#` comment in `Cargo.toml`,
`deny.toml` or a shell/jq script, or Markdown. No function was renamed — unlike
#262, no name carried one of these tags. Enforced mechanically: filtering the
diff for changed lines that are not comments produces nothing at all.

Most sites are a bare parenthetical on a comment that already states its rule
(`Bounded by a semaphore (P1 step 14)`), so the edit deletes four words and
re-wraps. The ones that *lead* with the tag — a dozen test doc comments read
`/// P1 step 11: run_all never admits more than …` — were rewritten to stand
alone, each checked against what its test actually asserts.

## Two traps a naive grep walks straight past

- **Tags wrap across line breaks.** `` `limit` (P1\n/// step 31)`` never matches
  a line-oriented `git grep`.
- **The same reference has several spellings**: the plural `P1 steps 34–35`
  (with an en-dash), and `P1 decision-gate evidence (step 1)` rather than
  `P1 step 1`. That last form is how five sites survived the first pass — one of
  them eighteen lines above a tag the first pass *did* remove, in the same file.

A multiline scan over every tracked file, joining comment continuation lines
first, found the rest.

## Three stale claims fixed in passing

- `types.rs` said "Full parsers and REPA land in later PRs; these stubs keep
  traits compilable…". They landed, and these are the real domain types, not
  stubs. It now names `product_parse` and `repo_parse` — the two modules that
  actually build them. (`template.rs` and `repa.rs` never touch `crate::types`.)
- `tests/performance/p1-limit-decision.md` cited
  `crates/repose-core/src/commands/mod.rs:294` for the per-host cap. That line
  pointed inside `report_pruned` even before this branch, so the broken pointer
  is dropped.
- `deny.toml` said path deps pin "currently `version = "3.0.0"`". The workspace
  is at 3.1.1. Rather than update a number that goes stale on every release, the
  comment now states the rule without naming a version.

`crates/README.md` also said layering was "enforced more strictly in PR0.5" — a
promise about a milestone that landed long ago. It now names the script that
enforces it.

## About the re-wrapping

Deleting a mid-sentence parenthetical leaves an under-filled line, so the
touched comment paragraphs are re-filled. That inflates the diff, but a PR whose
whole point is comment quality should not leave ragged paragraphs behind. The
re-fill treats list items, headings, table rows and code fences as hard breaks,
and was checked afterwards for the two ways it can silently corrupt text: a
split inline code span, and a split `[`Foo`]` intra-doc link — the latter
degrades to plain text without warning, so `cargo doc` passing is not sufficient
evidence on its own. Three such splits were found and repaired.

## Deliberately not touched

`tests/performance/p1-limit-decision.md` and `p1-review-packet.md` still
reference `plans/p1-bound-resources-and-prevent-stalls.md`, in their headers and
their sign-off sections, and still speak of "Phases A–H". Those two files *are*
the evidence record for that plan; divorcing them from it would leave documents
that no longer explain what they are evidence of. A code comment must stand
alone for whoever is reading the code — an archival record carries no such
obligation.

`AGENTS.md` is unchanged. The policy it gained in #262 already covers this case:
record the constraint, not the citation.

## Testing

Full gate green: `cargo fmt --all --check`, `cargo clippy --workspace
--all-targets --locked -D warnings` (and with `--features gen`), `cargo test
--workspace --all-targets --locked` (269 tests), `cargo deny check`,
`scripts/check-rust-layering.sh`, `scripts/check-cli.sh` — all of `make check` —
plus the two gates outside it that a docs change would break: `cargo doc
--workspace --no-deps` under `RUSTDOCFLAGS=-D warnings`, and `typos` 1.48.0.
Both edited shell scripts pass `bash -n`. Regenerating man pages and completions
produces no drift.

_AI-assisted._
