### PR TITLE
fix(perf): make the ssh performance harness run and measure honestly

### DIFF
--- a/scripts/run-performance-baseline-ssh.sh
+++ b/scripts/run-performance-baseline-ssh.sh
@@ -17,9 +17,15 @@ set -euo pipefail
 : "${REPOSE_PERF_VALIDATOR:?run-performance-baseline.sh must set this}"
 : "${REPOSE_PERF_OUT:?run-performance-baseline.sh must set this}"
 
-REPS="${REPOSE_PERF_SSH_REPS:-5}"
-WARMUP="${REPOSE_PERF_SSH_WARMUP:-1}"
+# Defaults clear thresholds.json's `minimum_repetitions` (10), so an ssh
+# report is comparable without having to be asked for more repetitions.
+REPS="${REPOSE_PERF_SSH_REPS:-10}"
+WARMUP="${REPOSE_PERF_SSH_WARMUP:-2}"
 RUNNER_CLASS="${REPOSE_PERF_RUNNER_CLASS:-local-dev}"
+PROFILE="${REPOSE_PERF_PROFILE:-release}"
+# Set by run-performance-baseline.sh once it resolves which container runtime
+# started the fixture; null until then, never guessed.
+FIXTURE_RUNTIME="${REPOSE_PERF_FIXTURE_RUNTIME:-}"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
@@ -246,6 +252,10 @@ run_workload() {
 		--argjson stderr_digest "$stderr_digest" \
 		--arg toolchain "$(rustc --version)" \
 		--arg runner_class "$RUNNER_CLASS" \
+		--arg profile "$PROFILE" \
+		--arg rustflags "${RUSTFLAGS:-}" \
+		--arg fixture_runtime "$FIXTURE_RUNTIME" \
+		--arg target "$REPOSE_SSH_HOST:$REPOSE_SSH_PORT" \
 		--arg os "$(uname -s)" \
 		--arg arch "$(uname -m)" \
 		--arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -253,21 +263,32 @@ run_workload() {
             contract_version: 1,
             workload_id: $id,
             kind: "ssh",
-            runner: { os: $os, arch: $arch, toolchain: $toolchain, runner_class: $runner_class },
+            runner: {
+                os: $os, arch: $arch, toolchain: $toolchain,
+                profile: $profile, rustflags: $rustflags,
+                fixture_runtime: (if $fixture_runtime == "" then null else $fixture_runtime end),
+                runner_class: $runner_class
+            },
             generated_at: $generated_at,
             repetitions: $reps,
             warmup_repetitions: $warmup,
+            host_count: $host_count,
             wall_time_ns: ($samples | sort),
             latency_ns: { p50: $p50, p95: $p95, p99: $p99 },
             throughput_ops_per_sec: ($host_count / ($p50 / 1e9)),
             peak_rss_bytes: null,
-            command_count: 1,
-            probe_count: 0,
-            peak_concurrency: $host_count,
+            # Nothing here observes the remote command count, the probe count
+            # or the achieved concurrency: they would have to come from
+            # instrumenting the fixture. The deterministic `mock` workloads
+            # already gate all three, so these are reported as unknown rather
+            # than restated from the workload definition.
+            command_count: null,
+            probe_count: null,
+            peak_concurrency: null,
             exit_code: $exit_code,
             stdout_digest: $stdout_digest,
             stderr_digest: $stderr_digest,
-            host_order: [$id]
+            host_order: [$target]
         }' >"$REPOSE_PERF_OUT/$id.json.tmp"
 
 	jq -e -f "$REPOSE_PERF_VALIDATOR" "$REPOSE_PERF_OUT/$id.json.tmp" >/dev/null || return 1

--- a/scripts/run-performance-baseline-ssh.sh
+++ b/scripts/run-performance-baseline-ssh.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 # repose has no identity flag: the client key reaches it through the
 # `IdentityFile` line the fixture writes into $HOME/.ssh/config.
 : "${REPOSE_SSH_TARGET:?tests/ssh/run.sh must set this}"
+: "${REPOSE_SSH_HOST:?tests/ssh/run.sh must set this}"
+: "${REPOSE_SSH_PORT:?tests/ssh/run.sh must set this}"
 : "${REPOSE_SSH_KNOWN_HOSTS:?tests/ssh/run.sh must set this}"
 : "${REPOSE_BIN:?run-performance-baseline.sh must set this}"
 : "${REPOSE_PERF_WORKLOADS:?run-performance-baseline.sh must set this}"
@@ -21,7 +23,11 @@ RUNNER_CLASS="${REPOSE_PERF_RUNNER_CLASS:-local-dev}"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-: >"$tmp/empty_known_hosts"
+
+# Every repetition's exact stdout/stderr bytes, kept for debugging a digest
+# mismatch: the digests below are of the *normalized* streams, so the raw
+# ones are the only way to see what actually differed.
+RAW_IO="$REPOSE_PERF_OUT/raw-io"
 
 sha256_of() {
 	if command -v sha256sum >/dev/null; then
@@ -31,31 +37,146 @@ sha256_of() {
 	fi
 }
 
-# Build the repose argv for one ssh-kind workload (jq object on stdin as $w).
+# The fixture's port is ephemeral, so the raw streams differ between runs in
+# a way that says nothing about performance. Fold both spellings the output
+# carries — `[host]:port` (known_hosts entries, host-key messages) and
+# `host:port` (the target echo, the `Host:` header) — to fixed placeholders
+# before hashing.
+#
+# `jq -Rsj` round-trips the stream verbatim, so a stream that does not end in
+# a newline still does not after normalizing; `sed` would append one on BSD
+# but not on GNU and make the digest depend on the runner's userland.
+# `split`/`join` on a plain string is a literal replacement, so a host that
+# looks like a regex cannot misfire.
+normalized_digest() {
+	jq -Rsj \
+		--arg bracket "[$REPOSE_SSH_HOST]:$REPOSE_SSH_PORT" \
+		--arg plain "$REPOSE_SSH_HOST:$REPOSE_SSH_PORT" \
+		'split($bracket) | join("[FIXTURE]:PORT")
+		 | split($plain) | join("FIXTURE:PORT")' "$1" | sha256_of
+}
+
+# Build the repose argv for one ssh-kind workload ($1: workload JSON,
+# $2: the known_hosts path this repetition must use).
 build_args() {
-	local w="$1"
+	local w="$1" known_hosts="$2"
 	local args=()
-	local host_key_policy known_hosts output_format debug dry command
+	local host_key_policy output_format debug dry command
 
 	host_key_policy="$(jq -r '.host_key_policy // "yes"' <<<"$w")"
-	known_hosts_state="$(jq -r '.known_hosts_state // "prepopulated"' <<<"$w")"
 	output_format="$(jq -r '.output_format // "text"' <<<"$w")"
 	debug="$(jq -r '.debug // false' <<<"$w")"
 	dry="$(jq -r '.dry // false' <<<"$w")"
 	command="$(jq -r '.command' <<<"$w")"
 
-	if [[ "$known_hosts_state" == "empty" ]]; then
-		known_hosts="$tmp/empty_known_hosts"
+	args+=(--strict-host-key-checking="$host_key_policy" --known-hosts "$known_hosts")
+	if [[ "$output_format" == "json" ]]; then
+		args+=(--format=json)
+	fi
+	if [[ "$debug" == "true" ]]; then
+		args+=(--debug)
+	fi
+	if [[ "$dry" == "true" ]]; then
+		args+=(--print)
+	fi
+	args+=("$command" -t "$REPOSE_SSH_TARGET")
+	printf '%s\n' "${args[@]}"
+}
+
+# One repetition of one workload ($1: workload JSON, $2: id, $3: label).
+# Sets RUN_EXIT, RUN_OUT, RUN_ERR, RUN_STDOUT_DIGEST, RUN_STDERR_DIGEST and
+# leaves the raw bytes on disk. Wall time is measured by the caller so that
+# none of this bookkeeping lands inside the timed window.
+run_once() {
+	local w="$1" id="$2" label="$3"
+	local state known_hosts
+	local -a args
+
+	state="$(jq -r '.known_hosts_state // "prepopulated"' <<<"$w")"
+	if [[ "$state" == "empty" ]]; then
+		# A *fresh* file per repetition, warmups included. Sharing one file
+		# would make every repetition after the first a known host, and the
+		# workload would silently stop measuring first contact.
+		known_hosts="$tmp/known_hosts-$id-$label"
+		: >"$known_hosts"
+		if [[ -s "$known_hosts" ]]; then
+			echo "$id/$label: known_hosts was not empty before the run" >&2
+			return 1
+		fi
 	else
 		known_hosts="$REPOSE_SSH_KNOWN_HOSTS"
 	fi
 
-	args+=(--strict-host-key-checking="$host_key_policy" --known-hosts "$known_hosts")
-	[[ "$output_format" == "json" ]] && args+=(--format=json)
-	[[ "$debug" == "true" ]] && args+=(--debug)
-	[[ "$dry" == "true" ]] && args+=(--print)
-	args+=("$command" -t "$REPOSE_SSH_TARGET")
-	printf '%s\n' "${args[@]}"
+	mapfile -t args < <(build_args "$w" "$known_hosts")
+
+	RUN_OUT="$RAW_IO/$id/$label.out"
+	RUN_ERR="$RAW_IO/$id/$label.err"
+	RUN_EXIT=0
+	RUN_START="$(date +%s%N)"
+	env -u SSH_AUTH_SOCK -u COLOR NO_COLOR=1 "$REPOSE_BIN" "${args[@]}" \
+		>"$RUN_OUT" 2>"$RUN_ERR" || RUN_EXIT=$?
+	RUN_END="$(date +%s%N)"
+
+	# That the file gained exactly one entry *is* the proof this repetition
+	# accepted the host key on first contact; without it the run could have
+	# been trusting a key it already had.
+	if [[ "$state" == "empty" ]]; then
+		local entries
+		entries="$(grep -c . "$known_hosts" || true)"
+		if [[ "$entries" -ne 1 ]]; then
+			echo "$id/$label: known_hosts has $entries entries after the run, want exactly 1" >&2
+			return 1
+		fi
+	fi
+
+	RUN_STDOUT_DIGEST="$(normalized_digest "$RUN_OUT")"
+	RUN_STDERR_DIGEST="$(normalized_digest "$RUN_ERR")"
+}
+
+# Enforce the workload's reviewed `expect` block against one repetition.
+check_expect() {
+	local w="$1" id="$2" label="$3"
+	local want_exit needle
+
+	want_exit="$(jq -r '.expect.exit_code' <<<"$w")"
+	if [[ "$RUN_EXIT" -ne "$want_exit" ]]; then
+		echo "$id/$label: exit code changed (want $want_exit, got $RUN_EXIT)" >&2
+		cat "$RUN_ERR" >&2
+		return 1
+	fi
+	while IFS= read -r needle; do
+		if [[ -z "$needle" ]]; then
+			continue
+		fi
+		if ! grep -Fq -- "$needle" "$RUN_OUT"; then
+			echo "$id/$label: stdout no longer contains expected substring: $needle" >&2
+			return 1
+		fi
+	done < <(jq -r '.expect.stdout_contains[]?' <<<"$w")
+}
+
+# The first repetition fixes the digests; every later one must reproduce
+# them. Reporting only the last run's digest would let genuinely unstable
+# output through as a stable-looking number.
+#
+# A workload may declare `expect.stderr_digest: null` to opt its stderr out,
+# for a stream that provably cannot reproduce (see the reason recorded
+# alongside it in workloads.json). stdout is never exempt.
+assert_stable() {
+	local id="$1" label="$2"
+	if [[ -z "$FIRST_STDOUT_DIGEST" ]]; then
+		FIRST_STDOUT_DIGEST="$RUN_STDOUT_DIGEST"
+		FIRST_STDERR_DIGEST="$RUN_STDERR_DIGEST"
+		return 0
+	fi
+	if [[ "$RUN_STDOUT_DIGEST" != "$FIRST_STDOUT_DIGEST" ]] ||
+		{ [[ "$SKIP_STDERR_DIGEST" -eq 0 ]] && [[ "$RUN_STDERR_DIGEST" != "$FIRST_STDERR_DIGEST" ]]; }; then
+		echo "$id/$label: normalized output is not stable across repetitions" >&2
+		echo "  first:  out=$FIRST_STDOUT_DIGEST err=$FIRST_STDERR_DIGEST" >&2
+		echo "  $label: out=$RUN_STDOUT_DIGEST err=$RUN_STDERR_DIGEST" >&2
+		echo "  raw streams kept under $RAW_IO/$id/" >&2
+		return 1
+	fi
 }
 
 percentile_ns() {
@@ -66,45 +187,50 @@ percentile_ns() {
 run_workload() {
 	local id="$1" w
 	w="$(jq -c --arg id "$id" '.workloads[] | select(.id == $id)' "$REPOSE_PERF_WORKLOADS")"
-	mapfile -t args < <(build_args "$w")
 
 	echo "-- $id --"
-	local i exit_code=0 stdout="" stderr=""
+	rm -rf "${RAW_IO:?}/$id"
+	mkdir -p "$RAW_IO/$id"
+
+	local i label
+	FIRST_STDOUT_DIGEST=""
+	FIRST_STDERR_DIGEST=""
+	SKIP_STDERR_DIGEST=0
+	if [[ "$(jq -r '.expect | has("stderr_digest") and .stderr_digest == null' <<<"$w")" == "true" ]]; then
+		SKIP_STDERR_DIGEST=1
+	fi
+
+	# Warmups are checked exactly as measured repetitions are; only their
+	# timings are discarded.
+	# `run_workload` is called as `run_workload ... || failed=1`, which
+	# disables errexit for everything it calls: every failure has to be
+	# propagated by hand.
 	for ((i = 0; i < WARMUP; i++)); do
-		stdout="$(env -u SSH_AUTH_SOCK -u COLOR NO_COLOR=1 "$REPOSE_BIN" "${args[@]}" 2>"$tmp/stderr")" || exit_code=$?
+		label="warmup-$i"
+		run_once "$w" "$id" "$label" || return 1
+		check_expect "$w" "$id" "$label" || return 1
+		assert_stable "$id" "$label" || return 1
 	done
 
 	local samples="[]"
 	for ((i = 0; i < REPS; i++)); do
-		local start end
-		start="$(date +%s%N)"
-		exit_code=0
-		stdout="$(env -u SSH_AUTH_SOCK -u COLOR NO_COLOR=1 "$REPOSE_BIN" "${args[@]}" 2>"$tmp/stderr")" || exit_code=$?
-		end="$(date +%s%N)"
-		stderr="$(cat "$tmp/stderr")"
-		samples="$(jq -c --argjson ns "$((end - start))" '. + [$ns]' <<<"$samples")"
-
-		local want_exit
-		want_exit="$(jq -r '.expect.exit_code' <<<"$w")"
-		if [[ "$exit_code" -ne "$want_exit" ]]; then
-			echo "$id: exit code changed (want $want_exit, got $exit_code)" >&2
-			echo "$stderr" >&2
-			return 1
-		fi
-		while IFS= read -r needle; do
-			[[ -z "$needle" ]] && continue
-			if [[ "$stdout" != *"$needle"* ]]; then
-				echo "$id: stdout no longer contains expected substring: $needle" >&2
-				return 1
-			fi
-		done < <(jq -r '.expect.stdout_contains[]?' <<<"$w")
+		label="rep-$i"
+		run_once "$w" "$id" "$label" || return 1
+		check_expect "$w" "$id" "$label" || return 1
+		assert_stable "$id" "$label" || return 1
+		samples="$(jq -c --argjson ns "$((RUN_END - RUN_START))" '. + [$ns]' <<<"$samples")"
 	done
 
-	local p50 p95 p99 host_count
+	local p50 p95 p99 host_count stderr_digest
 	p50="$(percentile_ns 50 <<<"$samples")"
 	p95="$(percentile_ns 95 <<<"$samples")"
 	p99="$(percentile_ns 99 <<<"$samples")"
 	host_count="$(jq -r '.host_count' <<<"$w")"
+	if [[ "$SKIP_STDERR_DIGEST" -eq 1 ]]; then
+		stderr_digest=null
+	else
+		stderr_digest="$(jq -n --arg d "$FIRST_STDERR_DIGEST" '$d')"
+	fi
 
 	jq -n \
 		--arg id "$id" \
@@ -115,9 +241,9 @@ run_workload() {
 		--argjson p95 "$p95" \
 		--argjson p99 "$p99" \
 		--argjson host_count "$host_count" \
-		--argjson exit_code "$exit_code" \
-		--arg stdout_digest "$(printf '%s' "$stdout" | sha256_of)" \
-		--arg stderr_digest "$(printf '%s' "$stderr" | sha256_of)" \
+		--argjson exit_code "$RUN_EXIT" \
+		--arg stdout_digest "$FIRST_STDOUT_DIGEST" \
+		--argjson stderr_digest "$stderr_digest" \
 		--arg toolchain "$(rustc --version)" \
 		--arg runner_class "$RUNNER_CLASS" \
 		--arg os "$(uname -s)" \
@@ -144,7 +270,7 @@ run_workload() {
             host_order: [$id]
         }' >"$REPOSE_PERF_OUT/$id.json.tmp"
 
-	jq -e -f "$REPOSE_PERF_VALIDATOR" "$REPOSE_PERF_OUT/$id.json.tmp" >/dev/null
+	jq -e -f "$REPOSE_PERF_VALIDATOR" "$REPOSE_PERF_OUT/$id.json.tmp" >/dev/null || return 1
 	mv "$REPOSE_PERF_OUT/$id.json.tmp" "$REPOSE_PERF_OUT/$id.json"
 	echo "  wrote $REPOSE_PERF_OUT/$id.json"
 }

--- a/scripts/run-performance-baseline-ssh.sh
+++ b/scripts/run-performance-baseline-ssh.sh
@@ -6,8 +6,9 @@
 # scripts/run-performance-baseline.sh.
 set -euo pipefail
 
+# repose has no identity flag: the client key reaches it through the
+# `IdentityFile` line the fixture writes into $HOME/.ssh/config.
 : "${REPOSE_SSH_TARGET:?tests/ssh/run.sh must set this}"
-: "${REPOSE_SSH_IDENTITY:?tests/ssh/run.sh must set this}"
 : "${REPOSE_SSH_KNOWN_HOSTS:?tests/ssh/run.sh must set this}"
 : "${REPOSE_BIN:?run-performance-baseline.sh must set this}"
 : "${REPOSE_PERF_WORKLOADS:?run-performance-baseline.sh must set this}"
@@ -70,7 +71,7 @@ run_workload() {
 	echo "-- $id --"
 	local i exit_code=0 stdout="" stderr=""
 	for ((i = 0; i < WARMUP; i++)); do
-		stdout="$(env -u SSH_AUTH_SOCK -u COLOR NO_COLOR=1 "$REPOSE_BIN" -i "$REPOSE_SSH_IDENTITY" "${args[@]}" 2>"$tmp/stderr")" || exit_code=$?
+		stdout="$(env -u SSH_AUTH_SOCK -u COLOR NO_COLOR=1 "$REPOSE_BIN" "${args[@]}" 2>"$tmp/stderr")" || exit_code=$?
 	done
 
 	local samples="[]"
@@ -78,7 +79,7 @@ run_workload() {
 		local start end
 		start="$(date +%s%N)"
 		exit_code=0
-		stdout="$(env -u SSH_AUTH_SOCK -u COLOR NO_COLOR=1 "$REPOSE_BIN" -i "$REPOSE_SSH_IDENTITY" "${args[@]}" 2>"$tmp/stderr")" || exit_code=$?
+		stdout="$(env -u SSH_AUTH_SOCK -u COLOR NO_COLOR=1 "$REPOSE_BIN" "${args[@]}" 2>"$tmp/stderr")" || exit_code=$?
 		end="$(date +%s%N)"
 		stderr="$(cat "$tmp/stderr")"
 		samples="$(jq -c --argjson ns "$((end - start))" '. + [$ns]' <<<"$samples")"

--- a/scripts/validate-performance-report.jq
+++ b/scripts/validate-performance-report.jq
@@ -43,9 +43,25 @@ def is_nonempty_string: type == "string" and length > 0;
     . == null or is_nonneg_int;
     "peak_rss_bytes must be a non-negative integer, or null before RSS collection runs"
   )
-| check($r.command_count; is_nonneg_int; "command_count must be a non-negative integer")
-| check($r.probe_count; is_nonneg_int; "probe_count must be a non-negative integer")
-| check($r.peak_concurrency; is_nonneg_int and . >= 1; "peak_concurrency must be an integer >= 1")
+
+# A `ssh` report may leave these unknown: observing them means instrumenting
+# the fixture, and the deterministic `mock` workloads already gate all three.
+# A `mock` report has no such excuse.
+| check(
+    $r.command_count;
+    is_nonneg_int or (. == null and $r.kind == "ssh");
+    "command_count must be a non-negative integer, or null for a kind == \"ssh\" report"
+  )
+| check(
+    $r.probe_count;
+    is_nonneg_int or (. == null and $r.kind == "ssh");
+    "probe_count must be a non-negative integer, or null for a kind == \"ssh\" report"
+  )
+| check(
+    $r.peak_concurrency;
+    (is_nonneg_int and . >= 1) or (. == null and $r.kind == "ssh");
+    "peak_concurrency must be an integer >= 1, or null for a kind == \"ssh\" report"
+  )
 | check($r.exit_code; is_nonneg_int; "exit_code must be a non-negative integer")
 | check($r.stdout_digest; is_nonempty_string; "stdout_digest must be a non-empty string")
 | check(

--- a/scripts/validate-performance-report.jq
+++ b/scripts/validate-performance-report.jq
@@ -48,7 +48,11 @@ def is_nonempty_string: type == "string" and length > 0;
 | check($r.peak_concurrency; is_nonneg_int and . >= 1; "peak_concurrency must be an integer >= 1")
 | check($r.exit_code; is_nonneg_int; "exit_code must be a non-negative integer")
 | check($r.stdout_digest; is_nonempty_string; "stdout_digest must be a non-empty string")
-| check($r.stderr_digest; is_nonempty_string; "stderr_digest must be a non-empty string")
+| check(
+    $r.stderr_digest;
+    . == null or is_nonempty_string;
+    "stderr_digest must be a non-empty string, or null for a workload whose stderr provably cannot reproduce (it must then declare `expect.stderr_digest: null` with a reason)"
+  )
 | check(
     $r.host_order;
     type == "array" and (all(.[]; type == "string"));

--- a/tests/performance/workloads.json
+++ b/tests/performance/workloads.json
@@ -271,7 +271,9 @@
         "exit_code": 0,
         "stdout_contains": [
           "\"event\": \"product\""
-        ]
+        ],
+        "stderr_digest": null,
+        "stderr_digest_reason": "Under --debug, stderr is russh's packet trace and nothing else: 103 lines, none of them a repose diagnostic. It reproduces neither across repetitions (TCP coalescing splits CHANNEL_DATA into a different number of `msg type 94, seqn N, len N` lines) nor across fixture runs (`enc: [...]` carries the bytes of a client key the fixture regenerates every start). Dropping the DEBUG lines instead would leave the digest of an empty stream, which would falsely read as a passing check. stdout is still digested."
       }
     },
     {


### PR DESCRIPTION
First of four PRs repairing the P0.1 performance-measurement system. This one
makes the `ssh` half of the harness run at all, and then makes what it reports
true. No behaviour change to `repose` itself — only to the measurement scripts,
the report contract, and one workload definition.

## Why

The `ssh`-kind half of the harness has never executed. Every invocation passed
`-i <identity>`, and `repose` has no identity flag, so clap rejected the argv
before a connection was attempted — the harness was timing a usage error and
reporting it as transport latency. Behind that were four more problems that
only became visible once the workloads actually ran.

## What changed

**`8b55c1b` — let the ssh workloads reach the fixture.** Drop `-i`. The key was
never needed on the command line: the fixture writes an `IdentityFile` line
into the `$HOME/.ssh/config` it exports, and `openssh_config.rs` reads it.
`REPOSE_SSH_IDENTITY` has no reader left here, so its guard goes too.

**`4517b47` — measure instead of approximate.**

- One empty known-hosts file was created once and shared by all repetitions,
  so `ssh-first-contact-accept-new-1h` measured first contact once and a
  *known* host every time after. Each repetition now gets a fresh file and
  must leave exactly one entry in it — that entry is the only real evidence
  the key was accepted on first contact.
- Digests were taken over `$(...)` output, which strips trailing newlines, so
  two streams differing only in their ending hashed alike. Both streams now go
  to files and the exact bytes are hashed, raw copies kept under
  `$REPOSE_PERF_OUT/raw-io/`.
- Only the last repetition's digest was reported. Every repetition must now
  reproduce the first one's.
- Warmups skipped the `expect` block the README says they run.
- The fixture's ephemeral port made every digest a one-off; the target is now
  folded to a placeholder in both the `[host]:port` and `host:port` spellings.
- `run_workload` is called as `... || failed=1`, which disables `errexit` for
  everything it calls — so a rejected report was moved into place anyway.
  Failures are now propagated by hand.

**`c40fe39` — report observed metrics or nothing.** `command_count: 1` and
`probe_count: 0` were literals, `peak_concurrency` echoed the workload's own
`host_count`, and `host_order` listed the *workload id* as a host key. The
first three are now `null` (observing them means instrumenting the fixture to
re-derive what the deterministic `mock` workloads already gate), and
`host_order` carries the real target. Adds `host_count` and
`runner.profile`/`.rustflags`/`.fixture_runtime`. Repetition defaults go 5→10
and warmup 1→2 so an ssh report clears `thresholds.json`'s
`minimum_repetitions` on its own.

## One judgement call worth reviewing

The stability assertion immediately found real instability in
`ssh-list-products-1h-json-debug`. Its stderr is 103 lines of russh packet
trace with no repose diagnostic in it, and it reproduces neither across
repetitions (TCP coalescing re-splits `CHANNEL_DATA`) nor across fixture runs
(`enc: [...]` carries a client key the fixture regenerates each start).

Normalizing the `DEBUG` lines away would have left the digest of an empty
stream — indistinguishable from the three workloads that genuinely emit no
stderr, i.e. a check that passes without checking. So that workload declares
`expect.stderr_digest: null` with the reason recorded beside it, and the
contract admits a null digest. stdout is still digested.

The validator is widened only as far as those honest nulls require: null
counters for `kind == "ssh"` **only** (a mock report claiming not to know its
own command count is still rejected), and a null `stderr_digest`. A later PR
bumps the contract to v2 and tightens this.

## Verification

`tests/ssh/run.sh` needs Docker, which this machine does not have, and its
Apple-`container` mirror cannot be used either: host→container networking is
broken here (a published port accepts then resets; container IPs never resolve
through ARP), persistently across reboots and fresh networks. Container↔container
works, so verification ran `repose` from a second container on the same network
as an unmodified `tests/ssh/Dockerfile` fixture, with sshd moved off port 22 so
the bracketed `[host]:port` known-hosts form is still exercised.

- All 4 `ssh` workloads pass and produce contract-valid reports; real timings
  (~140 ms), no clap error.
- A wrapper appending **one byte** on the 3rd invocation is caught
  (`rep-1: normalized output is not stable`), that workload writes no report,
  the script exits 1, and the other three still complete.
- First contact proven: empty file → exactly one `[host]:2222` entry; reusing
  one file leaves it at one entry and is no longer first contact.
- Defaults confirmed at 10 reps / 2 warmup with 10 samples; all counters
  `null`; `host_order` the real target.
- A **mock** report with a null counter is still rejected by the validator.

Gates: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D
warnings` and the `--features gen` leg, `cargo test --workspace --all-targets
--locked`, `cargo deny check`, `typos`, `scripts/check-rust-layering.sh`,
`make check`, `shfmt`/`shellcheck`, and `scripts/test-compare-performance.sh`
(including the real injected-slowdown guardrail) all pass.

## Out of scope, found on the way

`repose list-products` against a wholly unreachable target prints nothing and
**exits 0** — `connect_and_prune` drops every host and the command still
reports success. Deliberately not touched here; it needs its own issue.
