### PR TITLE
fix(ci): read the release version from [workspace.package] only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,18 @@ jobs:
       - name: Verify tag matches workspace version
         shell: bash
         run: |
-          pkg="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+          # Scoped to the [workspace.package] table and anchored at the
+          # closing quote. Unscoped, the first `version = ` key in any table
+          # that happens to precede it wins (a `[workspace.dependencies.foo]`
+          # entry would yield its version); unanchored, `\(.*\)"` keeps any
+          # trailing comment inside the value, so an annotated version line
+          # fails a correctly tagged release.
+          pkg="$(sed -n '/^\[workspace\.package\]/,/^\[/p' Cargo.toml |
+                 sed -n 's/^version = "\([^"]*\)".*/\1/p' | head -1)"
+          if [ -z "$pkg" ]; then
+            echo "::error::no version found in [workspace.package] of Cargo.toml"
+            exit 1
+          fi
           if [ "$pkg" != "$GITHUB_REF_NAME" ]; then
             echo "::error::tag '$GITHUB_REF_NAME' != workspace version '$pkg'"
             exit 1


### PR DESCRIPTION
The tag/version guard in `release.yml` extracts the workspace version with an unscoped, unanchored `sed`. Two ways that misreads a correct manifest:

**Unscoped** — the first column-0 `version = ` key wins, whatever table it sits in. Hoisting shared dependency pins into `[workspace.dependencies.foo]` sub-tables above `[workspace.package]` (a natural refactor here — `tokio` and `futures-util` are duplicated across all three manifests) makes the guard read the *dependency* version and reject every tag:

```
[workspace.dependencies.tokio]
version = "1"          <- guard reads this

[workspace.package]
version = "3.1.1"      <- meant to read this
```

**Unanchored** — `s/^version = "\(.*\)"/\1/p` substitutes only the matched span but prints the whole resulting line, so anything after the closing quote survives. Annotating the version line leaves `pkg` as `3.1.1  # ...`, and a correctly tagged release fails with:

```
::error::tag '3.1.1' != workspace version '3.1.1  # ...'
```

Neither is reachable with the manifest as it stands today, and both fail closed — a release is blocked, never mis-tagged. What makes it worth fixing anyway is that this step runs **only on a tag push**, so a latent break surfaces during a release rather than in CI.

## Change

Scope the `sed` range to the `[workspace.package]` table and anchor the capture at the closing quote, plus an explicit error when no version is found — an empty `pkg` previously reported a confusing mismatch against the empty string.

## Verification

Extraction compared old vs new across four manifests:

| manifest | old | new |
|---|---|---|
| current repo `Cargo.toml` | `3.1.1` | `3.1.1` |
| trailing comment on the version line | `3.1.1  # bump me` | `3.1.1` |
| `[workspace.dependencies.tokio]` before `[workspace.package]` | `1` | `3.1.1` |
| no `[workspace.package]` at all | *(empty)* | *(empty)* -> new explicit error |

The step was then run end-to-end under GitHub's exact shell (`bash --noprofile --norc -eo pipefail`) against the real `Cargo.toml`: `3.1.1` exits 0, `3.1.0` exits 1 with the intended message. YAML parses, and `yamllint` reports no new line-length findings.

_AI-assisted._