### PR TITLE
fix(deps): bump chacha20 to 0.10.2, 0.10.1 is yanked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher",


### PR DESCRIPTION
`chacha20` 0.10.1 (and 0.10.0) were yanked upstream; 0.10.2 landed 2026-08-27. It reaches us transitively through russh 0.63 — `rand 0.10.2`, and `ssh-cipher` via `ssh-key`.

This fails `cargo deny check` on master itself, so **#290, #291 and #292 are all red on `rust-deny` through no fault of their own** — #292 touches only `.github/workflows/`, which is the proof. Landing this first should clear them.

Lockfile only, two lines, no manifest change.

Verification: `cargo deny check` goes from `advisories FAILED` to `advisories ok, bans ok, licenses ok, sources ok`; `cargo test --workspace --all-targets --locked` 282 pass.

_AI-assisted._