### PR TITLE
fix(core): parse IPv6 targets instead of silently misreading them

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,12 @@ Frequently used global options (run `repose --help` for the full list):
 ### Targets and repository patterns
 
 - **HOST** is an SSH target such as `root@fubar.suse.cz`, passed with `-t`.
-  Repeat `-t` to operate on multiple hosts concurrently.
+  Repeat `-t` to operate on multiple hosts concurrently. The full form is
+  `[user@]host[:port]`. Brackets are for IPv6 literals only —
+  `[2001:db8::1]` or `[2001:db8::1]:2222`; a bare `2001:db8::1` also works at
+  the default port. The address is normalised to its canonical form, so every
+  spelling of one address shares a single `known_hosts` entry. A zone index
+  (`fe80::1%eth0`) is not supported.
 - **REPA** is a *REpository PAttern* — a positional argument naming a
   repository/add-on to act on. Pass several to act on several. Append a
   version after a colon to pin it, e.g. `SLES:12-SP2`.

--- a/crates/repose-core/src/commands/list_cmd.rs
+++ b/crates/repose-core/src/commands/list_cmd.rs
@@ -112,7 +112,19 @@ pub fn run_known_products(
     Ok(ExitCode::Ok)
 }
 
+/// Recover `(hostname, port)` from a host key.
+///
+/// An IPv6 key is bracketed at every port (`[::1]`, `[::1]:2222`), which is
+/// what keeps the port recoverable — a bare `::1` would split into host `:`
+/// port 1. The brackets are stripped again here so callers see the same bare
+/// address the transport and `known_hosts` use.
 fn split_key(key: &str) -> (&str, u16) {
+    if let Some(rest) = key.strip_prefix('[')
+        && let Some((inner, after)) = rest.split_once(']')
+    {
+        let port = after.strip_prefix(':').and_then(|p| p.parse().ok());
+        return (inner, port.unwrap_or(22));
+    }
     if let Some((h, p)) = key.rsplit_once(':')
         && let Ok(port) = p.parse()
     {
@@ -123,6 +135,29 @@ fn split_key(key: &str) -> (&str, u16) {
 
 #[cfg(test)]
 mod tests {
+    /// `parse_host` builds the key and `split_key` takes it apart; the two
+    /// must agree or `list-*` reports a host that was never targeted. This
+    /// is the pairing that hid the original bug — a bare `::1` key looks
+    /// harmless until it decodes to host `:` port 1.
+    #[test]
+    fn split_key_inverts_every_key_parse_host_can_build() {
+        for target in [
+            "example.com",
+            "example.com:2222",
+            "::1",
+            "[::1]",
+            "[::1]:2222",
+            "2001:db8::1",
+            "[2001:db8::1]:65535",
+            "[::1]:0",
+        ] {
+            let spec = crate::host_parse::parse_host(target).unwrap();
+            let (host, port) = super::split_key(&spec.key);
+            assert_eq!(host, spec.hostname, "{target}: hostname round trip");
+            assert_eq!(port, spec.port, "{target}: port round trip");
+        }
+    }
+
     use super::*;
     use crate::console::Buffer;
 

--- a/crates/repose-core/src/display.rs
+++ b/crates/repose-core/src/display.rs
@@ -136,13 +136,24 @@ fn is_numeric_like(s: &str) -> bool {
     }
 }
 
+/// YAML c-indicators, which cannot open a plain scalar: flow collections,
+/// anchors and aliases, tags, comments, block scalars, the directive and
+/// reserved markers, and both quote characters. Deliberately excludes `-`,
+/// `?` and `:`, which YAML 1.2 permits to open a plain scalar when the next
+/// character is not a space — `sle-ha` and `15-SP3` must stay unquoted.
+const YAML_INDICATORS: &[char] = &[
+    '[', ']', '{', '}', ',', '&', '*', '#', '|', '>', '!', '%', '@', '`', '"', '\'',
+];
+
 /// One YAML string scalar, single-quoted exactly where leaving it plain would
 /// stop it being a string: the empty string, int/float-like strings (`'0'`,
 /// `'22'`, `'08'`, `'6.1'`), YAML 1.2 core booleans/null (`true`/`True`/`TRUE`,
 /// `false`/..., `null`/`Null`/`NULL`, `~` — but NOT the YAML 1.1-only
-/// `yes`/`no`/`on`/`off`, which stay plain), and strings containing `": "` or
-/// `" #"`. Everything else (`15-SP3`, `SP3`, `ALL`, `SLES`, `tumbleweed`,
-/// hostnames) stays plain.
+/// `yes`/`no`/`on`/`off`, which stay plain), strings containing `": "` or
+/// `" #"`, and anything opening with a YAML indicator character — a
+/// bracketed IPv6 host name would otherwise be read back as a flow
+/// sequence rather than a string. Everything else (`15-SP3`, `SP3`, `ALL`,
+/// `SLES`, `tumbleweed`, hostnames) stays plain.
 fn yaml_string(s: &str) -> String {
     let quote = s.is_empty()
         || is_numeric_like(s)
@@ -150,6 +161,10 @@ fn yaml_string(s: &str) -> String {
             s,
             "true" | "True" | "TRUE" | "false" | "False" | "FALSE" | "null" | "Null" | "NULL" | "~"
         )
+        || s.starts_with(YAML_INDICATORS)
+        // A plain scalar loses its surrounding whitespace on the way back in,
+        // so padding has to be quoted or it is silently dropped.
+        || s.trim() != s
         || s.contains(": ")
         || s.contains(" #");
     if quote {
@@ -602,6 +617,16 @@ mod tests {
         ] {
             assert_eq!(yaml_string(s), format!("'{s}'"), "{s:?} must be quoted");
         }
+        // A bracketed IPv6 host name must be quoted, or reading the document
+        // back yields a one-element flow sequence instead of a string.
+        assert_eq!(yaml_string("[::1]"), "'[::1]'");
+        assert_eq!(yaml_string("[2001:db8::1]:2222"), "'[2001:db8::1]:2222'");
+        // Padding survives only if quoted; a plain scalar is trimmed on read.
+        assert_eq!(yaml_string(" pad"), "' pad'");
+        assert_eq!(yaml_string("pad "), "'pad '");
+        // `-`/`?`/`:` may open a plain scalar when not followed by a space.
+        assert_eq!(yaml_string("-SP3"), "-SP3");
+        assert_eq!(yaml_string("sle-ha"), "sle-ha");
         // Plain: the YAML 1.1-only bool spellings and ordinary SUSE shapes.
         for s in [
             "yes",

--- a/crates/repose-core/src/host_parse.rs
+++ b/crates/repose-core/src/host_parse.rs
@@ -1,4 +1,12 @@
 //! Parse `-t` host strings: `[user@]host[:port]`.
+//!
+//! An IPv6 target is written bracketed, `[2001:db8::1]` or
+//! `[2001:db8::1]:2222`, exactly as it appears in `known_hosts`. A bare
+//! unbracketed literal (`2001:db8::1`) is accepted at the default port,
+//! since a colon cannot occur in a hostname and the form is therefore
+//! unambiguous. A zone index (`fe80::1%eth0`) is not supported.
+
+use std::net::Ipv6Addr;
 
 use thiserror::Error;
 
@@ -9,8 +17,12 @@ const DEFAULT_PORT: u16 = 22;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HostSpec {
-    /// Map key: `hostname` or `hostname:port` when port ≠ 22.
+    /// Map key: `hostname`, or `hostname:port` when port ≠ 22. An IPv6
+    /// address is bracketed at every port (`[::1]`, `[::1]:2222`) so the
+    /// port stays recoverable; see the key construction in [`parse_host`].
     pub key: String,
+    /// Never bracketed, even for IPv6 — the connect tuple and `known_hosts`
+    /// both want the bare address.
     pub hostname: String,
     pub port: u16,
     pub username: String,
@@ -22,6 +34,30 @@ pub enum HostParseError {
     PortNotInt(String),
     #[error("Target host: empty hostname")]
     EmptyHost,
+    #[error(
+        "Target host: {0} is not a valid IPv6 address; brackets are only for IPv6 literals, as in [2001:db8::1]:2222"
+    )]
+    InvalidIpv6(String),
+}
+
+/// The RFC 5952 form of `s` if it is an IPv6 literal, else `None`.
+///
+/// Canonicalizing is what makes the `known_hosts` pin work. OpenSSH runs a
+/// numeric target through `getnameinfo(NI_NUMERICHOST)` before it looks the
+/// host up or records it, so `2001:db8:0:0:0:0:0:1` is stored as
+/// `2001:db8::1`. Keeping the text as typed would give one address as many
+/// identities as it has spellings, and under the default `accept-new` a
+/// missed identity is not a refusal — it looks like first contact, so any
+/// key the network offers gets trusted and appended.
+fn canonical_ipv6(s: &str) -> Option<String> {
+    s.parse::<Ipv6Addr>().ok().map(|a| a.to_string())
+}
+
+/// Parse the port segment, reporting `host` in the error the way the rest of
+/// this module does (lowercased, without any brackets).
+fn parse_port(p: &str, host: &str) -> Result<u16, HostParseError> {
+    p.parse::<u16>()
+        .map_err(|_| HostParseError::PortNotInt(host.to_string()))
 }
 
 /// Parse `[user@]host[:port]` without creating a Target.
@@ -39,32 +75,47 @@ pub fn parse_host(arg: &str) -> Result<HostSpec, HostParseError> {
         (None, s)
     };
 
-    // Bracketed IPv6 hosts are not supported — skip.
-    // host:port — if last colon and port is numeric.
-    //
     // The hostname is lowercased; the username and port are left untouched.
     // The PortNotInt error message also carries the lowercased hostname.
-    let (hostname, port) = if let Some((h, p)) = host_part.rsplit_once(':') {
-        // The LAST colon splits host from port, and a non-numeric segment
-        // after it errors as a bad port. Unbracketed IPv6 has no way to opt
-        // out of that split, so it either errors here or — when its final
-        // group happens to be numeric — is misread as host plus port.
+    let (hostname, port) = if let Some(rest) = host_part.strip_prefix('[') {
+        // `[addr]` or `[addr]:port`. The brackets must close, and must wrap
+        // an IPv6 literal — they are not a general quoting mechanism.
+        let Some((inner, after)) = rest.split_once(']') else {
+            return Err(HostParseError::InvalidIpv6(host_part.to_lowercase()));
+        };
+        if inner.is_empty() {
+            return Err(HostParseError::EmptyHost);
+        }
+        let Some(addr) = canonical_ipv6(inner) else {
+            return Err(HostParseError::InvalidIpv6(inner.to_lowercase()));
+        };
+        let port = match after {
+            "" => DEFAULT_PORT,
+            _ => {
+                let Some(p) = after.strip_prefix(':') else {
+                    return Err(HostParseError::InvalidIpv6(host_part.to_lowercase()));
+                };
+                parse_port(p, &addr)?
+            }
+        };
+        (addr, port)
+    } else if let Some(addr) = canonical_ipv6(host_part) {
+        // Unbracketed literal: unambiguous, but leaves no room for a port.
+        (addr, DEFAULT_PORT)
+    } else if let Some((h, p)) = host_part.rsplit_once(':') {
+        // The LAST colon splits host from port. A hostname cannot itself
+        // contain a colon, so a colon left in `h` means this was a malformed
+        // or unbracketed IPv6 target, not a host/port pair — refusing it is
+        // what stops such an input being silently read as some other host.
+        if h.contains(':') {
+            return Err(HostParseError::InvalidIpv6(host_part.to_lowercase()));
+        }
+        if h.is_empty() {
+            return Err(HostParseError::EmptyHost);
+        }
         let h_lower = h.to_lowercase();
-        if p.is_empty() {
-            return Err(HostParseError::PortNotInt(h_lower));
-        }
-        match p.parse::<u16>() {
-            Ok(port) => {
-                if h.is_empty() {
-                    return Err(HostParseError::EmptyHost);
-                }
-                (h_lower, port)
-            }
-            Err(_) => {
-                // non-numeric port segment
-                return Err(HostParseError::PortNotInt(h_lower));
-            }
-        }
+        let port = parse_port(p, &h_lower)?;
+        (h_lower, port)
     } else {
         if host_part.is_empty() {
             return Err(HostParseError::EmptyHost);
@@ -77,7 +128,19 @@ pub fn parse_host(arg: &str) -> Result<HostSpec, HostParseError> {
         .unwrap_or(DEFAULT_USER)
         .to_string();
 
-    let key = if port == DEFAULT_PORT {
+    // An IPv6 address is bracketed in the key at EVERY port, including the
+    // default. `split_key` recovers host and port by splitting on the last
+    // colon and accepting a numeric tail, so a bare `::1` would decode as
+    // host `:` port 1; a bracketed key always ends in `]` and can never hit
+    // that branch. `hostname` stays bare — the connect tuple and
+    // `known_hosts` both need it unbracketed.
+    let key = if canonical_ipv6(&hostname).is_some() {
+        if port == DEFAULT_PORT {
+            format!("[{hostname}]")
+        } else {
+            format!("[{hostname}]:{port}")
+        }
+    } else if port == DEFAULT_PORT {
         hostname.clone()
     } else {
         format!("{hostname}:{port}")
@@ -143,5 +206,67 @@ mod tests {
             parse_host("UPPER.host:abc"),
             Err(HostParseError::PortNotInt("upper.host".into()))
         );
+    }
+
+    /// The load-bearing split: `key` is bracketed so `split_key` can recover
+    /// the port, while `hostname` stays bare because the connect tuple and
+    /// `known_hosts`'s `host_pattern` both reject a bracketed address.
+    /// Changing either half in isolation breaks connection or host-key
+    /// verification.
+    #[test]
+    fn ipv6_key_is_bracketed_and_hostname_is_not() {
+        for (input, key, port) in [
+            ("::1", "[::1]", 22),
+            ("[::1]", "[::1]", 22),
+            ("[::1]:2222", "[::1]:2222", 2222),
+        ] {
+            let h = parse_host(input).unwrap();
+            assert_eq!(h.key, key, "{input}");
+            assert_eq!(h.hostname, "::1", "{input} hostname must stay bare");
+            assert_eq!(h.port, port, "{input}");
+        }
+    }
+
+    /// Every spelling of one address must collapse to one identity, because
+    /// the `known_hosts` pin is keyed on it and a miss under the default
+    /// `accept-new` policy is not a refusal — it reads as first contact and
+    /// trusts whatever key the network offered. OpenSSH canonicalizes the
+    /// same way (`ssh -G 2001:db8:0:0:0:0:0:1` reports `2001:db8::1`).
+    #[test]
+    fn every_spelling_of_an_address_yields_one_identity() {
+        for input in [
+            "[2001:DB8:0:0:0:0:0:1]:2222",
+            "[2001:db8::1]:2222",
+            "[2001:0db8:0000:0000:0000:0000:0000:0001]:2222",
+        ] {
+            let h = parse_host(input).unwrap();
+            assert_eq!(h.hostname, "2001:db8::1", "{input}");
+            assert_eq!(h.key, "[2001:db8::1]:2222", "{input}");
+        }
+        assert_eq!(parse_host("0:0:0:0:0:0:0:1").unwrap().hostname, "::1");
+        assert_eq!(
+            parse_host("::ffff:7f00:1").unwrap().hostname,
+            "::ffff:127.0.0.1"
+        );
+    }
+
+    /// The guard that closes the silent-misparse class: anything still
+    /// holding a colon after the port is split off was never a hostname, so
+    /// it is refused rather than read as some other host. Before this,
+    /// `2001:db8::1` resolved to host `2001:db8:` on port 1.
+    #[test]
+    fn ambiguous_colon_forms_are_refused_not_misread() {
+        for input in [
+            "fe80::1%eth0",
+            "2001:db8::gg",
+            "foo:bar:80",
+            "[::1",
+            "[example.com]:22",
+        ] {
+            assert!(
+                matches!(parse_host(input), Err(HostParseError::InvalidIpv6(_))),
+                "{input} must be refused, not silently reinterpreted"
+            );
+        }
     }
 }

--- a/crates/repose-core/src/traits.rs
+++ b/crates/repose-core/src/traits.rs
@@ -59,7 +59,8 @@ pub trait SshSession: Send {
 ///    after a successful `Ok` return from `run`.
 #[async_trait]
 pub trait Host: Send {
-    /// Map key: hostname or `host:port` when non-default port.
+    /// Map key: hostname, or `host:port` when non-default port. An IPv6
+    /// address is bracketed at every port (`[::1]`, `[::1]:2222`).
     fn key(&self) -> &str;
 
     fn is_connected(&self) -> bool;

--- a/crates/repose-core/tests/refhost_vectors.rs
+++ b/crates/repose-core/tests/refhost_vectors.rs
@@ -70,6 +70,12 @@ fn golden(dir: &Path, label: &str, file: &str, rendered: &str) -> String {
 
 /// Replicates `commands::list_cmd::split_key`: `host:port`, defaulting to 22.
 fn split_key(key: &str) -> (&str, u16) {
+    if let Some(rest) = key.strip_prefix('[')
+        && let Some((inner, after)) = rest.split_once(']')
+    {
+        let port = after.strip_prefix(':').and_then(|p| p.parse().ok());
+        return (inner, port.unwrap_or(22));
+    }
     if let Some((h, p)) = key.rsplit_once(':')
         && let Ok(port) = p.parse()
     {

--- a/crates/repose-ssh/src/glob.rs
+++ b/crates/repose-ssh/src/glob.rs
@@ -1,15 +1,19 @@
 //! OpenSSH-style glob matching shared by `known_hosts` patterns
 //! ([`crate::hostkey`]) and `ssh_config` `Host` patterns
 //! ([`crate::openssh_config`]). `*` matches any run of characters,
-//! `?` matches exactly one; there are no character classes.
+//! `?` matches exactly one; there are no character classes. Matching is
+//! case-insensitive, as OpenSSH's `match_hostname` is — host names are not
+//! case-sensitive, and treating them as if they were turns a `known_hosts`
+//! entry written in another case into a miss, which under `accept-new`
+//! silently re-pins the host instead of refusing it.
 
 /// Iterative two-pointer match (linear-ish, no recursion): on a mismatch after
 /// a `*`, backtrack the value by one position past the last star instead of
 /// exploring every split recursively — pathological patterns like `"****...a"`
 /// therefore cannot cause exponential blowup.
 pub(crate) fn glob_matches(pattern: &str, value: &str) -> bool {
-    let p: Vec<char> = pattern.chars().collect();
-    let v: Vec<char> = value.chars().collect();
+    let p: Vec<char> = pattern.to_lowercase().chars().collect();
+    let v: Vec<char> = value.to_lowercase().chars().collect();
     let (mut pi, mut vi) = (0usize, 0usize);
     // Position of the most recent `*` in the pattern and the value index the
     // current retry maps it to.
@@ -64,5 +68,17 @@ mod tests {
         assert!(!glob_matches(&pattern, &value));
         assert!(glob_matches(&(pattern + "*"), &(value + "z")));
         assert!(start.elapsed() < std::time::Duration::from_millis(200));
+    }
+
+    /// A `known_hosts` entry written in another case must still match, or
+    /// `accept-new` treats the host as unseen and re-pins it. OpenSSH's
+    /// `match_hostname` lowercases both sides for the same reason.
+    #[test]
+    fn matching_ignores_case_on_both_sides() {
+        assert!(glob_matches("HOST.EXAMPLE", "host.example"));
+        assert!(glob_matches("host.example", "HOST.EXAMPLE"));
+        assert!(glob_matches("[2001:DB8::1]:2222", "[2001:db8::1]:2222"));
+        assert!(glob_matches("*.EXAMPLE", "a.example"));
+        assert!(!glob_matches("other.example", "host.example"));
     }
 }

--- a/crates/repose-ssh/src/hostkey.rs
+++ b/crates/repose-ssh/src/hostkey.rs
@@ -405,7 +405,7 @@ mod tests {
     use repose_core::config::HostKeyPolicy;
     use tempfile::tempdir;
 
-    use super::{HostKeyVerifier, KeyDecision};
+    use super::{HostKeyVerifier, KeyDecision, host_pattern};
 
     /// Test-only stand-in for the production `check_server_key` handler's
     /// decide → persist → record sequence (P1 steps 34–35), run
@@ -579,6 +579,62 @@ mod tests {
             HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path.clone()), "host", 2222).unwrap();
         let mut on_22 = HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "host", 22).unwrap();
         assert!(verify(&mut on_2222, KEY_ONE));
+        assert!(!verify(&mut on_22, KEY_ONE));
+    }
+
+    /// Trust-on-first-use has to close the loop: the entry written on first
+    /// contact must be the one a later, independent run finds. If the write
+    /// and the lookup ever disagreed on spelling, `accept-new` would treat
+    /// every connection as first contact and re-pin whatever key it was
+    /// offered — a miss here is not a refusal.
+    #[test]
+    fn ipv6_first_contact_persists_an_entry_a_later_run_matches() {
+        for (port, expected) in [(22u16, "::1"), (2222, "[::1]:2222")] {
+            let temp = tempdir().unwrap();
+            let path = temp.path().join("known_hosts");
+            fs::write(&path, "").unwrap();
+
+            let mut first =
+                HostKeyVerifier::new(HostKeyPolicy::AcceptNew, Some(path.clone()), "::1", port)
+                    .unwrap();
+            assert!(verify(&mut first, KEY_ONE), "first contact at {port}");
+            assert_eq!(
+                fs::read_to_string(&path).unwrap(),
+                format!("{expected} {KEY_ONE}\n"),
+                "written spelling at {port}"
+            );
+
+            let mut later =
+                HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path.clone()), "::1", port).unwrap();
+            assert!(verify(&mut later, KEY_ONE), "reverify at {port}");
+            assert!(!verify(&mut later, KEY_TWO), "changed key at {port}");
+        }
+    }
+
+    /// OpenSSH spells an IPv6 host plainly at port 22 and `[addr]:port`
+    /// otherwise, and `host_pattern` must reproduce that exactly — an entry
+    /// written by `ssh` has to match, and one we append has to be one `ssh`
+    /// can find. Note the address arrives here BARE: `HostSpec.hostname` is
+    /// unbracketed even though `HostSpec.key` is not, and bracketing it
+    /// twice here would silently stop every IPv6 host verifying.
+    #[test]
+    fn ipv6_uses_the_openssh_known_hosts_spelling() {
+        assert_eq!(host_pattern("::1", 22), "::1");
+        assert_eq!(host_pattern("::1", 2222), "[::1]:2222");
+        assert_eq!(host_pattern("2001:db8::1", 2222), "[2001:db8::1]:2222");
+
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("known_hosts");
+        fs::write(&path, format!("[::1]:2222 {KEY_ONE}\n::1 {KEY_TWO}\n")).unwrap();
+
+        // Each port picks up its own entry, and neither picks up the other's.
+        let mut on_2222 =
+            HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path.clone()), "::1", 2222).unwrap();
+        assert!(verify(&mut on_2222, KEY_ONE));
+        assert!(!verify(&mut on_2222, KEY_TWO));
+
+        let mut on_22 = HostKeyVerifier::new(HostKeyPolicy::Yes, Some(path), "::1", 22).unwrap();
+        assert!(verify(&mut on_22, KEY_TWO));
         assert!(!verify(&mut on_22, KEY_ONE));
     }
 

--- a/tests/vectors/hostparse/hosts.json
+++ b/tests/vectors/hostparse/hosts.json
@@ -46,5 +46,73 @@
   {
     "input": "host:99999",
     "ok": false
+  },
+  {
+    "input": "[::1]",
+    "ok": true,
+    "key": "[::1]",
+    "hostname": "::1",
+    "port": 22,
+    "username": "root"
+  },
+  {
+    "input": "[::1]:2222",
+    "ok": true,
+    "key": "[::1]:2222",
+    "hostname": "::1",
+    "port": 2222,
+    "username": "root"
+  },
+  {
+    "input": "admin@[2001:db8::1]:2222",
+    "ok": true,
+    "key": "[2001:db8::1]:2222",
+    "hostname": "2001:db8::1",
+    "port": 2222,
+    "username": "admin"
+  },
+  {
+    "input": "::1",
+    "ok": true,
+    "key": "[::1]",
+    "hostname": "::1",
+    "port": 22,
+    "username": "root"
+  },
+  {
+    "input": "2001:DB8::1",
+    "ok": true,
+    "key": "[2001:db8::1]",
+    "hostname": "2001:db8::1",
+    "port": 22,
+    "username": "root"
+  },
+  {
+    "input": "[::1",
+    "ok": false
+  },
+  {
+    "input": "[example.com]:22",
+    "ok": false
+  },
+  {
+    "input": "fe80::1%eth0",
+    "ok": false
+  },
+  {
+    "input": "foo:bar:80",
+    "ok": false
+  },
+  {
+    "input": "[2001:0db8:0000:0000:0000:0000:0000:0001]:2222",
+    "ok": true,
+    "key": "[2001:db8::1]:2222",
+    "hostname": "2001:db8::1",
+    "port": 2222,
+    "username": "root"
+  },
+  {
+    "input": "[]",
+    "ok": false
   }
 ]


### PR DESCRIPTION
## What

`-t 2001:db8::1` did not fail — it connected to a **different host**. `parse_host`
split on the last colon, so the address decomposed into hostname `2001:db8:` and
port `1`. `-t ::1` became host `:` port 1. Only an address whose final group was
non-numeric errored at all, and then as a confusing "wrong port specification".

Bracketed targets are now accepted (`[2001:db8::1]`, `[2001:db8::1]:2222`), and a
bare literal is taken at the default port — a colon cannot appear in a hostname,
so the form is unambiguous. `std::net::Ipv6Addr` does the parsing; no new
dependency.

The guard that closes the whole class is one line: once the port is split off, a
hostname still holding a colon was never a hostname, so it is refused rather than
reinterpreted.

## The review changed the design twice

Both changes were security-relevant, and both came from adversarial review rather
than from writing the parser.

**The address is canonicalised, and my first version deliberately did not do
that.** I had reasoned that `known_hosts` stores literal text, so collapsing
`2001:db8:0:0:0:0:0:1` to `2001:db8::1` would stop entries matching. That is the
exact inverse of what OpenSSH does — it runs a numeric target through
`getnameinfo(NI_NUMERICHOST)` before lookup *and* before writing:

```
$ ssh -G 2001:db8:0:0:0:0:0:1   ->  hostname 2001:db8::1
$ ssh -G ::ffff:7f00:1          ->  hostname ::ffff:127.0.0.1
```

Storing the text as typed gives one address as many identities as it has
spellings. That is not a cosmetic wart: the default policy is `accept-new`, and
`decide()` cannot distinguish "never seen this host" from "spelled its name
differently than the file does". A missed identity therefore reads as first
contact — the key the network just offered gets trusted and appended next to the
real pin, silently.

**`split_key` had to learn about brackets.** Keying IPv6 as bare `::1` reintroduces
the identical bug one layer downstream, because `split_key` takes a numeric tail
after the last colon: `::1` decodes to host `:` port 1, and `list-products` would
have emitted `"host": ":"`. Bracketing at *every* port makes it correct by
construction — a bracketed key always ends in `]` — and `split_key` now strips the
brackets back off so callers still see the bare address. There is a round-trip
test over every key shape `parse_host` can build, which is the test whose absence
let this through the first time.

## Three invariants, each pinned by a test

- **The address is canonical**, so every spelling shares one `known_hosts` entry.
- **`key` is bracketed at every port** and `split_key` inverts it.
- **`hostname` is never bracketed.** The connect tuple resolves `::1` natively but
  fails DNS on `[::1]`, and `known_hosts`'s `host_pattern` adds brackets itself,
  so bracketing here would produce `[[::1]]:2222`.

Plus a trust-on-first-use round trip: first contact writes an entry, and a fresh
verifier reading that file back accepts the same key and refuses a changed one, at
both the default and a non-default port.

## Second commit: case-insensitive `known_hosts` matching

Pre-existing, but this feature makes it reachable, and it is the same fail-open
shape. OpenSSH's `match_hostname` lowercases both sides; `glob_matches` compared
chars directly, so an entry written in another case missed — and a miss under
`accept-new` re-pins the host. Reachable today via a mixed-case `HostName` in
`~/.ssh/config`, which is never lowercased, and for IPv6 because OpenSSH preserves
user-typed case when the canonical form differs only by case.

## Also

`yaml_string` now quotes a value opening with a YAML c-indicator or padded with
whitespace: a bracketed host reached `list-products --yaml` as `name: [::1]`,
which reads back as a flow sequence rather than a string, and padding was silently
trimmed. `-`, `?` and `:` are deliberately *not* treated as indicators — YAML 1.2
lets them open a plain scalar, and `sle-ha` / `15-SP3` must stay unquoted.

Zone indices (`fe80::1%eth0`) are refused rather than half-supported, so
link-local targets are explicitly unsupported rather than quietly mangled.

## Testing

Full `make check` green, plus the two gates outside it — `cargo doc` under
`RUSTDOCFLAGS=-D warnings`, and `typos` 1.48.0. Canonicalisation and the
`known_hosts` spelling were verified against the local OpenSSH 10.0p2 rather than
assumed. No drift in the generated man pages or completions. Independent of #263;
the two merge cleanly in either order.

_AI-assisted._
