### PR TITLE
fix(perf): bump the report contract to v2 for the mock baseline harness

### DIFF
--- a/crates/repose-core/examples/baseline_report.rs
+++ b/crates/repose-core/examples/baseline_report.rs
@@ -322,7 +322,7 @@ fn main() {
     let throughput = workload.host_count as f64 / (p50 as f64 / 1e9);
 
     let report = serde_json::json!({
-        "contract_version": 1,
+        "contract_version": 2,
         "workload_id": id,
         "kind": "mock",
         "runner": {
@@ -332,7 +332,15 @@ fn main() {
             // --version`), which knows the invoking toolchain; this binary
             // only knows its own target triple constants.
             "toolchain": serde_json::Value::Null,
+            "profile": if cfg!(debug_assertions) { "debug" } else { "release" },
+            "rustflags": std::env::var("RUSTFLAGS").unwrap_or_default(),
+            // This binary never leaves the host process: no ssh transport,
+            // no container. Filled in once the container pair (P0.1 step 7)
+            // measures mock workloads there too.
+            "fixture_runtime": serde_json::Value::Null,
+            "runner_image": serde_json::Value::Null,
         },
+        "host_count": workload.host_count,
         "repetitions": repetitions,
         "warmup_repetitions": warmup,
         "wall_time_ns": samples_ns,

--- a/scripts/run-performance-baseline.sh
+++ b/scripts/run-performance-baseline.sh
@@ -101,10 +101,14 @@ finish_report() {
 		--argjson rss "$rss_bytes" \
 		--arg toolchain "$(rustc --version)" \
 		--arg runner_class "$RUNNER_CLASS" \
+		--arg profile "release" \
+		--arg rustflags "${RUSTFLAGS:-}" \
 		--arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 		'.peak_rss_bytes = $rss
          | .runner.toolchain = $toolchain
          | .runner.runner_class = $runner_class
+         | .runner.profile = $profile
+         | .runner.rustflags = $rustflags
          | .generated_at = $generated_at' \
 		"$tmp_stdout" >"$dest.tmp"
 	jq -e -f "$VALIDATOR" "$dest.tmp" >/dev/null

--- a/scripts/validate-performance-report.jq
+++ b/scripts/validate-performance-report.jq
@@ -19,13 +19,34 @@ def is_nonneg_int: type == "number" and (. == (. | floor)) and . >= 0;
 def is_nonneg_num: type == "number" and . >= 0;
 def is_nonempty_string: type == "string" and length > 0;
 
+# Nearest-rank percentile, matching both emitters
+# (crates/repose-core/examples/baseline_report.rs's `percentile` and
+# scripts/run-performance-baseline-ssh.sh's `percentile_ns`): rank =
+# ceil((pct/100) * n), 1-indexed into the ascending sample array.
+def nearest_rank(sorted; pct):
+  (sorted | length) as $n
+  | sorted[(((pct / 100) * $n) | ceil) - 1];
+
 . as $r
-| check($r.contract_version; . == 1; "contract_version must be 1")
+| check($r.contract_version; . == 2; "contract_version must be 2")
 | check($r.workload_id; is_nonempty_string; "workload_id must be a non-empty string")
 | check($r.kind; . == "mock" or . == "ssh"; "kind must be \"mock\" or \"ssh\"")
 | check($r.runner; type == "object"; "runner must be an object")
 | check($r.runner.os; is_nonempty_string; "runner.os must be a non-empty string")
 | check($r.runner.arch; is_nonempty_string; "runner.arch must be a non-empty string")
+| check($r.runner.profile; is_nonempty_string; "runner.profile must be a non-empty string")
+| check($r.runner.rustflags; type == "string"; "runner.rustflags must be a string (may be empty)")
+| check(
+    $r.runner.fixture_runtime;
+    . == null or is_nonempty_string;
+    "runner.fixture_runtime must be a non-empty string, or null before the container pair resolves it"
+  )
+| check(
+    $r.runner.runner_image;
+    . == null or is_nonempty_string;
+    "runner.runner_image must be a non-empty string, or null before the runner image is built"
+  )
+| check($r.host_count; is_nonneg_int and . >= 1; "host_count must be an integer >= 1")
 | check($r.repetitions; is_nonneg_int and . >= 1; "repetitions must be an integer >= 1")
 | check($r.warmup_repetitions; is_nonneg_int; "warmup_repetitions must be a non-negative integer")
 | check(
@@ -33,11 +54,36 @@ def is_nonempty_string: type == "string" and length > 0;
     type == "array" and length == $r.repetitions and (all(.[]; is_nonneg_int));
     "wall_time_ns must have exactly `repetitions` non-negative nanosecond samples"
   )
+| check($r.wall_time_ns; . == sort; "wall_time_ns must be sorted ascending")
 | check($r.latency_ns; type == "object"; "latency_ns must be an object")
 | check($r.latency_ns.p50; is_nonneg_int; "latency_ns.p50 must be a non-negative integer")
 | check($r.latency_ns.p95; is_nonneg_int and . >= $r.latency_ns.p50; "latency_ns.p95 must be >= p50")
 | check($r.latency_ns.p99; is_nonneg_int and . >= $r.latency_ns.p95; "latency_ns.p99 must be >= p95")
+| check(
+    $r.latency_ns.p50;
+    . == nearest_rank($r.wall_time_ns; 50);
+    "latency_ns.p50 is not the nearest-rank p50 of wall_time_ns"
+  )
+| check(
+    $r.latency_ns.p95;
+    . == nearest_rank($r.wall_time_ns; 95);
+    "latency_ns.p95 is not the nearest-rank p95 of wall_time_ns"
+  )
+| check(
+    $r.latency_ns.p99;
+    . == nearest_rank($r.wall_time_ns; 99);
+    "latency_ns.p99 is not the nearest-rank p99 of wall_time_ns"
+  )
 | check($r.throughput_ops_per_sec; is_nonneg_num; "throughput_ops_per_sec must be a non-negative number")
+| check(
+    $r.throughput_ops_per_sec;
+    ($r.latency_ns.p50 == 0) or (
+      (. - ($r.host_count / ($r.latency_ns.p50 / 1e9))) / ($r.host_count / ($r.latency_ns.p50 / 1e9))
+      | fabs
+      | . <= 1e-9
+    );
+    "throughput_ops_per_sec is inconsistent with host_count and latency_ns.p50"
+  )
 | check(
     $r.peak_rss_bytes;
     . == null or is_nonneg_int;


### PR DESCRIPTION
PR 2 of `plans/p0.1-repair-performance-measurement.md` ("contract v2 and the mock harness"): steps 4-6.

## What

- `scripts/validate-performance-report.jq`: `contract_version` must be `2`; requires `host_count`, `runner.profile`, `runner.rustflags` (may be empty), `runner.fixture_runtime`/`runner.runner_image` (string or null — filled in once the container pair from a later step exists); requires `wall_time_ns` sorted ascending; recomputes nearest-rank `p50`/`p95`/`p99` and `throughput_ops_per_sec` from the raw samples and rejects a mismatch instead of trusting the emitter's arithmetic.
- `crates/repose-core/examples/baseline_report.rs`: emits the new v2 fields (`host_count`, real `runner.profile`/`rustflags`, null `fixture_runtime`/`runner_image`). No change to any observed metric.
- `scripts/run-performance-baseline.sh`: `finish_report` now stamps `runner.profile`/`runner.rustflags` onto every mock report, alongside the existing `toolchain`/`runner_class`/RSS injection.

## Verification

- `target/release/examples/baseline_report mock-add-1h 12 2 | jq -e -f scripts/validate-performance-report.jq` passes.
- `scripts/run-performance-baseline.sh --skip-ssh` produces contract-valid reports for all 12 mock workloads.
- Hand-mutated reports (wrong `p95`, unsorted `wall_time_ns`, a mock report with a null counter, a `contract_version: 1` report) each fail validation with a distinct message.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, the `--features gen` clippy leg, `cargo test --workspace --all-targets --locked`, `cargo deny check`, and `typos` all pass.

## Known follow-up (later steps in the same plan)

The ssh emitter (`scripts/run-performance-baseline-ssh.sh`, from the prior PR) and the six `tests/performance/comparator-fixtures/*.json` are still `contract_version: 1`, so `make perf-compare-test`'s fixture-based cases and a full (non-`--skip-ssh`) `make perf-baseline` will fail contract validation until the plan's later steps regenerate the fixtures, wire `runner_image`/`fixture_runtime` from the container pair, and regenerate the committed baseline. Neither target is wired into CI yet, so nothing currently gated is affected.