### PR TITLE
ci(perf): wire the performance harness into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,3 +263,54 @@ jobs:
           workspaces: . -> target
       - name: Build (MSRV)
         run: cargo build --workspace --locked
+
+  perf-semantic:
+    # P0.1 step 13: the same container pair a contributor runs locally
+    # (tests/performance/README.md) — Docker is available here (the
+    # rust-coverage job above already builds tests/ssh/Dockerfile with it),
+    # so REPOSE_PERF_CONTAINER_CLI=auto resolves to `docker` and CI
+    # measures from the same pinned runner image a contributor does.
+    # Deterministic/semantic metrics only (exit code, command/probe
+    # counts, output digests, peak-concurrency ceiling): latency/RSS
+    # gating stays opt-in until a controlled/scheduled runner has its own
+    # variance study (see tests/performance/README.md#why-this-isnt-in-ci-yet).
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
+        with:
+          toolchain: stable
+      - name: Cache cargo
+        # Tag runs re-verify a release: keep them off restored build state;
+        # PR/master runs keep the cache.
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: . -> target
+      - name: Comparator unit tests
+        run: make perf-compare-test
+      - name: Run the baseline inside the container pair
+        # A runner_class distinct from the committed "local-dev" baseline,
+        # so the compact summary this writes to
+        # tests/performance/baselines/<runner_class>.json never clobbers
+        # the committed one being compared against below.
+        env:
+          REPOSE_PERF_RUNNER_CLASS: ci-pr
+        run: |
+          bash scripts/run-performance-baseline.sh --mock-reps 10 --mock-warmup 2 \
+            --ssh-reps 3 --ssh-warmup 1 --out "$RUNNER_TEMP/perf"
+      - name: Compare every workload against local-dev (semantic metrics only)
+        run: |
+          status=0
+          for id in $(jq -r '.workloads[].id' tests/performance/workloads.json); do
+            echo "== $id =="
+            if ! bash scripts/compare-performance.sh --semantic-only --workload "$id" \
+                tests/performance/baselines/local-dev.json "$RUNNER_TEMP/perf/$id.json"; then
+              status=1
+            fi
+          done
+          exit "$status"

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,102 @@
+---
+name: perf
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Monday 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: perf
+  cancel-in-progress: false
+
+jobs:
+  full-baseline:
+    # P0.1 step 14: the full baseline (not the PR-sized one in ci.yml's
+    # perf-semantic), measured in the same pinned container pair
+    # (tests/performance/README.md), tagged runner_class "github-ubuntu".
+    #
+    # Semantic metrics (exit code, command/probe counts, output digests,
+    # peak-concurrency ceiling) block. Latency/RSS comparison against the
+    # committed baseline is `continue-on-error: true`: the thresholds in
+    # tests/performance/thresholds.json come from a handful of runs on one
+    # shared, uncontrolled development machine, not this runner class.
+    # Gating stays deferred until five scheduled runs here have supplied
+    # their own variance study, at which point thresholds.json gets
+    # runner-class-specific ratios (see its baseline_refresh_policy/
+    # evidence fields) and this step flips to blocking.
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
+        with:
+          toolchain: stable
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: . -> target
+      - name: Snapshot the committed github-ubuntu baseline (if any)
+        # Copied before the baseline run below overwrites this same path
+        # with a fresh summary. Absent on the run that first produces it —
+        # the committed baseline lands in a follow-up commit once its
+        # numbers are reviewed (tests/performance/README.md#baseline-update-review-requirements).
+        id: snapshot
+        run: |
+          if [ -f tests/performance/baselines/github-ubuntu.json ]; then
+            cp tests/performance/baselines/github-ubuntu.json "$RUNNER_TEMP/committed-github-ubuntu.json"
+            echo "exists=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >>"$GITHUB_OUTPUT"
+          fi
+      - name: Run the full baseline inside the container pair
+        env:
+          REPOSE_PERF_RUNNER_CLASS: github-ubuntu
+        run: |
+          bash scripts/run-performance-baseline.sh --mock-reps 100 --mock-warmup 10 \
+            --ssh-reps 20 --ssh-warmup 3 --out "$RUNNER_TEMP/perf"
+      - name: Upload raw per-workload reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: perf-raw-github-ubuntu
+          path: ${{ runner.temp }}/perf
+          if-no-files-found: error
+      - name: Upload the github-ubuntu summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: perf-summary-github-ubuntu
+          path: tests/performance/baselines/github-ubuntu.json
+          if-no-files-found: error
+      - name: Compare every workload against github-ubuntu (semantic metrics — blocking)
+        if: steps.snapshot.outputs.exists == 'true'
+        run: |
+          status=0
+          for id in $(jq -r '.workloads[].id' tests/performance/workloads.json); do
+            echo "== $id =="
+            if ! bash scripts/compare-performance.sh --semantic-only --workload "$id" \
+                "$RUNNER_TEMP/committed-github-ubuntu.json" "$RUNNER_TEMP/perf/$id.json"; then
+              status=1
+            fi
+          done
+          exit "$status"
+      - name: Compare every workload against github-ubuntu (latency/RSS — non-blocking)
+        if: steps.snapshot.outputs.exists == 'true'
+        continue-on-error: true
+        run: |
+          status=0
+          for id in $(jq -r '.workloads[].id' tests/performance/workloads.json); do
+            echo "== $id =="
+            if ! bash scripts/compare-performance.sh --allow-cross-runner --workload "$id" \
+                "$RUNNER_TEMP/committed-github-ubuntu.json" "$RUNNER_TEMP/perf/$id.json"; then
+              status=1
+            fi
+          done
+          exit "$status"

--- a/scripts/run-performance-baseline-ssh.sh
+++ b/scripts/run-performance-baseline-ssh.sh
@@ -45,11 +45,17 @@ sha256_of() {
 	fi
 }
 
-# The fixture's port is ephemeral, so the raw streams differ between runs in
-# a way that says nothing about performance. Fold both spellings the output
-# carries — `[host]:port` (known_hosts entries, host-key messages) and
-# `host:port` (the target echo, the `Host:` header) — to fixed placeholders
-# before hashing.
+# The fixture's address varies between runs (an ephemeral port pre-container,
+# a container-network IP that differs per host/CLI post-container) in a way
+# that says nothing about performance. Fold every spelling the output
+# carries to fixed placeholders before hashing: `[host]:port` (known_hosts
+# entries, host-key messages), `host:port` (the target echo, the `Host:`
+# header), and bare `host` with no port suffix at all — `--format=json`
+# prints host and port as separate JSON fields (never contiguous as
+# `host:port`), and `HostSpec::key` (repose-core's `host_parse.rs`) drops
+# the port entirely at the default 22, so `clear --print`'s dry-run line
+# carries the bare address. The bare pass runs last so it only catches what
+# the first two didn't already consume.
 #
 # `jq -Rsj` round-trips the stream verbatim, so a stream that does not end in
 # a newline still does not after normalizing; `sed` would append one on BSD
@@ -60,8 +66,10 @@ normalized_digest() {
 	jq -Rsj \
 		--arg bracket "[$REPOSE_SSH_HOST]:$REPOSE_SSH_PORT" \
 		--arg plain "$REPOSE_SSH_HOST:$REPOSE_SSH_PORT" \
+		--arg bare "$REPOSE_SSH_HOST" \
 		'split($bracket) | join("[FIXTURE]:PORT")
-		 | split($plain) | join("FIXTURE:PORT")' "$1" | sha256_of
+		 | split($plain) | join("FIXTURE:PORT")
+		 | split($bare) | join("FIXTURE")' "$1" | sha256_of
 }
 
 # Build the repose argv for one ssh-kind workload ($1: workload JSON,

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -357,9 +357,9 @@ scripts/compare-performance.sh before.json after.json
 scripts/compare-performance.sh --workload mock-add-100h \
   tests/performance/baselines/local-dev.json tests/performance/baselines/raw/mock-add-100h.json
 
-# Deterministic checks only, runner-independent (what CI runs on every
-# PR — see the plan's PR4 for the workflow): implies --allow-cross-runner
-# and skips the repetition-count gate.
+# Deterministic checks only, runner-independent (what the `perf-semantic`
+# job in .github/workflows/ci.yml runs on every PR): implies
+# --allow-cross-runner and skips the repetition-count gate.
 scripts/compare-performance.sh --semantic-only --workload mock-add-100h \
   tests/performance/baselines/local-dev.json fresh-report.json
 ```
@@ -387,18 +387,32 @@ workload must compare as a pass, and a third run with
 `REPOSE_PERF_INJECT_DELAY_MS` set (a real, controllable per-repetition
 delay — not a fabricated fixture) must be caught as a regression.
 
-### Why this isn't in CI yet
+### What's in CI, and why latency/RSS gating still isn't
 
-CI enforcement is intentionally deferred: the thresholds above come from a
-handful of runs on one shared, uncontrolled development machine (see the
-`evidence` fields in `thresholds.json`), not a dedicated/scheduled runner.
-Shared CI runners are noisier still, so enabling latency/RSS gating there
-without runner-specific variance data would either pass everything (too
-loose) or flap on noise (too tight). Deterministic checks (the exact/ceiling
-metrics above) are cheap to run anywhere and can gate PRs today via `make
-perf-compare-test`; wall-clock/RSS gating should wait for a controlled or
-scheduled runner with its own variance study, per `thresholds.json`'s
-`baseline_refresh_policy`.
+Two workflows run the harness:
+
+- `.github/workflows/ci.yml`'s `perf-semantic` job, on every PR/push: the
+  same container pair described above, PR-sized (`--mock-reps 10
+  --mock-warmup 2 --ssh-reps 3 --ssh-warmup 1`), compared against the
+  committed `tests/performance/baselines/local-dev.json` with
+  `--semantic-only` — exact + ceiling metrics only, runner-independent, so
+  it blocks a PR that changes a command count or an observable digest.
+- `.github/workflows/perf.yml`'s `full-baseline` job, weekly (and
+  `workflow_dispatch`): the full-sized run (mock 100/10, ssh 20/3),
+  tagged `runner_class: github-ubuntu`, uploaded as artifacts and
+  compared against a committed `tests/performance/baselines/github-ubuntu.json`.
+  Its semantic-metrics comparison blocks the same way; its latency/RSS
+  comparison is `continue-on-error: true`.
+
+Latency/RSS gating stays deferred there because the thresholds above come
+from a handful of runs on one shared, uncontrolled development machine
+(see the `evidence` fields in `thresholds.json`), not `github-ubuntu`.
+Shared CI runners are noisier still, so gating on them without
+runner-specific variance data would either pass everything (too loose) or
+flap on noise (too tight). The weekly job exists in part to collect that
+data: once it has supplied five runs' worth, `thresholds.json` gets
+runner-class-specific ratios (per its `baseline_refresh_policy`) and its
+latency/RSS comparison flips to blocking.
 
 ### Baseline update review requirements
 

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -86,15 +86,21 @@ that is `null` on either side instead of failing or silently comparing
 ### Digest normalization for `ssh`-kind reports
 
 `ssh`-kind stdout/stderr are hashed as the exact raw bytes (trailing
-newlines included) after one substitution: the fixture's container address
-and port (`<host>:<port>` and, for OpenSSH's own `known_hosts` bracket form
-on a non-default port, `[<host>]:<port>`) are folded to a fixed placeholder
-before hashing, since that address is a property of this run's container
-network, not of `repose`'s behavior. The raw, unnormalized bytes are kept
-under `$REPOSE_PERF_OUT/raw-io/<workload-id>/` for debugging a digest
-mismatch. Every repetition's normalized digest is asserted equal to the
-first; a mismatch fails the workload rather than reporting the last run's
-digest as if it were representative.
+newlines included) after every spelling of the fixture's container address
+is folded to a fixed placeholder, since that address is a property of this
+run's container network, not of `repose`'s behavior: `[<host>]:<port>`
+(OpenSSH's own `known_hosts` bracket form on a non-default port),
+`<host>:<port>` (the target echo, the `Host:` header), and finally bare
+`<host>` with no port at all — `--format=json` prints host and port as
+separate JSON fields, never contiguous as `host:port`, and `HostSpec::key`
+drops the port entirely at the default 22, so `clear --print`'s dry-run
+line carries the bare address. All three substitutions are literal
+(`split`/`join`, not a regex), applied narrowest-first so the bare pass
+only catches what the first two didn't already consume. The raw,
+unnormalized bytes are kept under `$REPOSE_PERF_OUT/raw-io/<workload-id>/`
+for debugging a digest mismatch. Every repetition's normalized digest is
+asserted equal to the first; a mismatch fails the workload rather than
+reporting the last run's digest as if it were representative.
 
 ## Workload dimensions
 

--- a/tests/performance/baselines/local-dev.json
+++ b/tests/performance/baselines/local-dev.json
@@ -5,12 +5,12 @@
     "fixture_runtime": "container",
     "os": "linux",
     "profile": "release",
-    "runner_image": "sha256:26d9611f03b8168a0965106a605337d7e8474101824c9c3ec37ce48bd1e18e04",
+    "runner_image": "sha256:024b65364f868f05e4a88a2a84240953f1de7f7e5a69af7a6e43718deef1e9ad",
     "rustflags": "",
     "toolchain": "rustc 1.97.1 (8bab26f4f 2026-07-14)",
     "runner_class": "local-dev"
   },
-  "generated_at": "2026-08-05T19:09:36Z",
+  "generated_at": "2026-08-05T20:49:25Z",
   "workloads": [
     {
       "workload_id": "mock-add-100h",
@@ -19,11 +19,11 @@
       "warmup_repetitions": 3,
       "host_count": 100,
       "latency_ns": {
-        "p50": 301334,
-        "p95": 337208,
-        "p99": 382583
+        "p50": 301417,
+        "p95": 316333,
+        "p99": 317875
       },
-      "throughput_ops_per_sec": 331857.6728812547,
+      "throughput_ops_per_sec": 331766.29055428196,
       "peak_rss_bytes": 2932736,
       "command_count": 200,
       "probe_count": 100,
@@ -39,11 +39,11 @@
       "warmup_repetitions": 3,
       "host_count": 100,
       "latency_ns": {
-        "p50": 363417,
-        "p95": 604083,
-        "p99": 735416
+        "p50": 362000,
+        "p95": 395416,
+        "p99": 404625
       },
-      "throughput_ops_per_sec": 275165.9938858116,
+      "throughput_ops_per_sec": 276243.0939226519,
       "peak_rss_bytes": 3063808,
       "command_count": 200,
       "probe_count": 200,
@@ -59,11 +59,11 @@
       "warmup_repetitions": 3,
       "host_count": 100,
       "latency_ns": {
-        "p50": 20993625,
-        "p95": 21017041,
-        "p99": 21021000
+        "p50": 20996792,
+        "p95": 21006541,
+        "p99": 21018041
       },
-      "throughput_ops_per_sec": 4763.350779105562,
+      "throughput_ops_per_sec": 4762.632310688223,
       "peak_rss_bytes": 2932736,
       "command_count": 200,
       "probe_count": 100,
@@ -79,11 +79,11 @@
       "warmup_repetitions": 3,
       "host_count": 1,
       "latency_ns": {
-        "p50": 86709,
-        "p95": 92625,
-        "p99": 93833
+        "p50": 90875,
+        "p95": 107667,
+        "p99": 134708
       },
-      "throughput_ops_per_sec": 11532.828195458373,
+      "throughput_ops_per_sec": 11004.126547455297,
       "peak_rss_bytes": 2801664,
       "command_count": 2,
       "probe_count": 1,
@@ -99,11 +99,11 @@
       "warmup_repetitions": 3,
       "host_count": 20,
       "latency_ns": {
-        "p50": 158750,
-        "p95": 253375,
-        "p99": 276250
+        "p50": 168667,
+        "p95": 211250,
+        "p99": 414416
       },
-      "throughput_ops_per_sec": 125984.25196850393,
+      "throughput_ops_per_sec": 118576.84075723171,
       "peak_rss_bytes": 2801664,
       "command_count": 40,
       "probe_count": 20,
@@ -119,12 +119,12 @@
       "warmup_repetitions": 3,
       "host_count": 20,
       "latency_ns": {
-        "p50": 166584,
-        "p95": 181917,
-        "p99": 185375
+        "p50": 177667,
+        "p95": 336667,
+        "p99": 346209
       },
-      "throughput_ops_per_sec": 120059.54953657014,
-      "peak_rss_bytes": 2801664,
+      "throughput_ops_per_sec": 112570.14527177248,
+      "peak_rss_bytes": 2785280,
       "command_count": 40,
       "probe_count": 20,
       "peak_concurrency": 1,
@@ -139,12 +139,12 @@
       "warmup_repetitions": 3,
       "host_count": 100,
       "latency_ns": {
-        "p50": 352416,
-        "p95": 402083,
-        "p99": 451500
+        "p50": 349959,
+        "p95": 377292,
+        "p99": 385458
       },
-      "throughput_ops_per_sec": 283755.56160900753,
-      "peak_rss_bytes": 3063808,
+      "throughput_ops_per_sec": 285747.75902319985,
+      "peak_rss_bytes": 3055616,
       "command_count": 300,
       "probe_count": 100,
       "peak_concurrency": 1,
@@ -159,11 +159,11 @@
       "warmup_repetitions": 3,
       "host_count": 1,
       "latency_ns": {
-        "p50": 139291,
-        "p95": 195333,
-        "p99": 363542
+        "p50": 139875,
+        "p95": 172209,
+        "p99": 174250
       },
-      "throughput_ops_per_sec": 7179.214737492013,
+      "throughput_ops_per_sec": 7149.240393208222,
       "peak_rss_bytes": 2801664,
       "command_count": 3,
       "probe_count": 1,
@@ -179,11 +179,11 @@
       "warmup_repetitions": 3,
       "host_count": 20,
       "latency_ns": {
-        "p50": 180250,
-        "p95": 217333,
-        "p99": 220833
+        "p50": 180500,
+        "p95": 241000,
+        "p99": 243500
       },
-      "throughput_ops_per_sec": 110957.00416088766,
+      "throughput_ops_per_sec": 110803.32409972299,
       "peak_rss_bytes": 2801664,
       "command_count": 60,
       "probe_count": 20,
@@ -199,12 +199,12 @@
       "warmup_repetitions": 3,
       "host_count": 100,
       "latency_ns": {
-        "p50": 67375,
-        "p95": 95000,
-        "p99": 123750
+        "p50": 67125,
+        "p95": 73334,
+        "p99": 79042
       },
-      "throughput_ops_per_sec": 1484230.055658627,
-      "peak_rss_bytes": 2789376,
+      "throughput_ops_per_sec": 1489757.9143389198,
+      "peak_rss_bytes": 2801664,
       "command_count": 0,
       "probe_count": 0,
       "peak_concurrency": 1,
@@ -220,8 +220,8 @@
       "host_count": 1,
       "latency_ns": {
         "p50": 1167,
-        "p95": 1333,
-        "p99": 1708
+        "p95": 1334,
+        "p99": 1916
       },
       "throughput_ops_per_sec": 856898.029134533,
       "peak_rss_bytes": 2670592,
@@ -239,11 +239,11 @@
       "warmup_repetitions": 3,
       "host_count": 20,
       "latency_ns": {
-        "p50": 14209,
-        "p95": 15125,
-        "p99": 15500
+        "p50": 15750,
+        "p95": 39167,
+        "p99": 99250
       },
-      "throughput_ops_per_sec": 1407558.5896262932,
+      "throughput_ops_per_sec": 1269841.2698412698,
       "peak_rss_bytes": 2670592,
       "command_count": 0,
       "probe_count": 0,
@@ -259,17 +259,17 @@
       "warmup_repetitions": 2,
       "host_count": 1,
       "latency_ns": {
-        "p50": 138604000,
-        "p95": 148702708,
-        "p99": 148702708
+        "p50": 136981125,
+        "p95": 149531750,
+        "p99": 149531750
       },
-      "throughput_ops_per_sec": 7.214798995699979,
+      "throughput_ops_per_sec": 7.300275859174028,
       "peak_rss_bytes": null,
       "command_count": null,
       "probe_count": null,
       "peak_concurrency": null,
       "exit_code": 0,
-      "stdout_digest": "sha256:2b5a25bc4ee779a7aaf6949bccfb4f5c9b5762b83e3cca9aabc80140af72ba59",
+      "stdout_digest": "sha256:43f2f6f7b636bf31383a47ac8d2c169184119f57617a1e17b455b0b105449ced",
       "stderr_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     },
     {
@@ -279,11 +279,11 @@
       "warmup_repetitions": 2,
       "host_count": 1,
       "latency_ns": {
-        "p50": 142811875,
-        "p95": 147697833,
-        "p99": 147697833
+        "p50": 138398500,
+        "p95": 147432083,
+        "p99": 147432083
       },
-      "throughput_ops_per_sec": 7.002218828091151,
+      "throughput_ops_per_sec": 7.225511837194767,
       "peak_rss_bytes": null,
       "command_count": null,
       "probe_count": null,
@@ -299,11 +299,11 @@
       "warmup_repetitions": 2,
       "host_count": 1,
       "latency_ns": {
-        "p50": 137598708,
-        "p95": 151024416,
-        "p99": 151024416
+        "p50": 142470958,
+        "p95": 154018709,
+        "p99": 154018709
       },
-      "throughput_ops_per_sec": 7.267510099004709,
+      "throughput_ops_per_sec": 7.018974351249887,
       "peak_rss_bytes": null,
       "command_count": null,
       "probe_count": null,
@@ -319,17 +319,17 @@
       "warmup_repetitions": 2,
       "host_count": 1,
       "latency_ns": {
-        "p50": 146946542,
-        "p95": 156724208,
-        "p99": 156724208
+        "p50": 150689542,
+        "p95": 165972750,
+        "p99": 165972750
       },
-      "throughput_ops_per_sec": 6.805195865037776,
+      "throughput_ops_per_sec": 6.63616059036134,
       "peak_rss_bytes": null,
       "command_count": null,
       "probe_count": null,
       "peak_concurrency": null,
       "exit_code": 0,
-      "stdout_digest": "sha256:74a7d7977e02d261ce937cae5ac99ac234c73077184d450f9987628ad0b8621e",
+      "stdout_digest": "sha256:4daef08732e63d5ba9431583c75da4d4c79fbe606b31b156b395eac004296d94",
       "stderr_digest": null
     }
   ]

--- a/tests/performance/thresholds.json
+++ b/tests/performance/thresholds.json
@@ -32,7 +32,7 @@
     "latency_ns.p50": {
       "rule": "max_increase_ratio",
       "value": 1.0,
-      "evidence": "5 independent local runs of mock-add-100h (20 reps, 3 warmup) on this shared/uncontrolled runner ranged 189625-296375 ns p50 (~56% spread); mock-add-1h ranged 33708-44916 ns (~33% spread). A 100% (2x) threshold sits comfortably above observed noise while still catching a real regression. Tighten per-runner-class once a controlled/scheduled runner has its own variance study (see baseline_refresh_policy)."
+      "evidence": "5 independent local runs of mock-add-100h (20 reps, 3 warmup) on this shared/uncontrolled runner ranged 189625-296375 ns p50 (~56% spread); mock-add-1h ranged 33708-44916 ns (~33% spread). A 100% (2x) threshold sits comfortably above observed noise while still catching a real regression. Tighten per-runner-class once .github/workflows/perf.yml's scheduled 'github-ubuntu' job (weekly + workflow_dispatch) has supplied five runs' worth of variance data (see baseline_refresh_policy); until then that job's latency/RSS comparison stays continue-on-error and only its semantic-metrics comparison blocks."
     },
     "latency_ns.p95": {
       "rule": "max_increase_ratio",


### PR DESCRIPTION
The performance harness (ssh runner, contract v2, the pinned container
pair, the comparator) already lives on `master` but has no CI wiring:
nothing runs it automatically, so a PR could change a workload's
command count or break the ssh runner outright and nothing would
notice before a human ran `make perf-baseline` by hand.

## CI wiring

- `.github/workflows/ci.yml`: new `perf-semantic` job, every PR/push.
  Runs the container pair PR-sized (mock 10/2, ssh 3/1) and compares
  every workload against the committed `local-dev` baseline with
  `--semantic-only` — exact/ceiling metrics only (exit code,
  command/probe counts, output digests, peak-concurrency ceiling),
  runner-independent, so it blocks a PR that changes one of those from
  day one. Docker is already proven available on these runners by the
  `rust-coverage` job's `tests/ssh/Dockerfile` build.
- `.github/workflows/perf.yml` (new): weekly + `workflow_dispatch`, the
  full-sized run (mock 100/10, ssh 20/3) tagged `runner_class:
  github-ubuntu`, raw reports and the summary uploaded as artifacts.
  Its semantic-metrics comparison against a committed `github-ubuntu`
  baseline blocks the same way; its latency/RSS comparison is
  `continue-on-error: true` until five scheduled runs supply the
  variance study `thresholds.json`'s ratios need (recorded both in the
  workflow and in `thresholds.json`'s evidence field). The committed
  `github-ubuntu` baseline itself is a follow-up PR once a real run's
  numbers are reviewed.
- `tests/performance/README.md` updated to describe what's actually in
  CI now.

## Bug found by the new `perf-semantic` job

The job failed on an unmodified tree: `ssh-list-products-1h-json-debug`
and `ssh-dry-clear-1h` regressed on `stdout_digest` against the
committed `local-dev` baseline, while the other two `ssh` workloads
passed.

Isolated to the digest normalizer in
`scripts/run-performance-baseline-ssh.sh`, not `repose`: `--format=json`
prints `"host": "<ip>", "port": 22` as separate JSON fields, never
contiguous as `host:port`, and `HostSpec::key` drops the port entirely
at the default 22 — `clear --print`'s dry-run line carries that bare
key. Neither shape matched the normalizer's `host:port` / `[host]:port`
substitutions, so the container's real, run-specific IP address reached
the hash unmodified. It went unnoticed locally because one
baseline-generation session reuses the same fixture address for every
repetition; it only surfaces comparing across two sessions with
different container-assigned addresses (the committed baseline vs. a
fresh CI run) — reproduced locally across two independent container-pair
sessions on this machine, which picked different addresses for the same
fixture image.

Fix: a third, narrowest-last substitution for the bare host with no
port suffix. Verified against the exact output shapes with two
different fake addresses (identical normalized digest both times), and
against two real, independent container-pair sessions (all 16 workloads
now compare clean). `local-dev.json` regenerated; only the two affected
`stdout_digest` values and this run's own
timing/RSS/`generated_at`/`runner_image` changed.

## Verification

- `make perf-compare-test` passes.
- `actionlint` and `shellcheck` clean on both workflow files.
- `cargo fmt --check`, `typos`: clean.
- CI on this PR: `perf-semantic` passes; all other checks green.
- Not exercised (needs a real scheduled run): a `workflow_dispatch` run
  of `perf.yml`.