### PR TITLE
chore(release): 3.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,7 +2140,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "repose-cli"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "repose-core"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "repose-ssh"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.1.1"
+version = "3.2.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/openSUSE/repose"

--- a/crates/README.md
+++ b/crates/README.md
@@ -84,7 +84,7 @@ Run these commands from the repository root.
 
 - **Layering:** `repose-core` must never depend on `repose-ssh` or `russh`; `scripts/check-rust-layering.sh` enforces it, and CI runs it.
 - **Single SSH backend:** `deny.toml` bans `ssh2` / `libssh2-sys` / async-ssh2-* crates.
-- **Path deps** pin the workspace version (`version = "3.1.1"`) so `cargo-deny` `wildcards = "deny"` accepts them.
+- **Path deps** pin the workspace version (`version = "3.2.0"`) so `cargo-deny` `wildcards = "deny"` accepts them.
 - **Binary name:** `repose` (replace strategy; no `repose-rs`).
 
 Behavior is pinned by the committed expected-output vectors under

--- a/crates/repose-cli/Cargo.toml
+++ b/crates/repose-cli/Cargo.toml
@@ -29,8 +29,8 @@ gen = ["dep:clap_complete", "dep:clap_mangen"]
 workspace = true
 
 [dependencies]
-repose-core = { path = "../repose-core", version = "3.0.0" }
-repose-ssh = { path = "../repose-ssh", version = "3.0.0" }
+repose-core = { path = "../repose-core", version = "3.2.0" }
+repose-ssh = { path = "../repose-ssh", version = "3.2.0" }
 clap = { version = "4", features = ["derive"] }
 clap_complete = { version = "4", optional = true }
 clap_mangen = { version = "0.3", optional = true }

--- a/crates/repose-cli/man/repose-add.1
+++ b/crates/repose-cli/man/repose-add.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-add 1  "repose-add 3.1.1" 
+.TH repose-add 1  "repose-add 3.2.0" 
 .SH NAME
 repose\-add \- add specified repository to target
 .SH SYNOPSIS
@@ -90,4 +90,4 @@ Print help
 <\fIREPA\fR>
 REPA pattern specification for needed repository
 .SH VERSION
-v3.1.1
+v3.2.0

--- a/crates/repose-cli/man/repose-clear.1
+++ b/crates/repose-cli/man/repose-clear.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-clear 1  "repose-clear 3.1.1" 
+.TH repose-clear 1  "repose-clear 3.2.0" 
 .SH NAME
 repose\-clear \- clear all repositories from target
 .SH SYNOPSIS
@@ -81,4 +81,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.1.1
+v3.2.0

--- a/crates/repose-cli/man/repose-install.1
+++ b/crates/repose-cli/man/repose-install.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-install 1  "repose-install 3.1.1" 
+.TH repose-install 1  "repose-install 3.2.0" 
 .SH NAME
 repose\-install \- add specified repository to target and install product
 .SH SYNOPSIS
@@ -93,4 +93,4 @@ Print help
 <\fIREPA\fR>
 REPA pattern specification for needed repository
 .SH VERSION
-v3.1.1
+v3.2.0

--- a/crates/repose-cli/man/repose-known-products.1
+++ b/crates/repose-cli/man/repose-known-products.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-known-products 1  "repose-known-products 3.1.1" 
+.TH repose-known-products 1  "repose-known-products 3.2.0" 
 .SH NAME
 repose\-known\-products \- list known products by \*(Aqrepose\*(Aq
 .SH SYNOPSIS
@@ -78,4 +78,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.1.1
+v3.2.0

--- a/crates/repose-cli/man/repose-list-products.1
+++ b/crates/repose-cli/man/repose-list-products.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-list-products 1  "repose-list-products 3.1.1" 
+.TH repose-list-products 1  "repose-list-products 3.2.0" 
 .SH NAME
 repose\-list\-products \- list products on target
 .SH SYNOPSIS
@@ -84,4 +84,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.1.1
+v3.2.0

--- a/crates/repose-cli/man/repose-list-repos.1
+++ b/crates/repose-cli/man/repose-list-repos.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-list-repos 1  "repose-list-repos 3.1.1" 
+.TH repose-list-repos 1  "repose-list-repos 3.2.0" 
 .SH NAME
 repose\-list\-repos \- list repositories on target
 .SH SYNOPSIS
@@ -81,4 +81,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.1.1
+v3.2.0

--- a/crates/repose-cli/man/repose-remove.1
+++ b/crates/repose-cli/man/repose-remove.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-remove 1  "repose-remove 3.1.1" 
+.TH repose-remove 1  "repose-remove 3.2.0" 
 .SH NAME
 repose\-remove \- remove repository from target
 .SH SYNOPSIS
@@ -84,4 +84,4 @@ Print help
 <\fIREPA\fR>
 REPA pattern specification for needed repository
 .SH VERSION
-v3.1.1
+v3.2.0

--- a/crates/repose-cli/man/repose-reset.1
+++ b/crates/repose-cli/man/repose-reset.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-reset 1  "repose-reset 3.1.1" 
+.TH repose-reset 1  "repose-reset 3.2.0" 
 .SH NAME
 repose\-reset \- reset target repositories to only installed products repositories
 .SH SYNOPSIS
@@ -87,4 +87,4 @@ path to a custom known_hosts file (overrides ~/.ssh/known_hosts)
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH VERSION
-v3.1.1
+v3.2.0

--- a/crates/repose-cli/man/repose-uninstall.1
+++ b/crates/repose-cli/man/repose-uninstall.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose-uninstall 1  "repose-uninstall 3.1.1" 
+.TH repose-uninstall 1  "repose-uninstall 3.2.0" 
 .SH NAME
 repose\-uninstall \- remove specified repository from target and uninstall product
 .SH SYNOPSIS
@@ -87,4 +87,4 @@ Print help
 <\fIREPA\fR>
 REPA pattern specification for needed repository
 .SH VERSION
-v3.1.1
+v3.2.0

--- a/crates/repose-cli/man/repose.1
+++ b/crates/repose-cli/man/repose.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH repose 1  "repose 3.1.1" 
+.TH repose 1  "repose 3.2.0" 
 .SH NAME
 repose \- Repository manipulation tool for QAM
 .SH SYNOPSIS
@@ -109,4 +109,4 @@ list known products by \*(Aqrepose\*(Aq
 repose\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v3.1.1
+v3.2.0

--- a/crates/repose-ssh/Cargo.toml
+++ b/crates/repose-ssh/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 workspace = true
 
 [dependencies]
-repose-core = { path = "../repose-core", version = "3.0.0" }
+repose-core = { path = "../repose-core", version = "3.2.0" }
 async-trait = "0.1"
 # >=0.60.3 for GHSA-g9f8-wqj9-fjw5 (CryptoVec growth)
 russh = "0.62"


### PR DESCRIPTION
Minor version bump: 3.1.1 → 3.2.0.

- `[workspace.package] version` bumped to `3.2.0`.
- Path-dep pins in `crates/repose-cli/Cargo.toml` and `crates/repose-ssh/Cargo.toml` realigned from `3.0.0` to `3.2.0`, and the `crates/README.md` note updated to match.
- `Cargo.lock` refreshed (only the three `repose-*` entries move).
- `crates/repose-cli/man/*.1` regenerated via `make assets` (version string only — no help-text churn).

Rationale for the minor bump: new public resource-limit config and trait surface landed in `repose-core` since `3.1.1`.

Local gate (`make check`: fmt, clippy incl. `--features gen`, tests, deny, layering, CLI self-check) passes.

After this merges, an annotated tag `3.2.0` will be created on the merged commit to trigger the release workflow.