### PR TITLE
fix(ci): close two asset-pipeline gaps and harden repose-gen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
+      - name: Clippy (gen feature)
+        # Without this leg `repose-gen.rs` is never linted: clippy skips
+        # binaries whose required-features are off, and the drift job only
+        # `cargo run`s the tool, where warnings do not fail. Mirrors the
+        # second clippy line of `make clippy`.
+        run: cargo clippy --workspace --all-targets --features gen --locked -- -D warnings
       - name: Layering (core ↛ ssh/russh)
         run: bash scripts/check-rust-layering.sh
       - name: Test
@@ -209,10 +215,21 @@ jobs:
         with:
           workspaces: . -> target
       - name: Regenerate man pages + completions
-        run: cargo run --locked -p repose-cli --features gen --bin repose-gen -- crates/repose-cli
+        # Empty the asset directories first: regenerating over the committed
+        # files hides an output the generator stopped emitting (dropped or
+        # renamed) — it stays byte-identical and tracked, so neither drift
+        # check below would ever see it. After the wipe it surfaces as a
+        # deletion in the diff. The output directory stays explicit: the
+        # tool's built-in default is baked at compile time, and an explicit
+        # path keeps the destination right even for a binary compiled at a
+        # different checkout location.
+        run: |
+          rm -rf crates/repose-cli/man crates/repose-cli/completions
+          cargo run --locked -p repose-cli --features gen --bin repose-gen -- crates/repose-cli
       - name: Check for drift
-        # Fail on modified tracked assets AND on untracked leftovers (e.g. a
-        # renamed page that regeneration no longer produces/overwrites).
+        # Fail on modified/deleted tracked assets AND on untracked leftovers
+        # (a renamed page shows up as both: a deletion of the old name and an
+        # untracked file under the new one).
         run: |
           git diff --exit-code -- crates/repose-cli/man crates/repose-cli/completions
           untracked="$(git status --porcelain -- crates/repose-cli/man crates/repose-cli/completions)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,14 @@ Run commands from the repository root:
 ```bash
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --features gen -- -D warnings
 cargo test --workspace --all-targets --locked
 cargo deny check
 ```
+
+The second clippy line is not optional: without `--features gen` the
+`repose-gen` binary is skipped entirely (required-features off), so a
+violation there passes the first line and fails only the gen leg.
 
 Use the toolchain pinned in `rust-toolchain.toml` (repo root). The workspace MSRV is
 declared once in `Cargo.toml` (`rust-version = "1.96"`); do not introduce APIs

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ layer:        ## enforce core -/-> ssh layering
 cli:          ## CLI consistency self-check vs committed expected output
 	bash scripts/check-cli.sh
 assets:       ## regenerate committed man pages + shell completions
+	rm -rf crates/repose-cli/man crates/repose-cli/completions
 	cargo run --locked -p repose-cli --features gen --bin repose-gen -- crates/repose-cli
 check: fmt clippy test deny layer cli  ## the local gate (CI additionally runs typos, docs, coverage, MSRV, assets drift)
 install:      ## install `repose` into ~/.cargo/bin

--- a/crates/README.md
+++ b/crates/README.md
@@ -104,12 +104,15 @@ variant.
 generator crates):
 
 ```bash
-# from repository root (the argument is the output directory)
-cargo run -p repose-cli --features gen --bin repose-gen -- crates/repose-cli
+# from repository root; wipes the asset dirs first so an output the
+# generator no longer emits shows up as a deletion instead of surviving
+make assets
 ```
 
-CI (`rust-assets-drift`) regenerates and `git diff --exit-code`s these paths,
-so they can never drift from the CLI. Install paths (rename the generated
+(`repose-gen` alone also works: the optional argument is the output
+directory, defaulting to the crate's own.) CI (`rust-assets-drift`) runs the
+same wipe + regenerate and `git diff --exit-code`s these paths, so a
+modified, added, *or dropped* output can never drift from the CLI. Install paths (rename the generated
 files to the distro convention):
 
 | Asset | Generated file | Install path |

--- a/crates/repose-cli/src/bin/repose-gen.rs
+++ b/crates/repose-cli/src/bin/repose-gen.rs
@@ -7,13 +7,21 @@
 use std::path::{Path, PathBuf};
 
 fn main() -> std::process::ExitCode {
-    let out = std::env::args()
+    // `args_os`, not `args`: the argument is a path, which need not be UTF-8
+    // — a non-UTF-8 path is legal on Unix and must work, where `args()`
+    // panics on it. The default is this crate's own directory: a cwd-relative
+    // default would nest a stray `crates/repose-cli/crates/repose-cli/` tree
+    // when run from inside the crate. The path is baked at compile time, so a
+    // stale binary whose source tree has moved recreates the old location —
+    // invoke via `make assets`/`cargo run`, or pass the directory explicitly
+    // as CI and the Makefile do.
+    let out = std::env::args_os()
         .nth(1)
-        .map_or_else(|| PathBuf::from("crates/repose-cli"), PathBuf::from);
+        .map_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")), PathBuf::from);
     match generate(&out) {
         Ok(()) => std::process::ExitCode::SUCCESS,
         Err(e) => {
-            eprintln!("error: {e}");
+            eprintln!("error: {}: {e}", out.display());
             std::process::ExitCode::from(2)
         }
     }


### PR DESCRIPTION
Fixes #272.

## What

**1. The drift gate now catches a dropped generator output.** `rust-assets-drift` regenerated *over* the committed assets, so an output the generator stops emitting (dropped, or the old name in a rename) stayed byte-identical and tracked — invisible to both the `git diff` and the untracked-leftovers check — and would ship stale in release tarballs forever. The job and `make assets` now empty `crates/repose-cli/{man,completions}` first, so a dropped output surfaces as a deletion and fails the diff.

**2. `repose-gen.rs` is now clippy-linted in CI.** Clippy skips binaries whose `required-features` are off, and the drift job only `cargo run`s the tool (rustc warnings don't fail there) — so the generator reached CI unlinted in a deny-warnings repo. CI gains the `--features gen` clippy leg the Makefile already had; the AGENTS.md command block documents it.

**3. Two `repose-gen` footguns from the same review:**
- The default output dir was the **cwd-relative** `crates/repose-cli`, silently nesting a stray `crates/repose-cli/crates/repose-cli/` tree when run from inside the crate. Now defaults to the crate's own directory (`CARGO_MANIFEST_DIR`). Since that value is baked at compile time and cargo does not fingerprint it, a stale binary from a moved checkout would recreate the old path — so CI and the Makefile keep passing the output directory **explicitly**; the baked default serves manual runs.
- `std::env::args()` panics on a non-UTF-8 argument; the argument is a path, which need not be UTF-8. Switched to `args_os()`, and the error path now names the path it failed on.

## Verification

Every acceptance criterion in #272 was mutation-tested:

| criterion | test | result |
|---|---|---|
| dropped output fails the job | staged a fake `repose-stale.1`, ran the new step | `git diff` exits 1 with the deletion |
| clippy violation in repose-gen fails CI | injected `needless_return` | default leg exit 0 (the gap, confirmed), gen leg exit 101 |
| unmodified checkout stays green | wipe + regenerate | byte-identical, no untracked leftovers |

Plus: run from inside the crate dir → no nested tree; `$'\xff\xfe'` argument → old code panics (verified), new code succeeds; permission-denied on the output dir → error now names the path. Full `make check` green.

Two adversarial reviews ran before this PR; their findings (a moved-checkout hazard in an earlier draft that dropped the explicit CI/Makefile argument — reinstated; comment overclaims; stale `crates/README.md` invocation) are incorporated. The gate semantics were additionally mutation-verified for mode changes, case-only renames, and pure additions — each fails exactly one of the two drift checks, so both checks are load-bearing.

_AI-assisted._