### PR TITLE
feat(ssh)!: update to russh 0.63

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.62.6"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41043523e0edcbd4e31d00903e26f12994f63b21bae9904f7405c1ed92752a5"
+checksum = "00cf00190c315093734a8d405225bd8773a219bc86538a9b73bfc51145b33995"
 dependencies = [
  "aes",
  "aws-lc-rs",

--- a/crates/repose-ssh/Cargo.toml
+++ b/crates/repose-ssh/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 repose-core = { path = "../repose-core", version = "3.2.0" }
 async-trait = "0.1"
 # >=0.60.3 for GHSA-g9f8-wqj9-fjw5 (CryptoVec growth)
-russh = "0.62"
+russh = "0.63"
 russh-sftp = "2.3"
 rpassword = "7.5"
 # Hashed (HashKnownHosts) known_hosts matching; both already in-tree via russh.

--- a/crates/repose-ssh/src/hostkey.rs
+++ b/crates/repose-ssh/src/hostkey.rs
@@ -197,6 +197,11 @@ impl HostKeyVerifier {
         });
     }
 
+    /// Whether the configured policy disables host-key validation outright.
+    pub(crate) fn validation_disabled(&self) -> bool {
+        matches!(self.policy, HostKeyPolicy::No | HostKeyPolicy::Off)
+    }
+
     pub(crate) fn host(&self) -> &str {
         &self.host
     }

--- a/crates/repose-ssh/src/session.rs
+++ b/crates/repose-ssh/src/session.rs
@@ -113,8 +113,25 @@ impl Handler for ClientHandler {
 
     async fn check_server_key(
         &mut self,
-        server_public_key: &russh::keys::ssh_key::PublicKey,
+        server_public_key: &russh::keys::PublicKeyOrCertificate,
     ) -> Result<bool, Self::Error> {
+        // known_hosts matching has no `@cert-authority` support, so a host
+        // certificate cannot be validated against anything and is refused.
+        // Unreachable in practice: `Preferred::default()` advertises no
+        // `*-cert-v01@openssh.com`, so a server cannot negotiate one.
+        let server_public_key = match server_public_key {
+            russh::keys::PublicKeyOrCertificate::PublicKey { key, .. } => key,
+            russh::keys::PublicKeyOrCertificate::Certificate(_) => {
+                if self.verifier.validation_disabled() {
+                    return Ok(true);
+                }
+                log::error!(
+                    "{}: server offered a host certificate, which repose cannot validate; rejecting",
+                    self.verifier.host()
+                );
+                return Ok(false);
+            }
+        };
         match self.verifier.decide_public_key(server_public_key) {
             KeyDecision::Accept => Ok(true),
             KeyDecision::Reject => Ok(false),
@@ -1053,10 +1070,23 @@ mod tests {
     use crate::openssh_config::OpenSshOptions;
     use repose_core::config::HostKeyPolicy;
     use russh::client::Handler;
-    use russh::keys::ssh_key::PublicKey;
+    use russh::keys::PublicKeyOrCertificate;
+    use russh::keys::ssh_key::{Certificate, PublicKey};
 
     const TEST_KEY: &str =
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti";
+
+    /// An `ssh-ed25519-cert-v01@openssh.com` host certificate, signed by a
+    /// throwaway CA, valid for the principal `host`.
+    const TEST_HOST_CERT: &str = "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAINeWzBsdfZmRI9d3EINs42iTH0pWjQYPxgLwkieqDJccAAAAID9Dw+0BhZEyhhnocT8UnoOh69GWwPGMLDQQsVCNc14OAAAAAAAAAAAAAAACAAAADnRlc3QtaG9zdC1jZXJ0AAAACAAAAARob3N0AAAAAGqDPu8AAAAAbGxbbwAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgtlYII5S1UbAL9t8Mn02akH0bjipPWvWGOfZ4vii4oEgAAABTAAAAC3NzaC1lZDI1NTE5AAAAQADGx1sLeBo2eo68Z4OySgmVNYDwrSIi8zthHPE2Kv0dv+py6gYkwXoNrDlsV/d5Ehgto4iHRMZohCB5dSv8pA4= test-host";
+
+    /// Wrap a plain key the way russh hands one to `check_server_key`.
+    fn offered(key: &PublicKey) -> PublicKeyOrCertificate {
+        PublicKeyOrCertificate::PublicKey {
+            key: key.clone(),
+            hash_alg: None,
+        }
+    }
 
     #[tokio::test]
     async fn with_deadline_returns_ok_unchanged_for_a_fast_future() {
@@ -1414,7 +1444,7 @@ mod tests {
 
         assert!(
             handler
-                .check_server_key(&key)
+                .check_server_key(&offered(&key))
                 .await
                 .expect("check_server_key should not error"),
             "first contact should be accepted once persisted"
@@ -1430,10 +1460,62 @@ mod tests {
         // recorded by the first call and does not need to write again.
         assert!(
             handler
-                .check_server_key(&key)
+                .check_server_key(&offered(&key))
                 .await
                 .expect("check_server_key should not error")
         );
+    }
+
+    /// repose has no `@cert-authority` support, so a host certificate cannot
+    /// be checked against anything and must not be trusted by default. The
+    /// arm is unreachable while `Preferred::default()` advertises no
+    /// certificate algorithm, so this pins the behaviour if that changes.
+    #[tokio::test]
+    async fn check_server_key_rejects_a_host_certificate_under_enforcing_policies() {
+        let cert = Certificate::from_openssh(TEST_HOST_CERT).expect("test cert should parse");
+        let offered = PublicKeyOrCertificate::Certificate(cert);
+
+        for policy in [HostKeyPolicy::Yes, HostKeyPolicy::AcceptNew] {
+            let temp = tempfile::tempdir().expect("temp dir should be created");
+            let path = temp.path().join("known_hosts");
+            let verifier = HostKeyVerifier::new(policy, Some(path.clone()), "host", 22)
+                .expect("verifier should build");
+            let mut handler = ClientHandler { verifier };
+
+            assert!(
+                !handler
+                    .check_server_key(&offered)
+                    .await
+                    .expect("check_server_key should not error"),
+                "{policy:?} must refuse a certificate it cannot validate"
+            );
+            assert!(
+                !path.exists(),
+                "{policy:?} must not record anything for a refused certificate"
+            );
+        }
+    }
+
+    /// `no`/`off` disable host-key validation outright, so refusing a
+    /// certificate there would contradict the policy the user chose.
+    #[tokio::test]
+    async fn check_server_key_accepts_a_host_certificate_when_validation_is_disabled() {
+        let cert = Certificate::from_openssh(TEST_HOST_CERT).expect("test cert should parse");
+        let offered = PublicKeyOrCertificate::Certificate(cert);
+
+        for policy in [HostKeyPolicy::No, HostKeyPolicy::Off] {
+            let verifier =
+                HostKeyVerifier::new(policy, None, "host", 22).expect("verifier should build");
+            let mut handler = ClientHandler { verifier };
+
+            assert!(
+                handler
+                    .check_server_key(&offered)
+                    .await
+                    .expect("check_server_key should not error"),
+                "{policy:?} disables validation and must not refuse a certificate"
+            );
+        }
     }
 
     #[tokio::test]
@@ -1454,7 +1536,7 @@ mod tests {
 
         assert!(
             !handler
-                .check_server_key(&key)
+                .check_server_key(&offered(&key))
                 .await
                 .expect("check_server_key should not error"),
             "a persistence failure must reject the session (fail-closed), not trust the key"
@@ -1480,7 +1562,8 @@ mod tests {
         let mut handler = ClientHandler { verifier };
 
         let start = Instant::now();
-        let check = handler.check_server_key(&key);
+        let offered_key = offered(&key);
+        let check = handler.check_server_key(&offered_key);
         let sibling_done_at = std::sync::Arc::new(std::sync::Mutex::new(None));
         let sibling_done_at_write = sibling_done_at.clone();
         let sibling = async move {


### PR DESCRIPTION
Supersedes #285, which is the bare version bump and does not compile: russh 0.63 changes `Handler::check_server_key` to take a `PublicKeyOrCertificate` instead of a `PublicKey`, so every CI leg fails on it.

**What**

- `russh` 0.62 → 0.63 (`crates/repose-ssh/Cargo.toml` + `Cargo.lock`), as in #285.
- `check_server_key` now matches exhaustively on `PublicKeyOrCertificate`.

**Why the certificate arm behaves the way it does**

The plain-key path is unchanged — the same `PublicKey` reaches `decide_public_key`, so known_hosts matching, `accept-new` TOFU persistence and the fail-closed persistence handling are all byte-for-byte as before. The discarded `hash_alg` is the signature algorithm, which russh verifies before invoking the callback; it is not an identity input, and known_hosts matches on the key.

A host **certificate** is refused under `yes` and `accept-new`. repose has no `@cert-authority` support — `hostkey.rs` already states that CA entries are deliberately not interpreted — so there is nothing to validate a certificate against, and trusting one would be trusting it unconditionally. Under `no`/`off` it is accepted, because those disable validation outright and refusing there would contradict the policy the user chose.

This arm is **unreachable today**: `Preferred::default()` advertises only Ed25519, ECDSA P-256/384/521 and RSA — no `*-cert-v01@openssh.com` — so a server cannot negotiate a host certificate the client never offered. It is written defensively and pinned by tests so the behaviour is already settled if that ever changes. The match is exhaustive on purpose: a future russh variant should break the build rather than fall through to a trust decision.

**Verification**

- `cargo fmt --check`; `cargo clippy --workspace --all-targets --locked -- -D warnings` and the same with `--features gen`; `cargo test --workspace --all-targets --locked`; `cargo deny check`; `scripts/check-rust-layering.sh`; `scripts/check-cli.sh`; `cargo doc` with `-D warnings` — all pass.
- Two new tests cover both certificate arms. The rejection test was mutation-checked: forcing the arm to return `Ok(true)` fails it.
- Not verified locally (no rustup on this machine): the MSRV leg. russh 0.63 brings a newer RustCrypto tree, so `rust-msrv` is the check to watch here.

Based on #287, which fixes an unrelated `h2` advisory failing `rust-deny` on every branch; the first commit here is that fix and drops out once it merges.

_AI-assisted._